### PR TITLE
Refresh PATH, fix parser, expand NoCli, add sysinternals to PATH

### DIFF
--- a/.github/scripts/Get-PackageCommands.ps1
+++ b/.github/scripts/Get-PackageCommands.ps1
@@ -86,8 +86,8 @@ $ExpectedCliOverrides = @{
     'dbxcli'                                               = 'dbxcli'
     'eSpeak-NG.eSpeak-NG'                                  = 'espeak-ng'
     'ScooterSoftware.BeyondCompare.4'                      = 'bcompare'
+    'extras/beyondcompare'                                 = 'bcompare'
     'calibre.calibre'                                      = 'calibre'
-    'Anthropic.Claude'                                     = 'claude'
     'MarkMichaelis/ClaudeCode'                             = 'claude'
     'MarkMichaelis/Codex'                                  = 'codex'
     'MarkMichaelis/GeminiCli'                              = 'gemini'
@@ -105,12 +105,28 @@ $NoCliPackages = @(
     'Google.Chrome','voidtools.Everything','WinDirStat.WinDirStat',
     'Microsoft.Sysinternals.ProcessExplorer','Microsoft.Sysinternals.Suite',
     'WindowsPostInstallWizard.UniversalSilentSwitchFinder',
-    '9NT1R1C2HH7J','9NRQBLR605RG','XPDDXX9QW8N9D7','9NKSQGP7F2NH',
+    '9NT1R1C2HH7J','9NRQBLR605RG','XPDDXX9QW8N9D7','9NKSQGP7F2NH','XPDNSF6TXN2R6Z',
     'gitextensions','gitkraken','git-credential-manager-for-windows',
-    'Microsoft-Teams','Office365ProPlus','foxitreader','geosetter',
-    'TotalCommander','MarkMichaelis/ChatGPT',
+    'Microsoft-Teams','Office365ProPlus','foxitreader','Foxit.FoxitReader',
+    'geosetter','TotalCommander','MarkMichaelis/ChatGPT',
     'MarkMichaelis/Claude','MarkMichaelis/Gemini','MarkMichaelis/MicrosoftCopilot',
-    'MarkMichaelis/ClaudeExcel','MarkMichaelis/AIAgents'
+    'MarkMichaelis/ClaudeExcel','MarkMichaelis/AIAgents',
+    # Scoop GUI desktop apps (separate from corresponding CLI packages above)
+    'extras/claude','extras/notion','extras/spotify',
+    # Bundle of tools (procexp/procmon/psexec/...); availability handled by
+    # adding the install dir to Machine PATH in OSBasePackages.ps1, not by
+    # probing for a single binary called "sysinternals".
+    'extras/sysinternals',
+    # PS modules / chocolatey-internal packages without a CLI surface.
+    'au','Pester','chocolatey-core.extension',
+    # Anthropic.Claude is the desktop GUI; the CLI ships as Anthropic.ClaudeCode
+    # (mapped via MarkMichaelis/ClaudeCode override above).
+    'Anthropic.Claude',
+    # Parser-defense: the .EXAMPLE comment in Utils.ps1 used to slip "VisualStudio"
+    # past the choco-install regex.  The Strip-comment-blocks pass below is the
+    # primary fix; this entry is belt-and-braces in case someone re-introduces
+    # an .EXAMPLE doc that mentions a literal `choco install VisualStudio`.
+    'VisualStudio'
 )
 
 function Get-ExpectedCliName {
@@ -147,6 +163,40 @@ function Get-ExpectedCliName {
 
 $script:FindBinaryScript  = Join-Path $PSScriptRoot 'Find-PackageBinary.ps1'
 $script:HelpProbeScript   = Join-Path $PSScriptRoot 'Test-CliHelpFlag.ps1'
+
+function Update-PathFromRegistry {
+    <#
+    .SYNOPSIS
+        Refresh $env:Path with the current Machine + User PATH from the registry.
+    .DESCRIPTION
+        Installer programs (winget, scoop -g, choco) write to the *Machine* PATH
+        in the registry, but a long-running PowerShell process inherits its
+        $env:Path snapshot at start-up and never re-reads it.  In CI that means
+        every CLI installed during the same job appears "missing on PATH" even
+        though a fresh shell would see it (issue surfaced by run 25642136341 —
+        bw/rg/copilot/fzf/bat/es all sat in C:\Program Files\WinGet\Links\
+        which Machine PATH knew about but our pwsh process didn't).
+
+        Call this once after install batches and before CLI probing.  Idempotent.
+    #>
+    $machine = [Environment]::GetEnvironmentVariable('Path', 'Machine')
+    $user    = [Environment]::GetEnvironmentVariable('Path', 'User')
+    $current = $env:Path
+    $segments = @()
+    foreach ($src in @($machine, $user, $current)) {
+        if (-not $src) { continue }
+        foreach ($p in ($src -split ';')) {
+            $p = $p.Trim()
+            if ($p -and ($segments -notcontains $p)) { $segments += $p }
+        }
+    }
+    $env:Path = $segments -join ';'
+}
+
+# Refresh PATH from the registry so freshly-installed CLIs (whose installers
+# updated Machine PATH after this process started) become discoverable to the
+# Get-Command probe below.
+Update-PathFromRegistry
 
 function New-Record {
     param(
@@ -229,9 +279,13 @@ foreach ($file in $bundleScripts) {
     $scriptName = $file.Name
     $content    = Get-Content -Path $file.FullName -Raw
 
-    # Strip line-leading comments so commented-out installs are ignored.
+    # Strip multi-line comment-help blocks (<# ... #>) first so .EXAMPLE
+    # snippets (e.g. "choco install VisualStudio -y --force" inside Utils.ps1's
+    # comment header) aren't parsed as real installs.  Then strip line-leading
+    # # comments so commented-out installs are also ignored.
+    $stripped = [regex]::Replace($content, '(?s)<#.*?#>', '')
     $sanitizedLines = @()
-    foreach ($line in ($content -split "`r?`n")) {
+    foreach ($line in ($stripped -split "`r?`n")) {
         if ($line -match '^\s*#') { $sanitizedLines += '' } else { $sanitizedLines += $line }
     }
     $sanitized = $sanitizedLines -join "`n"

--- a/bucket/OSBasePackages.json
+++ b/bucket/OSBasePackages.json
@@ -1,6 +1,6 @@
 ﻿{
     "$schema": "https://raw.githubusercontent.com/lukesampson/scoop/master/schema.json",
-    "version": "1.13.000",
+    "version": "1.13.001",
     "url": [
         "https://raw.githubusercontent.com/MarkMichaelis/ScoopBucket/master/bucket/Utils.ps1",
         "https://raw.githubusercontent.com/MarkMichaelis/ScoopBucket/master/bucket/OSBasePackages.ps1"

--- a/bucket/OSBasePackages.ps1
+++ b/bucket/OSBasePackages.ps1
@@ -37,4 +37,23 @@ scoop install ffmpeg
 Write-Host 'Installing sysinternals suite (scoop extras)...'
 scoop install extras/sysinternals
 
+# extras/sysinternals unpacks the suite (procexp, procmon, psexec, handle, ...)
+# but does NOT shim individual tools.  Append the install directory to Machine
+# PATH so every tool in the suite is callable from the command line.
+# Idempotent: only adds the entry if it isn't already present.
+$siDir = $null
+try { $siDir = (& scoop prefix sysinternals 2>$null | Select-Object -First 1) } catch { }
+if ($siDir -and (Test-Path $siDir)) {
+    $machinePath = [Environment]::GetEnvironmentVariable('Path', 'Machine')
+    $alreadyPresent = ($machinePath -split ';' | Where-Object { $_.TrimEnd('\') -ieq $siDir.TrimEnd('\') })
+    if (-not $alreadyPresent) {
+        [Environment]::SetEnvironmentVariable('Path', "$machinePath;$siDir", 'Machine')
+        Write-Host "  Added sysinternals dir to Machine PATH: $siDir"
+    } else {
+        Write-Host "  sysinternals dir already on Machine PATH: $siDir"
+    }
+} else {
+    Write-Warning "  Could not resolve sysinternals install dir via 'scoop prefix sysinternals'"
+}
+
 


### PR DESCRIPTION
## Why

Run `25642136341` proved the missing-CLI set is **deterministic**, not flaky. The artifact's existing `OnDiskPath` column showed the truth:

- `bw`, `rg`, `copilot`, `fzf`, `bat`, `es` all sit in `C:\Program Files\WinGet\Links\`. winget *did* link them; CI process PATH was just stale.
- `gcloud` in `google-cloud-sdk\bin\` (same root cause).
- `calibre`, `devenv`, `sox`, `code` in fixed install dirs (real shim/PATH-add candidates  separate follow-up).
- `claude`/`notion`/`spotify` are GUI desktop apps masquerading as CLIs.
- `Pester`/`au`/`chocolatey-core.extension` are PS modules / extension packages.
- `XPDNSF6TXN2R6Z` is Snagit (msstore ID for a GUI app).
- `choco / VisualStudio` was a parser false positive: the `.EXAMPLE` doc-comment in `Utils.ps1` contained `choco install VisualStudio -y --force`, which the regex matched as a real install.

The `sysinternals` bundle has no single `sysinternals.exe`  it ships `procexp`/`procmon`/`psexec`/`handle`/etc. We want all of them callable.

## What

**`.github/scripts/Get-PackageCommands.ps1`**:
- Add `Update-PathFromRegistry` helper (re-reads Machine + User PATH from the registry, merges into `\C:\Program Files\PowerShell\7;C:\Program Files\Microsoft SDKs\Azure\CLI2\wbin;C:\Program Files\Microsoft\jdk-11.0.12.7-hotspot\bin;C:\ProgramData\scoop\shims;C:\Windows\system32;C:\Windows;C:\Windows\System32\Wbem;C:\Windows\System32\WindowsPowerShell\v1.0\;C:\Windows\System32\OpenSSH\;C:\ProgramData\chocolatey\bin;C:\Program Files\dotnet\;C:\WINDOWS\system32;C:\WINDOWS;C:\WINDOWS\System32\Wbem;C:\WINDOWS\System32\WindowsPowerShell\v1.0\;C:\WINDOWS\System32\OpenSSH\;C:\Program Files\Microsoft SQL Server\Client SDK\ODBC\170\Tools\Binn\;C:\Program Files\Microsoft SQL Server\150\Tools\Binn\;C:\Program Files (x86)\NVIDIA Corporation\PhysX\Common;C:\Program Files\Microsoft VS Code\bin;C:\Program Files\GitHub CLI\;C:\Program Files\Git\cmd;C:\Program Files\nodejs\;C:\WINDOWS\system32;C:\WINDOWS;C:\WINDOWS\System32\Wbem;C:\WINDOWS\System32\WindowsPowerShell\v1.0\;C:\WINDOWS\System32\OpenSSH\;C:\Program Files\NVIDIA Corporation\NVIDIA App\NvDLISR;C:\Program Files\PowerShell\7\;C:\Users\Mark\scoop\shims;C:\Users\Mark\AppData\Local\Microsoft\WindowsApps;C:\Users\Mark\.dotnet\tools;C:\Users\Mark\AppData\Local\gitkraken\bin;C:\Users\Mark\AppData\Local\Programs\Microsoft VS Code\bin;C:\Users\Mark\AppData\Local\Programs\Fiddler;C:\Users\Mark\AppData\Roaming\npm;C:\Users\Mark\AppData\Local\Microsoft\WinGet\Links;C:\Users\Mark\.dotnet\tools;C:\Users\Mark\AppData\Local\Microsoft\WinGet\Packages\Gyan.FFmpeg_Microsoft.Winget.Source_8wekyb3d8bbwe\ffmpeg-6.1.1-full_build\bin;;C:\Users\Mark\AppData\Local\Microsoft\WindowsApps`). Called once before the bundle scan.
- Strip `<# ... #>` doc-comment blocks before pattern matching.
- Override map: add `extras/beyondcompare = bcompare`; remove wrong `Anthropic.Claude = claude` (Anthropic.Claude is the desktop GUI; CLI is `Anthropic.ClaudeCode` via `MarkMichaelis/ClaudeCode`).
- `\`: add Snagit msstore ID, scoop GUI desktop apps (claude/notion/spotify), the sysinternals bundle, Foxit, `au`, `Pester`, `chocolatey-core.extension`, `Anthropic.Claude`, `VisualStudio` (defense-in-depth).

**`bucket/OSBasePackages.ps1`** (manifest bumped to 1.13.001):
- After `scoop install extras/sysinternals`, append the install dir (via `scoop prefix sysinternals`) to Machine PATH. Idempotent.

## Expected validate-installs delta

Before: 13  / 23  (of 36 with ExpectedCli)
After (predicted): ~22  / 4  (of 26 with ExpectedCli)  residuals expected to be `calibre`, `devenv`, `sox` (real shim candidates) and possibly one more depending on PATH details.

Remaining shims will be a follow-up PR once we observe the actual diff. After that, expectation tests pin the now-working CLIs (per #45 Phase 3 spirit).

## Local validation

- `Get-PackageCommands.ps1` runs clean; phantom `choco/VisualStudio` row gone; with-CLI count drops 36  26.
- Pester: 67 pass / 4 fail (same as baseline; pre-existing).

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>