### PR TITLE
Pinned CLI-availability contract  close #45 Phase 3

### DIFF
--- a/.github/workflows/validate-installs.yml
+++ b/.github/workflows/validate-installs.yml
@@ -169,6 +169,18 @@ jobs:
           }
           $sb.ToString() | Out-File -FilePath $env:GITHUB_STEP_SUMMARY -Append -Encoding utf8
 
+      - name: CLI availability — pinned contract (enforcing)
+        if: always()
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = 'Continue'
+          $result = Invoke-Pester -Path "${{ github.workspace }}\bucket\CliAvailabilityPinned.Tests.ps1" -Tag Heavy -Output Detailed -PassThru
+          if ($result.FailedCount -gt 0) {
+            Write-Host "::error::Pinned CLI contract regressed: $($result.FailedCount) of $($result.TotalCount) checks failed."
+            exit 1
+          }
+          Write-Host "Pinned CLI contract held: $($result.PassedCount)/$($result.TotalCount) checks passed."
+
       - name: Upload CLI availability artifact
         if: always()
         continue-on-error: true

--- a/bucket/CliAvailabilityPinned.Tests.ps1
+++ b/bucket/CliAvailabilityPinned.Tests.ps1
@@ -1,0 +1,127 @@
+<#
+.SYNOPSIS
+    Phase 3 contract tests for CLI-availability (#45).
+
+.DESCRIPTION
+    PINNED expectations.  Each CLI listed here MUST resolve via Get-Command in
+    a CI environment where the validate-installs workflow has run (so all
+    bundle packages and the post-install hooks have been applied).  Locks
+    the contract restored by PR #63 (PATH refresh + parser fixes) and PR #64
+    (standalone-scoop parser, devenv shim, BeyondCompare bcomp.com remap,
+    sysinternals dir on Machine PATH).
+
+    Regressions surface here as test failures with actionable detail.
+
+    Tagged 'Heavy','CliAvailability' so the standard fast suite is unaffected.
+    The validate-installs workflow already invokes Pester with -Tag Heavy
+    against bucket\*.Tests.ps1 immediately after CLI-availability discovery.
+
+    To run locally (requires bundle packages already installed on the host):
+        Invoke-Pester -Path .\bucket\CliAvailabilityPinned.Tests.ps1 -Tag Heavy
+#>
+
+Describe 'CLI availability — pinned contract' -Tag 'Heavy','CliAvailability' {
+
+    BeforeAll {
+        # Refresh PATH from registry so newly-installed shims/dirs are visible
+        # in this Pester process, mirroring Invoke-PostInstallHooks.ps1.
+        $machine = [Environment]::GetEnvironmentVariable('Path', 'Machine')
+        $user    = [Environment]::GetEnvironmentVariable('Path', 'User')
+        $merged  = @($machine, $user) |
+            Where-Object { $_ } |
+            ForEach-Object { $_.TrimEnd(';') } |
+            Where-Object { $_ } |
+            ForEach-Object { $_ }
+        if ($merged) { $env:Path = ($merged -join ';') }
+    }
+
+    # -------------------------------------------------------------------------
+    # Core CLIs that PR #63's PATH refresh restored (winget Links dir, scoop
+    # global shims).  All shipped from winget's `C:\Program Files\WinGet\Links\`
+    # or scoop's `C:\ProgramData\scoop\shims\` after `Update-PathFromRegistry`.
+    # -------------------------------------------------------------------------
+    Context 'PATH-refresh-fixed CLIs (PR #63)' {
+        It 'resolves <Cli>' -ForEach @(
+            @{ Cli = 'bw';       Package = 'Bitwarden.CLI' }
+            @{ Cli = 'rg';       Package = 'BurntSushi.ripgrep.MSVC' }
+            @{ Cli = 'calibre';  Package = 'calibre.calibre' }
+            @{ Cli = 'sox';      Package = 'ChrisBagwell.SoX' }
+            @{ Cli = 'copilot';  Package = 'GitHub.Copilot' }
+            @{ Cli = 'gcloud';   Package = 'Google.CloudSDK' }
+            @{ Cli = 'fzf';      Package = 'junegunn.fzf' }
+            @{ Cli = 'code';     Package = 'Microsoft.VisualStudioCode' }
+            @{ Cli = 'bat';      Package = 'sharkdp.bat' }
+            @{ Cli = 'es';       Package = 'voidtools.Everything.Cli' }
+            @{ Cli = 'bcompare'; Package = 'extras/beyondcompare' }
+        ) {
+            param($Cli, $Package)
+            $cmd = Get-Command $Cli -ErrorAction SilentlyContinue
+            $cmd | Should -Not -BeNullOrEmpty -Because "expected '$Cli' (from $Package) to be on PATH"
+        }
+    }
+
+    # -------------------------------------------------------------------------
+    # CLIs that PR #64 wired up via standalone-scoop parser + post-install hooks.
+    # -------------------------------------------------------------------------
+    Context 'Post-install-hook CLIs (PR #64)' {
+        It 'resolves ffmpeg (scoop install ffmpeg now actually runs in CI)' {
+            $cmd = Get-Command ffmpeg -ErrorAction SilentlyContinue
+            $cmd | Should -Not -BeNullOrEmpty
+        }
+
+        It 'resolves devenv (shim created by Invoke-PostInstallHooks.ps1 via vswhere)' {
+            $cmd = Get-Command devenv -ErrorAction SilentlyContinue
+            $cmd | Should -Not -BeNullOrEmpty
+        }
+    }
+
+    # -------------------------------------------------------------------------
+    # Sysinternals: representative subset proves the install-dir-on-PATH fix
+    # in OSBasePackages.ps1 (humans) / Invoke-PostInstallHooks.ps1 (CI) works.
+    # Drift on any of these means the PATH-add regressed.
+    # -------------------------------------------------------------------------
+    Context 'Sysinternals suite (install dir on Machine PATH)' {
+        It 'resolves <_>' -ForEach @('procexp','procmon','psexec','handle','pslist') {
+            $cmd = Get-Command $_ -ErrorAction SilentlyContinue
+            $cmd | Should -Not -BeNullOrEmpty -Because "extras/sysinternals install dir must be on Machine PATH"
+        }
+    }
+
+    # -------------------------------------------------------------------------
+    # BeyondCompare: the package ships THREE relevant binaries with different
+    # behaviour.  Scoop's manifest only shims BCompare.exe (-> bcompare) and
+    # BComp.exe (-> bcomp); BComp.com (the console-waiting variant used by
+    # VCS hooks) is not shimmed by default.  PR #64 retargets `bcomp` -> BComp.com
+    # and adds the install dir to Machine PATH so `bcomp.exe` remains reachable
+    # by explicit name.
+    # -------------------------------------------------------------------------
+    Context 'BeyondCompare three-binary surface (PR #64)' {
+        It 'resolves bcompare -> BCompare.exe (main app)' {
+            $cmd = Get-Command bcompare -ErrorAction SilentlyContinue
+            $cmd | Should -Not -BeNullOrEmpty
+        }
+
+        It 'resolves bcomp and targets BComp.com (console-waiting variant)' {
+            $cmd = Get-Command bcomp -ErrorAction SilentlyContinue
+            $cmd | Should -Not -BeNullOrEmpty
+            # Resolve through the shim to its ultimate target.  Scoop shims are
+            # `.shim` text files alongside a `.exe` launcher; the launcher's
+            # path is what Get-Command returns.  For the BComp.com remap we
+            # inspect the sidecar `.shim` file which records the real target.
+            $shimDir = Split-Path $cmd.Source -Parent
+            $shimMeta = Join-Path $shimDir 'bcomp.shim'
+            if (Test-Path $shimMeta) {
+                $target = (Get-Content $shimMeta | Select-String '^path\s*=' | Select-Object -First 1).Line
+                $target | Should -Match 'BComp\.com'
+            } else {
+                # Fallback: source path itself should end with BComp.com.
+                $cmd.Source | Should -Match 'BComp\.com$'
+            }
+        }
+
+        It 'resolves bcomp.exe by explicit extension (BC install dir on PATH)' {
+            $cmd = Get-Command bcomp.exe -ErrorAction SilentlyContinue
+            $cmd | Should -Not -BeNullOrEmpty
+        }
+    }
+}


### PR DESCRIPTION
## What this does

Adds Phase 3 of #45: an **enforcing** Pester `Heavy`-tagged contract that asserts `Get-Command <cli>` returns a result for every CLI we've stabilized in PRs #63, #64, and #67.  Regressions surface as test failures with actionable detail; `validate-installs.yml` exits 1 on any failure.

## Evidence the pinning matches reality

After PR #67 (Test-Installs.ps1 crash fix), validate-installs run [25651081642](https://github.com/MarkMichaelis/ScoopBucket/actions/runs/25651081642) produced:

- 91 installs attempted: **82 pass, 9 untested (skipped), 0 fail**
- CLI availability discovery: **26 / 26 , 0 missing**

Every CLI pinned by this PR is in the 26 working set, plus three additional surfaces validated by the post-install hook logs:
- sysinternals dir added to Machine PATH (`C:\ProgramData\scoop\apps\sysinternals\current`)
- BeyondCompare `bcomp` shim retargeted to `BComp.com` (console-waiting variant per VCS convention)
- BC install dir added to Machine PATH (`bcomp.exe` resolves by explicit extension)

## Pinned contract surface

| Section | Count | CLIs |
|---|---|---|
| PATH-refresh-fixed (PR #63) | 11 | bw, rg, calibre, sox, copilot, gcloud, fzf, code, bat, es, bcompare |
| Post-install hooks (PR #64) | 2 | ffmpeg, devenv |
| Sysinternals (install dir on Machine PATH) | 5 | procexp, procmon, psexec, handle, pslist |
| BeyondCompare three-binary surface | 3 | bcompare, bcomp (-> BComp.com), bcomp.exe |
| **Total** | **21** | |

The `bcomp` test inspects the `.shim` sidecar to verify the retarget actually points at `BComp.com` (not just that any shim exists).

## Workflow change

New step in `validate-installs.yml`:

`yaml
- name: CLI availability  pinned contract (enforcing)
  if: always()
  ...
  if ($result.FailedCount -gt 0) { exit 1 }
`

Closes #45.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>