### PR TITLE
Post-install hooks: ffmpeg parser fix, devenv shim, BeyondCompare bcomp.com remap

### DIFF
--- a/.github/scripts/Invoke-PostInstallHooks.ps1
+++ b/.github/scripts/Invoke-PostInstallHooks.ps1
@@ -1,0 +1,173 @@
+#Requires -Version 5.1
+<#
+.SYNOPSIS
+    Apply idempotent post-install fixes to make installed CLIs reachable in CI.
+
+.DESCRIPTION
+    Test-Installs.ps1 parses bundle .ps1 files and re-issues installer commands;
+    it does NOT dot-source the bundles, so any sidecar PATH/shim logic embedded
+    in the bundle .ps1 (e.g. OSBasePackages.ps1's sysinternals PATH-add) never
+    runs in CI.  This script reproduces those side effects so the downstream
+    cli-availability discovery (#45 Phase 2) sees an accurate picture.
+
+    All operations are idempotent and best-effort; missing prerequisites only
+    emit warnings.
+
+.NOTES
+    Hooks applied (each guarded so a single failure does not cascade):
+      1. Refresh $env:Path from registry (Machine + User) so newly-installed
+         shim/install dirs are visible in this process.
+      2. Sysinternals: append `scoop prefix sysinternals` directory to Machine
+         PATH so individual tools (procexp, procmon, psexec, handle, ...) are
+         callable without per-tool shims.
+      3. Visual Studio 2026: locate devenv.exe via vswhere and create a scoop
+         shim named `devenv` so the editor is reachable from the command line.
+      4. BeyondCompare: replace scoop's default `bcomp` shim (which targets
+         BComp.exe — a GUI launcher that returns immediately) with one that
+         targets BComp.com (console-waiting variant, correct for VCS hooks
+         and scripts).  Also append the BC install directory to Machine PATH
+         so `bcomp.exe` and `BCompare.exe` remain reachable by explicit name.
+#>
+[CmdletBinding()]
+param()
+
+$ErrorActionPreference = 'Continue'
+
+function Update-PathFromRegistry {
+    [CmdletBinding()]
+    param()
+    try {
+        $machine = [Environment]::GetEnvironmentVariable('Path', 'Machine')
+        $user    = [Environment]::GetEnvironmentVariable('Path', 'User')
+        $merged  = @($machine, $user) | Where-Object { $_ } | ForEach-Object { $_.TrimEnd(';') } | Where-Object { $_ } | Join-String -Separator ';'
+        if ($merged) {
+            $env:Path = $merged
+            Write-Host "  PATH refreshed from registry ($($merged.Length) chars)"
+        }
+    } catch {
+        Write-Warning "  PATH refresh failed: $($_.Exception.Message)"
+    }
+}
+
+function Add-MachinePathEntry {
+    [CmdletBinding()]
+    param([Parameter(Mandatory)][string]$Dir)
+
+    if (-not (Test-Path $Dir)) {
+        Write-Warning "  Skipping PATH-add: directory not found: $Dir"
+        return
+    }
+    try {
+        $current = [Environment]::GetEnvironmentVariable('Path', 'Machine')
+        $present = ($current -split ';' | Where-Object { $_.TrimEnd('\') -ieq $Dir.TrimEnd('\') })
+        if ($present) {
+            Write-Host "  Already on Machine PATH: $Dir"
+            return
+        }
+        [Environment]::SetEnvironmentVariable('Path', "$current;$Dir", 'Machine')
+        Write-Host "  Added to Machine PATH: $Dir"
+    } catch {
+        Write-Warning "  Failed to add Machine PATH entry '$Dir': $($_.Exception.Message)"
+    }
+}
+
+function Invoke-Hook {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)][string]$Name,
+        [Parameter(Mandatory)][scriptblock]$Block
+    )
+    Write-Host "::group::Post-install hook: $Name"
+    try {
+        & $Block
+    } catch {
+        Write-Warning "Hook '$Name' threw: $($_.Exception.Message)"
+    } finally {
+        Write-Host '::endgroup::'
+    }
+}
+
+# --- 1. PATH refresh ----------------------------------------------------------
+Invoke-Hook -Name 'PATH refresh from registry' -Block {
+    Update-PathFromRegistry
+}
+
+# --- 2. Sysinternals install dir on Machine PATH ------------------------------
+Invoke-Hook -Name 'Sysinternals dir on Machine PATH' -Block {
+    if (-not (Get-Command scoop -ErrorAction Ignore)) {
+        Write-Warning '  scoop not on PATH; cannot resolve sysinternals install dir'
+        return
+    }
+    $siDir = $null
+    try { $siDir = (& scoop prefix sysinternals 2>$null | Select-Object -First 1) } catch { }
+    if (-not $siDir) {
+        Write-Warning '  `scoop prefix sysinternals` returned nothing (package not installed?)'
+        return
+    }
+    Add-MachinePathEntry -Dir $siDir
+}
+
+# --- 3. devenv shim (Visual Studio 2026 Enterprise) ---------------------------
+Invoke-Hook -Name 'devenv shim via vswhere' -Block {
+    $vswhere = @(
+        "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vswhere.exe",
+        "${env:ProgramFiles}\Microsoft Visual Studio\Installer\vswhere.exe",
+        "${env:ChocolateyInstall}\bin\vswhere.exe"
+    ) | Where-Object { $_ -and (Test-Path $_) } | Select-Object -First 1
+
+    if (-not $vswhere) {
+        Write-Warning '  vswhere.exe not found in any standard location'
+        return
+    }
+    $devenv = & $vswhere -latest -prerelease -property productPath 2>$null | Select-Object -First 1
+    if (-not $devenv -or -not (Test-Path $devenv)) {
+        Write-Warning "  vswhere returned no productPath (or path missing): '$devenv'"
+        return
+    }
+    if (-not (Get-Command scoop -ErrorAction Ignore)) {
+        Write-Warning '  scoop not on PATH; cannot create devenv shim'
+        return
+    }
+    # `scoop shim add` is idempotent only insofar as it overwrites an existing
+    # shim with the same name; calling it repeatedly is safe.
+    & scoop shim add devenv "$devenv" 2>&1 | ForEach-Object { Write-Host "    $_" }
+    Write-Host "  devenv shim points at: $devenv"
+}
+
+# --- 4. BeyondCompare: bcomp -> BComp.com remap + BC dir on Machine PATH ------
+Invoke-Hook -Name 'BeyondCompare bcomp.com remap + PATH' -Block {
+    if (-not (Get-Command scoop -ErrorAction Ignore)) {
+        Write-Warning '  scoop not on PATH; cannot manipulate BeyondCompare shims'
+        return
+    }
+    $bcDir = $null
+    try { $bcDir = (& scoop prefix beyondcompare 2>$null | Select-Object -First 1) } catch { }
+    if (-not $bcDir -or -not (Test-Path $bcDir)) {
+        Write-Warning '  `scoop prefix beyondcompare` returned nothing (package not installed?)'
+        return
+    }
+    $bcompCom = Join-Path $bcDir 'BComp.com'
+    if (-not (Test-Path $bcompCom)) {
+        Write-Warning "  BComp.com not found at: $bcompCom"
+        return
+    }
+    # Remove existing `bcomp` shim (default scoop manifest points it at
+    # BComp.exe — the GUI launcher that returns immediately).  `scoop shim rm`
+    # is non-fatal if the shim doesn't exist, but we ignore output either way.
+    & scoop shim rm bcomp 2>&1 | Out-Null
+    & scoop shim add bcomp "$bcompCom" 2>&1 | ForEach-Object { Write-Host "    $_" }
+    Write-Host "  bcomp shim now -> $bcompCom"
+
+    # Add the install dir to Machine PATH so `bcomp.exe` and `BCompare.exe`
+    # are reachable by explicit name (the .exe shims would otherwise collide
+    # with the `bcomp` shim above).
+    Add-MachinePathEntry -Dir $bcDir
+}
+
+# Final refresh so the immediately-following CLI-availability discovery picks
+# up everything we just touched without needing a separate process.
+Invoke-Hook -Name 'Final PATH refresh' -Block {
+    Update-PathFromRegistry
+}
+
+Write-Host 'Post-install hooks complete.'

--- a/.github/scripts/Test-Installs.Tests.ps1
+++ b/.github/scripts/Test-Installs.Tests.ps1
@@ -395,8 +395,8 @@ Describe 'Get-PackagesFromScript — real bucket scripts' {
         }
 
         It 'should discover winget packages' {
-            $pkgs.Count | Should -BeGreaterOrEqual 10
-            $pkgs | ForEach-Object { $_.InstallerType | Should -Be 'winget' }
+            $wingetPkgs = $pkgs | Where-Object InstallerType -eq 'winget'
+            @($wingetPkgs).Count | Should -BeGreaterOrEqual 10
         }
 
         It 'should find 7-Zip' {
@@ -408,15 +408,24 @@ Describe 'Get-PackagesFromScript — real bucket scripts' {
         }
 
         It 'should find FFmpeg' {
-            ($pkgs | Where-Object PackageId -eq 'Gyan.FFmpeg') | Should -Not -BeNullOrEmpty
+            # Gyan.FFmpeg (winget) was retired in favour of `scoop install ffmpeg`
+            # because the winget manifest hash drifts on every upstream release.
+            ($pkgs | Where-Object { $_.PackageId -eq 'ffmpeg' -and $_.InstallerType -eq 'scoop' }) |
+                Should -Not -BeNullOrEmpty
         }
 
         It 'should find Google Cloud SDK' {
             ($pkgs | Where-Object PackageId -eq 'Google.CloudSDK') | Should -Not -BeNullOrEmpty
         }
 
-        It 'should have machine scope' {
-            $pkgs | ForEach-Object { $_.Scope | Should -Be 'machine' }
+        It 'should find sysinternals (scoop)' {
+            ($pkgs | Where-Object { $_.PackageId -eq 'extras/sysinternals' -and $_.InstallerType -eq 'scoop' }) |
+                Should -Not -BeNullOrEmpty
+        }
+
+        It 'should have machine scope for winget packages' {
+            $pkgs | Where-Object InstallerType -eq 'winget' |
+                ForEach-Object { $_.Scope | Should -Be 'machine' }
         }
 
         It 'should not include commented-out entries' {

--- a/.github/scripts/Test-Installs.ps1
+++ b/.github/scripts/Test-Installs.ps1
@@ -505,6 +505,30 @@ function Get-PackagesFromScript {
         }
     }
 
+    # --- 4b. Standalone scoop install (e.g. `scoop install ffmpeg`,
+    #         `scoop install extras/sysinternals`).  Bare-positional, NOT
+    #         inside a `... | ForEach-Object` pipeline (handled by --- 2 ---).
+    foreach ($line in $lines) {
+        $trimmed = $line.Trim()
+        if ($trimmed -match '^\s*#') { continue }
+        if ($trimmed -match '\$_') { continue }
+        if ($trimmed -match '^\s*scoop\s+install\s+(?:-g\s+)?([A-Za-z0-9][\w\-/.]*)\s*$') {
+            $pkgName = $Matches[1]
+            $key = "scoop:$pkgName"
+            if ($foundPackageIds.ContainsKey($key)) { continue }
+            $foundPackageIds[$key] = $true
+
+            $null = $packages.Add([PSCustomObject]@{
+                Name           = $pkgName
+                PackageId      = $pkgName
+                InstallerType  = 'scoop'
+                SourceScript   = $scriptName
+                Scope          = ''
+                AdditionalArgs = ''
+            })
+        }
+    }
+
     # --- 5. Install-Module commands ---
     foreach ($line in $lines) {
         $trimmed = $line.Trim()

--- a/.github/workflows/validate-installs.yml
+++ b/.github/workflows/validate-installs.yml
@@ -113,6 +113,14 @@ jobs:
           Set-ExecutionPolicy Bypass -Scope Process -Force
           & "${{ github.workspace }}\.github\scripts\Test-Installs.ps1"
 
+      - name: Apply post-install hooks (PATH/shim sidecars)
+        if: always()
+        continue-on-error: true
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = 'Continue'
+          & "${{ github.workspace }}\.github\scripts\Invoke-PostInstallHooks.ps1"
+
       - name: CLI availability discovery (#45 Phase 2, non-failing)
         if: always()
         continue-on-error: true

--- a/bucket/DeveloperBasePackages.Tests.ps1
+++ b/bucket/DeveloperBasePackages.Tests.ps1
@@ -37,21 +37,27 @@ Describe 'DeveloperBasePackages bundle' -Tag 'Light','Bundle' {
 
     It 'invokes scoop install for each developer package' {
         # 3 globals (dotnet, VisualStudio2026Enterprise, extras/beyondcompare)
-        # + 1 per-user (MarkMichaelis/Aspire) = 4 scoop calls. Aspire is
-        # installed without -g because it shells out to `dotnet tool install
-        # --global` which already places the CLI on the user's PATH.
-        $script:scoopCalls.Count | Should -Be 4
-        $names = $script:scoopCalls | ForEach-Object { $_[-1] }
+        # + 1 per-user (MarkMichaelis/Aspire) = 4 scoop *install* calls. Aspire
+        # is installed without -g because it shells out to `dotnet tool install
+        # --global` which already places the CLI on the user's PATH.  The
+        # bundle also issues `scoop prefix beyondcompare` (and conditionally
+        # `scoop shim rm/add bcomp`) for the BComp.com remap; here the stub
+        # returns $null, so only the `prefix` call is observed.
+        $installCalls = $script:scoopCalls | Where-Object { $_[0] -eq 'install' }
+        @($installCalls).Count | Should -Be 4
+        $names = $installCalls | ForEach-Object { $_[-1] }
         $names | Should -Contain 'dotnet'
         $names | Should -Contain 'VisualStudio2026Enterprise'
         $names | Should -Contain 'extras/beyondcompare'
         $names | Should -Contain 'MarkMichaelis/Aspire'
 
-        $globalCalls = $script:scoopCalls | Where-Object { $_ -contains '-g' }
+        $globalCalls = $installCalls | Where-Object { $_ -contains '-g' }
         @($globalCalls).Count | Should -Be 3
-        foreach ($call in $script:scoopCalls) {
-            $call[0] | Should -Be 'install'
-        }
+    }
+
+    It 'queries scoop prefix beyondcompare for the BComp.com remap' {
+        $prefixCalls = $script:scoopCalls | Where-Object { $_[0] -eq 'prefix' -and $_[1] -eq 'beyondcompare' }
+        @($prefixCalls).Count | Should -BeGreaterOrEqual 1
     }
 
     It 'invokes winget install --scope machine for each winget package' {
@@ -76,7 +82,8 @@ Describe 'DeveloperBasePackages bundle' -Tag 'Light','Bundle' {
         $script:wingetCalls = @()
         { & $script:InvokeBundle } | Should -Not -Throw
         $script:chocoCalls.Count  | Should -Be 1
-        $script:scoopCalls.Count  | Should -Be 4
+        $installCalls = $script:scoopCalls | Where-Object { $_[0] -eq 'install' }
+        @($installCalls).Count | Should -Be 4
         $script:wingetCalls.Count | Should -Be 3
     }
 }

--- a/bucket/DeveloperBasePackages.json
+++ b/bucket/DeveloperBasePackages.json
@@ -1,6 +1,6 @@
 ﻿{
     "$schema": "https://raw.githubusercontent.com/lukesampson/scoop/master/schema.json",
-    "version": "1.14.000",
+    "version": "1.14.001",
     "url": [
         "https://raw.githubusercontent.com/MarkMichaelis/ScoopBucket/master/bucket/Utils.ps1",
         "https://raw.githubusercontent.com/MarkMichaelis/ScoopBucket/master/bucket/DeveloperBasePackages.ps1"

--- a/bucket/DeveloperBasePackages.ps1
+++ b/bucket/DeveloperBasePackages.ps1
@@ -16,6 +16,25 @@ Write-Host 'Installing and configuring OSBasePackages...'
     scoop install -g $_
 }
 
+# BeyondCompare CLI surface fix-up: scoop's `extras/beyondcompare` manifest
+# shims `BCompare.exe` (-> bcompare) and `BComp.exe` (-> bcomp).  But `BComp.exe`
+# is the *GUI* launcher that returns immediately; for a shell or VCS hook the
+# console-waiting `BComp.com` is what you want.  Replace the `bcomp` shim and
+# put the install dir on Machine PATH so `bcomp.exe` and `BCompare.exe` remain
+# reachable by explicit name.  Idempotent.
+$bcDir = $null
+try { $bcDir = (& scoop prefix beyondcompare 2>$null | Select-Object -First 1) } catch { }
+if ($bcDir -and (Test-Path (Join-Path $bcDir 'BComp.com'))) {
+    & scoop shim rm bcomp 2>&1 | Out-Null
+    & scoop shim add bcomp (Join-Path $bcDir 'BComp.com') 2>&1 | ForEach-Object { Write-Host "  $_" }
+    $machinePath = [Environment]::GetEnvironmentVariable('Path', 'Machine')
+    $alreadyPresent = ($machinePath -split ';' | Where-Object { $_.TrimEnd('\') -ieq $bcDir.TrimEnd('\') })
+    if (-not $alreadyPresent) {
+        [Environment]::SetEnvironmentVariable('Path', "$machinePath;$bcDir", 'Machine')
+        Write-Host "  Added BeyondCompare dir to Machine PATH: $bcDir"
+    }
+}
+
 $WingetPackages = @{
     'VisualStudioCode'=([PSCustomObject]@{ WingetName='Visual Studio Code'; WinGetID='Microsoft.VisualStudioCode'; })
 #    'Cursor'=([PSCustomObject]@{ WingetName='Cursor'; WinGetID='Anysphere.Cursor'; })

--- a/bucket/VisualStudio2026Enterprise.json
+++ b/bucket/VisualStudio2026Enterprise.json
@@ -1,11 +1,13 @@
 {
     "$schema": "https://raw.githubusercontent.com/lukesampson/scoop/master/schema.json",
-    "version": "1.00.000",
+    "version": "1.00.001",
     "url": ["https://raw.githubusercontent.com/MarkMichaelis/ScoopBucket/master/blank"],
     "installer": {
         "script": [
             "choco install -y VisualStudio2026enterprise --package-parameters \"--includeRecommended --add Microsoft.VisualStudio.Workload.Azure --add Microsoft.VisualStudio.Workload.Data --add Microsoft.VisualStudio.Workload.DataScience --add Microsoft.VisualStudio.Component.CodeClone --add Microsoft.VisualStudio.Workload.ManagedDesktop --add Microsoft.VisualStudio.Workload.NativeCrossPlat --add Microsoft.VisualStudio.Workload.NativeDesktop --add Microsoft.VisualStudio.Workload.NetCrossPlat --add Microsoft.VisualStudio.Workload.NetWeb --add Microsoft.VisualStudio.Workload.Node --add Microsoft.VisualStudio.Workload.Office --add Microsoft.VisualStudio.Workload.Python --add Microsoft.VisualStudio.Workload.VisualStudioExtension --add Microsoft.VisualStudio.Workload.Universal --add Microsoft.VisualStudio.Component.VisualStudioData\"",
-            "choco install vswhere"
+            "choco install vswhere",
+            "$vswhere = @(\"$env:ProgramData\\chocolatey\\bin\\vswhere.exe\",\"${env:ProgramFiles(x86)}\\Microsoft Visual Studio\\Installer\\vswhere.exe\") | Where-Object { Test-Path $_ } | Select-Object -First 1; if ($vswhere) { $vsExe = & $vswhere -latest -prerelease -property productPath 2>$null | Select-Object -First 1; if ($vsExe -and (Test-Path $vsExe)) { scoop shim add devenv $vsExe } else { Write-Warning \"vswhere returned no productPath: '$vsExe'\" } } else { Write-Warning 'vswhere.exe not found' }"
         ]
     }
 }
+


### PR DESCRIPTION
Follow-up to #63.  Addresses the 2 residual  rows from the post-#63 `cli-availability` artifact (`ffmpeg`, `devenv`) and the `bcomp` shim quality issue documented in the prior threads.

### Why
`Test-Installs.ps1` PARSES bundle `.ps1` files and re-issues installer commands; it does NOT dot-source the bundles.  So any sidecar PATH/shim logic embedded in the bundle `.ps1` (e.g. `OSBasePackages.ps1`'s sysinternals PATH-add added in #63) never runs in CI.

Additionally, the parser was missing a standalone `scoop install <name>` pattern (only `scoop install -g` inside a piped `ForEach-Object` was recognised).  That meant `scoop install ffmpeg` and `scoop install extras/sysinternals` from `OSBasePackages.ps1` were silently no-ops in CI.

### What
1. **`Test-Installs.ps1`**  new standalone-`scoop install` parser pattern (mirrors the standalone-choco/winget patterns).  ffmpeg and sysinternals now actually install in CI.
2. **`Invoke-PostInstallHooks.ps1`** (new)  idempotent script that runs after install validation and applies sidecar fixes:
   - PATH refresh from registry
   - Sysinternals install dir  Machine PATH
   - Visual Studio `devenv` shim via `vswhere`
   - BeyondCompare `bcomp` shim retargeted from `BComp.exe` (GUI; returns immediately)  `BComp.com` (console-waiting; correct for VCS hooks).  Install dir on Machine PATH so `bcomp.exe` / `BCompare.exe` remain reachable by explicit name.
3. **`validate-installs.yml`**  invoke the hook script between Test-Installs and CLI-availability discovery.
4. **`bucket/DeveloperBasePackages.ps1`**  mirror BC fix in the bundle so humans running the bundle directly get the same surface.  Manifest `1.14.000`  `1.14.001`.
5. **`bucket/VisualStudio2026Enterprise.json`**  add `devenv` shim creation as a third install.script line.  Manifest `1.00.000`  `1.00.001`.

### Tests
- `DeveloperBasePackages.Tests.ps1`: install-call assertion now filters by verb (`install` vs `prefix`); new test asserts the BC prefix query is issued.
- `Test-Installs.Tests.ps1`: `OSBasePackages` discovery tests filter by `InstallerType=winget` so they don't mis-flag the new ffmpeg/sysinternals scoop entries.  `should find FFmpeg` updated to expect `scoop ffmpeg` (Gyan.FFmpeg was retired).  New test for sysinternals.

### Expected post-merge result
`cli-availability` artifact should show **26/26** with all CLIs available (was 24/26 after #63).

Refs #45, follows #63.