### PR TITLE
AIAgents: drop shell MCP, add -Reset switch to prune deprecated entries

### DIFF
--- a/bucket/AIAgents.Tests.ps1
+++ b/bucket/AIAgents.Tests.ps1
@@ -48,7 +48,7 @@ Describe 'AIAgents install orchestration' -Tag 'Heavy','Bundle' {
         $script:InvokeBundle = {
             $src = Get-Content -Raw -Path $script:sut
             $src = $src -replace '(?m)^\s*\.\s+"\$PSScriptRoot\\Utils\.ps1".*$',''
-            . ([scriptblock]::Create($src))
+            . ([scriptblock]::Create($src)) @args
         }
         & $script:InvokeBundle
     }
@@ -131,7 +131,7 @@ Describe 'AIAgents MCP config generation' -Tag 'Light','Bundle' {
         $script:InvokeBundle = {
             $src = Get-Content -Raw -Path $script:sut
             $src = $src -replace '(?m)^\s*\.\s+"\$PSScriptRoot\\Utils\.ps1".*$',''
-            . ([scriptblock]::Create($src))
+            . ([scriptblock]::Create($src)) @args
         }
         & $script:InvokeBundle
     }
@@ -150,7 +150,7 @@ Describe 'AIAgents MCP config generation' -Tag 'Light','Bundle' {
         }
     }
 
-    It 'writes valid JSON with the 5 base mcpServers entries in <name>' -ForEach @(
+    It 'writes valid JSON with the 4 base mcpServers entries in <name>' -ForEach @(
         @{ name = 'ClaudeDesktop' }
         @{ name = 'ClaudeCode' }
         @{ name = 'Gemini' }
@@ -164,7 +164,6 @@ Describe 'AIAgents MCP config generation' -Tag 'Light','Bundle' {
         $json.mcpServers.playwright      | Should -Not -BeNullOrEmpty
         $json.mcpServers.filesystem      | Should -Not -BeNullOrEmpty
         $json.mcpServers.github          | Should -Not -BeNullOrEmpty
-        $json.mcpServers.shell           | Should -Not -BeNullOrEmpty
     }
 
     It 'writes a Codex TOML config containing each MCP server section' {
@@ -174,7 +173,6 @@ Describe 'AIAgents MCP config generation' -Tag 'Light','Bundle' {
         $content | Should -Match '\[mcp_servers\.playwright\]'
         $content | Should -Match '\[mcp_servers\.filesystem\]'
         $content | Should -Match '\[mcp_servers\.github\]'
-        $content | Should -Match '\[mcp_servers\.shell\]'
     }
 
     It 'is idempotent: re-running does not duplicate mcpServers entries' {
@@ -184,7 +182,7 @@ Describe 'AIAgents MCP config generation' -Tag 'Light','Bundle' {
             $path = $script:configPaths[$name]
             $json = Get-Content -Raw -Path $path | ConvertFrom-Json
             # Each named entry must appear exactly once.
-            foreach ($expected in 'context7','playwright','filesystem','github','shell') {
+            foreach ($expected in 'context7','playwright','filesystem','github') {
                 @($json.mcpServers.PSObject.Properties.Name |
                     Where-Object { $_ -eq $expected }).Count |
                         Should -Be 1 -Because "$expected should appear exactly once in $path"
@@ -192,10 +190,39 @@ Describe 'AIAgents MCP config generation' -Tag 'Light','Bundle' {
         }
 
         $codex = Get-Content -Raw -Path $script:configPaths.Codex
-        foreach ($expected in 'context7','playwright','filesystem','github','shell') {
+        foreach ($expected in 'context7','playwright','filesystem','github') {
             $pattern = "\[mcp_servers\.$expected\]"
             ([regex]::Matches($codex, $pattern)).Count |
                 Should -Be 1 -Because "[mcp_servers.$expected] should appear exactly once in codex config.toml"
         }
+    }
+
+    It '-Reset prunes deprecated shell entry but preserves user-added entries' {
+        # Pre-seed each JSON config with a deprecated 'shell' entry plus a
+        # user-added 'usercustom' entry that must survive.
+        foreach ($name in 'ClaudeDesktop','ClaudeCode','Gemini','Copilot') {
+            $path = $script:configPaths[$name]
+            $json = Get-Content -Raw -Path $path | ConvertFrom-Json
+            $json.mcpServers | Add-Member -NotePropertyName shell `
+                -NotePropertyValue ([pscustomobject]@{ command = 'npx'; args = @('-y','mcp-server-commands') }) -Force
+            $json.mcpServers | Add-Member -NotePropertyName usercustom `
+                -NotePropertyValue ([pscustomobject]@{ command = 'echo'; args = @('hi') }) -Force
+            $json | ConvertTo-Json -Depth 20 | Set-Content -Path $path -Encoding UTF8
+        }
+        $codexPath = $script:configPaths.Codex
+        Add-Content -Path $codexPath -Value "`r`n[mcp_servers.shell]`r`ncommand = `"npx`"`r`nargs = [`"-y`", `"mcp-server-commands`"]`r`n"
+        Add-Content -Path $codexPath -Value "`r`n[mcp_servers.usercustom]`r`ncommand = `"echo`"`r`nargs = [`"hi`"]`r`n"
+
+        & $script:InvokeBundle -Reset
+
+        foreach ($name in 'ClaudeDesktop','ClaudeCode','Gemini','Copilot') {
+            $path = $script:configPaths[$name]
+            $json = Get-Content -Raw -Path $path | ConvertFrom-Json
+            $json.mcpServers.PSObject.Properties.Name | Should -Not -Contain 'shell' -Because "shell should be pruned from $path"
+            $json.mcpServers.PSObject.Properties.Name | Should -Contain 'usercustom' -Because "user-added entries must survive in $path"
+        }
+        $codex = Get-Content -Raw -Path $codexPath
+        $codex | Should -Not -Match '\[mcp_servers\.shell\]'
+        $codex | Should     -Match '\[mcp_servers\.usercustom\]'
     }
 }

--- a/bucket/AIAgents.json
+++ b/bucket/AIAgents.json
@@ -1,6 +1,6 @@
 {
     "$schema": "https://raw.githubusercontent.com/lukesampson/scoop/master/schema.json",
-    "version": "1.08.000",
+    "version": "1.09.000",
     "url": [
         "https://raw.githubusercontent.com/MarkMichaelis/ScoopBucket/master/bucket/Utils.ps1",
         "https://raw.githubusercontent.com/MarkMichaelis/ScoopBucket/master/bucket/AIAgents.ps1"

--- a/bucket/AIAgents.ps1
+++ b/bucket/AIAgents.ps1
@@ -1,3 +1,12 @@
+[CmdletBinding()]
+param(
+    # When set, prune any MCP server names this bucket has retired
+    # (see $DeprecatedMcpServers below) from existing user MCP configs.
+    # Off by default so a routine `scoop install` / reinstall never removes
+    # entries the user may still rely on. Intended for direct invocation:
+    #   pwsh -File AIAgents.ps1 -Reset
+    [switch]$Reset
+)
 
 Write-Host 'Installing and configuring AIAgents...'
 . "$PSScriptRoot\Utils.ps1"
@@ -109,7 +118,14 @@ if ([string]::IsNullOrWhiteSpace($GithubToken)) {
 # Configure MCP servers for every MCP-capable agent.
 # Idempotent: re-running just overwrites the named entries; other MCP servers
 # in the same config are preserved.
+#
+# $DeprecatedMcpServers lists names this script previously configured but has
+# since retired. They are NOT removed by default (a routine reinstall must
+# never silently delete a server the user may rely on); pass -Reset to prune
+# them from existing configs.
 # ---------------------------------------------------------------------------
+
+$DeprecatedMcpServers = @('shell')
 
 $McpServers = @(
     @{
@@ -132,11 +148,6 @@ $McpServers = @(
         Command   = 'npx'
         Arguments = @('-y', '@modelcontextprotocol/server-github')
         Env       = @{ GITHUB_PERSONAL_ACCESS_TOKEN = $GithubToken }
-    }
-    @{
-        Name      = 'shell'
-        Command   = 'npx'
-        Arguments = @('-y', 'mcp-server-commands')
     }
 )
 
@@ -255,9 +266,63 @@ $JsonAgents = @(
     @{ Label = 'GitHub Copilot CLI';  Path = (Join-Path $env:USERPROFILE  '.copilot\mcp-config.json') }
 )
 
+Function Remove-McpServerFromJsonConfig {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)][string]$Path,
+        [Parameter(Mandatory)][string]$AgentLabel,
+        [Parameter(Mandatory)][string]$ServerName
+    )
+
+    if (-not (Test-Path $Path)) { return }
+    try {
+        $config = Get-Content -Path $Path -Raw | ConvertFrom-Json
+    }
+    catch {
+        Write-Warning "$AgentLabel`: existing config at $Path is not valid JSON; skipping prune of $ServerName."
+        return
+    }
+    if (-not $config.PSObject.Properties['mcpServers']) { return }
+    if (-not $config.mcpServers.PSObject.Properties[$ServerName]) { return }
+
+    $config.mcpServers.PSObject.Properties.Remove($ServerName)
+    $config | ConvertTo-Json -Depth 20 | Set-Content -Path $Path -Encoding UTF8
+    Write-Host "$AgentLabel`: pruned deprecated $ServerName MCP from $Path"
+}
+
+Function Remove-McpServerFromCodex {
+    param(
+        [Parameter(Mandatory)][string]$ServerName
+    )
+
+    $path = Join-Path $env:USERPROFILE '.codex\config.toml'
+    if (-not (Test-Path $path)) { return }
+
+    $sectionPattern    = "(?ms)^\[mcp_servers\.$([regex]::Escape($ServerName))\].*?(?=^\[|\z)"
+    $envSectionPattern = "(?ms)^\[mcp_servers\.$([regex]::Escape($ServerName))\.env\].*?(?=^\[|\z)"
+
+    $content    = Get-Content -Path $path -Raw
+    $newContent = [regex]::Replace($content, $envSectionPattern, '')
+    $newContent = [regex]::Replace($newContent, $sectionPattern, '')
+    if ($newContent -ne $content) {
+        Set-Content -Path $path -Value $newContent.TrimEnd() -Encoding UTF8
+        Write-Host "Codex CLI: pruned deprecated $ServerName MCP from $path"
+    }
+}
+
 foreach ($server in $McpServers) {
     foreach ($agent in $JsonAgents) {
         Add-McpServerToJsonConfig -Path $agent.Path -AgentLabel $agent.Label -Server $server
     }
     Add-McpServerToCodex -Server $server
+}
+
+if ($Reset) {
+    Write-Host "-Reset: pruning deprecated MCP server names ($($DeprecatedMcpServers -join ', '))..."
+    foreach ($name in $DeprecatedMcpServers) {
+        foreach ($agent in $JsonAgents) {
+            Remove-McpServerFromJsonConfig -Path $agent.Path -AgentLabel $agent.Label -ServerName $name
+        }
+        Remove-McpServerFromCodex -ServerName $name
+    }
 }


### PR DESCRIPTION
## Summary

- Removes the `shell` MCP server (`mcp-server-commands`) from ``. It defaulted to `cmd.exe` on Windows; coverage is provided by `posh` (PoshMcp typed cmdlets) and the Copilot CLI's built-in pwsh tool.
- Adds a `-Reset` switch (off by default; for direct `.ps1` invocation) that prunes any name in `` (currently `'shell'`) from each managed config (Claude Desktop, Claude Code, Gemini CLI, Copilot CLI, Codex). User-added MCP entries are preserved.
- Routine `scoop install` is unaffected.

## Version bump

`bucket/AIAgents.json`: `1.08.000 -> 1.09.000` (package removal + edit to referenced `.ps1` = minor bump).

## Tests

New Pester `It` asserts `-Reset` removes `shell` from JSON + Codex TOML configs and preserves a `usercustom` entry. Local run: 11 passed / 1 failed; the failure (`invokes npx to install Playwright chromium`) reproduces on unmodified `main` and is unrelated.