### PR TITLE
Fix Test-Installs.ps1 crash on negative winget exit codes

### DIFF
--- a/.github/scripts/Test-Installs.Tests.ps1
+++ b/.github/scripts/Test-Installs.Tests.ps1
@@ -767,3 +767,54 @@ Describe 'Get-ScoopAppLeaf' {
         Get-ScoopAppLeaf -Name '7zip' | Should -Be '7zip'
     }
 }
+
+
+# ============================================================================
+# Add-Result (regression: negative ExitCode must format as unsigned hex
+# without throwing  see fix in PR for the line-78 [uint32] cast crash)
+# ============================================================================
+
+Describe 'Add-Result hex formatting for negative ExitCode' -Tag 'Unit' {
+    BeforeAll {
+        # Dot-source Add-Result in isolation.
+        $scriptPath = Join-Path $PSScriptRoot 'Test-Installs.ps1'
+        $scriptContent = Get-Content $scriptPath -Raw
+        if ($scriptContent -match '(?ms)(function\s+Add-Result\s*\{.+?\n\})') {
+            $script:Results = [System.Collections.ArrayList]::new()
+            Invoke-Expression $Matches[1]
+        } else {
+            throw 'Add-Result function not found in Test-Installs.ps1'
+        }
+    }
+
+    It 'does not throw for winget signed-negative exit code -1978335184' {
+        $output = & {
+            Add-Result -Name 'TestPackage' -PackageId 'Test.Package' `
+                -InstallerType 'winget' -SourceScript 'fake.ps1' `
+                -Command 'winget install --id Test.Package' `
+                -Status 'fail' -ExitCode -1978335184 -ErrorOutput 'simulated failure'
+        } *>&1
+        # Should produce the hex group header with 0x8A150030
+        ($output -join "`n") | Should -Match '0x8A150030'
+    }
+
+    It 'does not throw for ExitCode -1' {
+        $output = & {
+            Add-Result -Name 'TestPkg2' -PackageId 'Test.Pkg2' `
+                -InstallerType 'choco' -SourceScript 'fake.ps1' `
+                -Command 'choco install test' `
+                -Status 'fail' -ExitCode -1 -ErrorOutput 'simulated'
+        } *>&1
+        ($output -join "`n") | Should -Match '0xFFFFFFFF'
+    }
+
+    It 'formats positive ExitCode correctly' {
+        $output = & {
+            Add-Result -Name 'TestPkg3' -PackageId 'Test.Pkg3' `
+                -InstallerType 'winget' -SourceScript 'fake.ps1' `
+                -Command 'winget install --id Test.Pkg3' `
+                -Status 'fail' -ExitCode 1 -ErrorOutput 'simulated'
+        } *>&1
+        ($output -join "`n") | Should -Match '0x00000001'
+    }
+}

--- a/.github/scripts/Test-Installs.ps1
+++ b/.github/scripts/Test-Installs.ps1
@@ -75,7 +75,17 @@ function Add-Result {
     # doesn't require a special re-run to learn the real cause.  Wrapped in a
     # GitHub Actions log group so the workflow log stays readable.
     if ($Status -eq 'fail' -and -not [string]::IsNullOrWhiteSpace($ErrorOutput)) {
-        $hex = '0x{0:X8}' -f ([uint32]([int]$ExitCode -band 0xFFFFFFFF))
+        # Format the exit code as unsigned hex.  Cannot use ([uint32]($ExitCode -band 0xFFFFFFFF))
+        # because PowerShell's 0xFFFFFFFF literal is int (-1), so -band preserves the
+        # signed value and the [uint32] cast then fails on any negative exit code (e.g.
+        # winget's -1978335184).  BitConverter reinterprets the int32 bit pattern as uint32.
+        # Wrapped in try/catch so a formatting bug here can never abort the install loop
+        # (which is exactly what bit us before the fix).
+        try {
+            $hex = '0x{0:X8}' -f [BitConverter]::ToUInt32([BitConverter]::GetBytes([int32]$ExitCode), 0)
+        } catch {
+            $hex = "(hex-format-failed: $($_.Exception.Message))"
+        }
         Write-Host "::group::[$InstallerType] $Name failure output (exit $ExitCode / $hex)"
         Write-Host $ErrorOutput
         Write-Host "::endgroup::"


### PR DESCRIPTION
## Problem

CI run [25649435617](https://github.com/MarkMichaelis/ScoopBucket/actions/runs/25649435617) terminated after installing only 12 of 76 discovered packages.  Test-Installs.ps1 threw at line 78:

```
InvalidArgument: D:\a\ScoopBucket\ScoopBucket\.github\scripts\Test-Installs.ps1:78
Cannot convert value "-1" to type "System.UInt32". Error: "Value was either too large or too small for a UInt32."
```

Root cause: PowerShell's `0xFFFFFFFF` literal is `int` (= -1), so `[int]\ -band 0xFFFFFFFF` preserves the signed bit pattern, and `[uint32]` then rejects the negative result.  Winget's transient/cancel exit codes (e.g. `-1978335184` = 0x8A150030) hit this path on every failure.

## Symptom

CLI availability artifact for that run showed **13 / 26 **  but most "missing" CLIs (rg, code, ffmpeg, bcompare, gcloud, fzf, copilot, bat, es, exiftool, dbxcli, zoom, espeak-ng) were missing because **their installers never ran**  Test-Installs.ps1 aborted on the first failed install, well before reaching them in the loop.

## Fix

- `[uint32]($ExitCode -band 0xFFFFFFFF)` -> `[BitConverter]::ToUInt32([BitConverter]::GetBytes([int32]$ExitCode), 0)`  bit-exact reinterpret, no signed/unsigned traps.
- Wrapped the formatter in `try/catch` so a future formatting bug here can never abort the install loop again.

## Tests

Added 3 Pester regression cases in `Test-Installs.Tests.ps1`:
- `ExitCode = -1978335184` -> hex contains `0x8A150030` (real winget value)
- `ExitCode = -1` -> hex contains `0xFFFFFFFF`
- `ExitCode = 1` -> hex contains `0x00000001`

All 3 pass.  Remaining 72/75 = same pre-existing failures (unchanged).

## Follow-up

Once this merges, validate-installs.yml will get a clean run with all 76 packages actually attempted.  At that point a follow-up PR will pin the verified working CLI surface (locking out future regressions).

Refs #45.