### PR TITLE
Register PowerShell tab completion for installed CLI tools

### DIFF
--- a/.github/workflows/validate-installs.yml
+++ b/.github/workflows/validate-installs.yml
@@ -181,6 +181,33 @@ jobs:
           }
           Write-Host "Pinned CLI contract held: $($result.PassedCount)/$($result.TotalCount) checks passed."
 
+      - name: CLI completion — pinned curated map
+        if: always()
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = 'Continue'
+          $result = Invoke-Pester -Path "${{ github.workspace }}\bucket\CompletionPinned.Tests.ps1" -Tag Heavy,CompletionPinned -Output Detailed -PassThru
+          if ($result.FailedCount -gt 0) {
+            Write-Host "::error::CLI completion curated map regressed: $($result.FailedCount) of $($result.TotalCount) checks failed."
+            exit 1
+          }
+          Write-Host "Curated completion map intact: $($result.PassedCount)/$($result.TotalCount) checks passed."
+
+      - name: CLI completion — bundle entry-point + idempotency
+        if: always()
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = 'Continue'
+          $result = Invoke-Pester -Path @(
+            "${{ github.workspace }}\bucket\CliCompletions.Tests.ps1",
+            "${{ github.workspace }}\bucket\CompletionIdempotency.Tests.ps1"
+          ) -Tag Light,Bundle,Heavy,Idempotency -Output Detailed -PassThru
+          if ($result.FailedCount -gt 0) {
+            Write-Host "::error::CLI completion bundle tests failed: $($result.FailedCount) of $($result.TotalCount)."
+            exit 1
+          }
+          Write-Host "CLI completion bundle tests passed: $($result.PassedCount)/$($result.TotalCount)."
+
       - name: Upload CLI availability artifact
         if: always()
         continue-on-error: true

--- a/README.md
+++ b/README.md
@@ -172,6 +172,38 @@ See #45 for the tracking issue. Rolling out in three phases:
   in an `ExpectedCliMap`, and any package missing its expected CLI
   fails the build.
 
+## CLI tab-completion registration
+
+Every bundle that installs CLI tools (`AIAgents`, `ClientBasePackages`,
+`DeveloperBasePackages`) calls `Register-AllCliCompletions -Force` after
+its installs run, so a fresh `scoop install` of any of these bundles
+leaves a usable PowerShell tab-completion experience in place without an
+extra opt-in step.
+
+The standalone `CliCompletions` bundle exists for retroactive coverage —
+install (or `scoop update CliCompletions`) at any time to scan every CLI
+already on `PATH` and register completion for it. The bundle exposes a
+`register-all-cli-completions` shim so you can re-run it on demand.
+
+Behavior:
+
+- Each CLI is resolved in order: built-in PowerShell-shell completion
+  command (curated map in `Utils.ps1`) → `PSCompletions` (`abgox/PSCompletions`)
+  fallback → skipped with a reason.
+- All registrations are written as sentinel-delimited blocks
+  (`# ScoopBucket:CliCompletion:<cli>:BEGIN v1 … :END`) inside
+  `$PROFILE.AllUsersAllHosts`. Two runs with `-Force` produce a
+  byte-identical profile.
+- `-Force` is opt-in for ad-hoc invocations (`register-all-cli-completions`
+  defaults to gap-fill only); the bundle installers pass `-Force`
+  explicitly so reinstalls always refresh blocks.
+- Writing to `$PROFILE.AllUsersAllHosts` requires an elevated session.
+  Bundle scripts wrap the call in `try/catch` and emit a warning, so a
+  non-elevated reinstall succeeds but the user is told their completion
+  blocks were not refreshed.
+- `-WhatIf` / `-Confirm` are honored (the helper opts in to
+  `SupportsShouldProcess` with `ConfirmImpact='Medium'`).
+
 ## Testing
 
 A per-package functional-test framework based on Pester is in development

--- a/bucket/AIAgents.json
+++ b/bucket/AIAgents.json
@@ -1,6 +1,6 @@
 {
     "$schema": "https://raw.githubusercontent.com/lukesampson/scoop/master/schema.json",
-    "version": "1.09.000",
+    "version": "1.09.001",
     "url": [
         "https://raw.githubusercontent.com/MarkMichaelis/ScoopBucket/master/bucket/Utils.ps1",
         "https://raw.githubusercontent.com/MarkMichaelis/ScoopBucket/master/bucket/AIAgents.ps1"

--- a/bucket/AIAgents.ps1
+++ b/bucket/AIAgents.ps1
@@ -326,3 +326,14 @@ if ($Reset) {
         Remove-McpServerFromCodex -ServerName $name
     }
 }
+
+
+# Tab-completion registration: idempotent best-effort. Skipped (with a
+# warning) when the session isn't elevated so a normal scoop reinstall
+# still succeeds for users without admin rights.
+try {
+    Register-AllCliCompletions -Force -Confirm:$false -ErrorAction Stop | Out-Null
+}
+catch {
+    Write-Warning "Skipping CLI tab-completion registration: $($_.Exception.Message)"
+}

--- a/bucket/Aspire.json
+++ b/bucket/Aspire.json
@@ -1,6 +1,6 @@
 {
     "$schema": "https://raw.githubusercontent.com/lukesampson/scoop/master/schema.json",
-    "version": "1.01.000",
+    "version": "1.02.000",
     "url": [
         "https://raw.githubusercontent.com/MarkMichaelis/ScoopBucket/master/bucket/Utils.ps1",
         "https://raw.githubusercontent.com/MarkMichaelis/ScoopBucket/master/bucket/Aspire.ps1"

--- a/bucket/ChatGPT.json
+++ b/bucket/ChatGPT.json
@@ -1,6 +1,6 @@
 {
     "$schema": "https://raw.githubusercontent.com/lukesampson/scoop/master/schema.json",
-    "version": "1.05.000",
+    "version": "1.06.000",
     "url": [
         "https://raw.githubusercontent.com/MarkMichaelis/ScoopBucket/master/bucket/Utils.ps1",
         "https://raw.githubusercontent.com/MarkMichaelis/ScoopBucket/master/bucket/ChatGPT.ps1"

--- a/bucket/Chocolatey.json
+++ b/bucket/Chocolatey.json
@@ -1,6 +1,6 @@
 ﻿{
     "$schema": "https://raw.githubusercontent.com/lukesampson/scoop/master/schema.json",
-    "version": "1.03.000",
+    "version": "1.04.000",
     "url": [
         "https://raw.githubusercontent.com/MarkMichaelis/ScoopBucket/master/bucket/Utils.ps1",
         "https://raw.githubusercontent.com/MarkMichaelis/ScoopBucket/master/bucket/Chocolatey.ps1"

--- a/bucket/ClaudeExcel.json
+++ b/bucket/ClaudeExcel.json
@@ -1,6 +1,6 @@
 {
     "$schema": "https://raw.githubusercontent.com/lukesampson/scoop/master/schema.json",
-    "version": "1.01.000",
+    "version": "1.02.000",
     "url": [
         "https://raw.githubusercontent.com/MarkMichaelis/ScoopBucket/master/bucket/Utils.ps1",
         "https://raw.githubusercontent.com/MarkMichaelis/ScoopBucket/master/bucket/ClaudeExcel.ps1"

--- a/bucket/CliCompletions.Tests.ps1
+++ b/bucket/CliCompletions.Tests.ps1
@@ -1,0 +1,72 @@
+# ----------------------------------------------------------------------------
+# Pester v5 tests for the CliCompletions bundle entry point (Completions.ps1)
+# and the bundle manifest. Uses a sandbox profile path to avoid touching
+# $PSHOME\Profile.ps1.
+# ----------------------------------------------------------------------------
+
+Describe 'CliCompletions bundle' -Tag 'Light','Bundle' {
+
+    BeforeAll {
+        $script:repoBucket = $PSScriptRoot
+        $script:manifest   = Join-Path $script:repoBucket 'CliCompletions.json'
+        $script:script     = Join-Path $script:repoBucket 'Completions.ps1'
+        $script:sandbox    = Join-Path ([System.IO.Path]::GetTempPath()) ("CliCompletions-" + [guid]::NewGuid().ToString('N'))
+        New-Item -ItemType Directory -Path $script:sandbox -Force | Out-Null
+        $script:profilePath = Join-Path $script:sandbox 'Profile.ps1'
+    }
+
+    AfterAll {
+        if (Test-Path $script:sandbox) {
+            Remove-Item -Path $script:sandbox -Recurse -Force -ErrorAction SilentlyContinue
+        }
+    }
+
+    Context 'Manifest' {
+        It 'is valid JSON' {
+            { Get-Content -Raw -Path $script:manifest | ConvertFrom-Json } | Should -Not -Throw
+        }
+        It 'follows the semver patch convention (X.YY.ZZZ)' {
+            $json = Get-Content -Raw -Path $script:manifest | ConvertFrom-Json
+            $json.version | Should -Match '^\d+\.\d{2}\.\d{3}$'
+        }
+        It 'exposes the register-all-cli-completions shim' {
+            $json = Get-Content -Raw -Path $script:manifest | ConvertFrom-Json
+            $names = @($json.bin | ForEach-Object { if ($_ -is [array]) { $_[1] } else { $_ } })
+            $names | Should -Contain 'register-all-cli-completions'
+        }
+        It 'wires Completions.ps1 with -Force in the installer' {
+            $json = Get-Content -Raw -Path $script:manifest | ConvertFrom-Json
+            $json.installer.script | Should -Match '-Force'
+        }
+    }
+
+    Context 'Completions.ps1 against a sandbox profile' {
+        It 'creates a profile and registers a curated CLI when present in -Names' {
+            & $script:script -Force -ProfilePath $script:profilePath -Names @('gh')
+            Test-Path $script:profilePath | Should -Be $true
+        }
+        It 'is idempotent: running twice with -Force produces identical bytes' {
+            $names = @('gh','rg','docker')
+            & $script:script -Force -ProfilePath $script:profilePath -Names $names
+            $first = [System.IO.File]::ReadAllBytes($script:profilePath)
+            & $script:script -Force -ProfilePath $script:profilePath -Names $names
+            $second = [System.IO.File]::ReadAllBytes($script:profilePath)
+            (Compare-Object $first $second) | Should -BeNullOrEmpty
+        }
+        It 'preserves existing blocks when run without -Force' {
+            # Run once with -Force to seed.
+            & $script:script -Force -ProfilePath $script:profilePath -Names @('gh')
+            $seeded = Get-Content -Raw -Path $script:profilePath
+            # Run again without -Force; profile must be unchanged.
+            & $script:script -ProfilePath $script:profilePath -Names @('gh')
+            $after = Get-Content -Raw -Path $script:profilePath
+            $after | Should -Be $seeded
+        }
+        It '-WhatIf does not touch the profile file' {
+            # Reset the sandbox profile.
+            if (Test-Path $script:profilePath) { Remove-Item $script:profilePath -Force }
+            & $script:script -Force -WhatIf -ProfilePath $script:profilePath -Names @('gh')
+            (Test-Path $script:profilePath) | Should -Be $false
+        }
+    }
+}

--- a/bucket/CliCompletions.json
+++ b/bucket/CliCompletions.json
@@ -1,0 +1,24 @@
+{
+    "version": "1.00.000",
+    "description": "Register PowerShell tab completion for every CLI on the machine. Native curated commands preferred (gh, rg, bw, docker, copilot, gcloud, ...) with PSCompletions (abgox/PSCompletions) as the fallback. Writes sentinel-delimited blocks into $PSHOME\\Profile.ps1 so completion works for every user, every host, every shell start. Idempotent; supports -Force and -WhatIf via Completions.ps1.",
+    "homepage": "https://github.com/MarkMichaelis/ScoopBucket",
+    "license": "MIT",
+    "url": [
+        "https://raw.githubusercontent.com/MarkMichaelis/ScoopBucket/master/bucket/Completions.ps1",
+        "https://raw.githubusercontent.com/MarkMichaelis/ScoopBucket/master/bucket/Utils.ps1"
+    ],
+    "installer": {
+        "script": "& \"$dir\\Completions.ps1\" -Force"
+    },
+    "bin": [
+        [
+            "Completions.ps1",
+            "register-all-cli-completions"
+        ]
+    ],
+    "notes": [
+        "Tab completion is now configured for every CLI on the machine that has either a native PowerShell completion command (gh, rg, bw, docker, copilot, gcloud, ...) or a PSCompletions catalog entry.",
+        "Re-run any time with `register-all-cli-completions` (from an elevated PowerShell). Default: only register CLIs without an existing block. Pass `-Force` to overwrite existing blocks.",
+        "Preview changes with: register-all-cli-completions -Force -WhatIf"
+    ]
+}

--- a/bucket/ClientBasePackages.json
+++ b/bucket/ClientBasePackages.json
@@ -1,6 +1,6 @@
-﻿{
+{
     "$schema": "https://raw.githubusercontent.com/lukesampson/scoop/master/schema.json",
-    "version": "1.05.000",
+    "version": "1.05.001",
     "url": [
         "https://raw.githubusercontent.com/MarkMichaelis/ScoopBucket/master/bucket/Utils.ps1",
         "https://raw.githubusercontent.com/MarkMichaelis/ScoopBucket/master/bucket/ClientBasePackages.ps1"

--- a/bucket/ClientBasePackages.ps1
+++ b/bucket/ClientBasePackages.ps1
@@ -90,3 +90,14 @@ Invoke-WebRequest -Uri 'https://readwise.io/read/download_latest/desktop/windows
 Add-AppxPackage -Path "$env:TEMP\ReadwiseReader.msix"
 Remove-Item "$env:TEMP\ReadwiseReader.msix" -ErrorAction Ignore
 
+
+
+# Tab-completion registration: idempotent best-effort. Skipped (with a
+# warning) when the session isn't elevated so a normal scoop reinstall
+# still succeeds for users without admin rights.
+try {
+    Register-AllCliCompletions -Force -Confirm:$false -ErrorAction Stop | Out-Null
+}
+catch {
+    Write-Warning "Skipping CLI tab-completion registration: $($_.Exception.Message)"
+}

--- a/bucket/CompletionIdempotency.Tests.ps1
+++ b/bucket/CompletionIdempotency.Tests.ps1
@@ -1,0 +1,70 @@
+# ----------------------------------------------------------------------------
+# Opt-in idempotency test for the completion registration system.
+# Tag 'Idempotency' so it stays out of the default Light run; opt in with:
+#   Invoke-Pester -Path bucket\CompletionIdempotency.Tests.ps1 -Tag Idempotency
+# ----------------------------------------------------------------------------
+
+Describe 'CliCompletion idempotency' -Tag 'Heavy','Idempotency' {
+
+    BeforeAll {
+        . (Join-Path $PSScriptRoot 'Utils.ps1')
+        $script:sandbox = Join-Path ([System.IO.Path]::GetTempPath()) ("CC-idem-" + [guid]::NewGuid().ToString('N'))
+        New-Item -ItemType Directory -Path $script:sandbox -Force | Out-Null
+        $script:profilePath = Join-Path $script:sandbox 'Profile.ps1'
+
+        # Use a small deterministic set so the test doesn't depend on
+        # whatever happens to be on the developer's PATH.
+        $script:names = @('gh','rg','docker','copilot')
+    }
+
+    AfterAll {
+        if (Test-Path $script:sandbox) {
+            Remove-Item -Path $script:sandbox -Recurse -Force -ErrorAction SilentlyContinue
+        }
+    }
+
+    It 'two -Force runs produce byte-identical profile content' {
+        Register-AllCliCompletions -Force -ProfilePath $script:profilePath -Names $script:names | Out-Null
+        $first = [System.IO.File]::ReadAllBytes($script:profilePath)
+        Register-AllCliCompletions -Force -ProfilePath $script:profilePath -Names $script:names | Out-Null
+        $second = [System.IO.File]::ReadAllBytes($script:profilePath)
+        $first.Length | Should -Be $second.Length
+        for ($i = 0; $i -lt $first.Length; $i++) {
+            $first[$i] | Should -Be $second[$i]
+        }
+    }
+
+    It 'second run produces at most one :BEGIN block per CLI' {
+        $content = Get-Content -Raw -Path $script:profilePath
+        foreach ($n in $script:names) {
+            $pattern = "# ScoopBucket:CliCompletion:$n`:BEGIN"
+            $count = ([regex]::Matches($content, [regex]::Escape($pattern))).Count
+            # Could be 0 (no native completion / no PSCompletions def) or
+            # exactly 1 — never more.
+            $count | Should -BeLessOrEqual 1
+        }
+    }
+
+    It '-Force:$false preserves a manually-modified block' {
+        # Seed with -Force, then mutate the gh block, then re-run without
+        # -Force; the mutated block must survive.
+        Register-AllCliCompletions -Force -ProfilePath $script:profilePath -Names @('gh') | Out-Null
+        $content = Get-Content -Raw -Path $script:profilePath
+        if ($content -match '# ScoopBucket:CliCompletion:gh:BEGIN') {
+            $mutated = $content -replace 'Get-Command gh','Get-Command gh # USER MUTATION'
+            [System.IO.File]::WriteAllText($script:profilePath, $mutated, [System.Text.UTF8Encoding]::new($false))
+            Register-AllCliCompletions -ProfilePath $script:profilePath -Names @('gh') | Out-Null
+            $after = Get-Content -Raw -Path $script:profilePath
+            $after | Should -Match 'USER MUTATION'
+        }
+        else {
+            Set-ItResult -Skipped -Because "'gh' has no native completion available in this environment; mutation case n/a."
+        }
+    }
+
+    It '-WhatIf does not touch the profile file' {
+        $tempProfile = Join-Path $script:sandbox 'WhatIfProfile.ps1'
+        Register-AllCliCompletions -Force -WhatIf -ProfilePath $tempProfile -Names @('gh') | Out-Null
+        (Test-Path $tempProfile) | Should -Be $false
+    }
+}

--- a/bucket/CompletionPinned.Tests.ps1
+++ b/bucket/CompletionPinned.Tests.ps1
@@ -1,0 +1,36 @@
+# ----------------------------------------------------------------------------
+# Pinned contract for the curated CLI-completion native map.
+#
+# Locks the set of CLIs the bucket guarantees will get a tab-completion
+# block in the AllUsersAllHosts profile when their owning bundle is
+# installed. Regressions here mean either:
+#   (a) the curated map in Utils.ps1 silently lost an entry, or
+#   (b) the registration helper changed its sentinel format.
+#
+# Tagged 'Heavy','CompletionPinned' so the standard fast suite is
+# unaffected. Validate-installs.yml will invoke this explicitly.
+# ----------------------------------------------------------------------------
+
+Describe 'CliCompletion pinned contract — curated native map' -Tag 'Heavy','CompletionPinned' {
+
+    BeforeAll {
+        . (Join-Path $PSScriptRoot 'Utils.ps1')
+    }
+
+    It 'includes <Cli> in the curated native map' -ForEach @(
+        @{ Cli = 'gh' }
+        @{ Cli = 'rg' }
+        @{ Cli = 'bw' }
+        @{ Cli = 'docker' }
+        @{ Cli = 'copilot' }
+        @{ Cli = 'gcloud' }
+    ) {
+        param($Cli)
+        $script:CliCompletionNativeMap.ContainsKey($Cli) |
+            Should -BeTrue -Because "the curated native map must continue to declare '$Cli'"
+    }
+
+    It 'uses sentinel version v1' {
+        $script:CompletionSentinelVersion | Should -Be 'v1'
+    }
+}

--- a/bucket/Completions.ps1
+++ b/bucket/Completions.ps1
@@ -1,0 +1,39 @@
+[CmdletBinding(SupportsShouldProcess, ConfirmImpact = 'Medium')]
+param(
+    # Overwrite existing per-CLI completion blocks. Default OFF (PowerShell
+    # convention: explicit opt-in). Scoop bucket bundle scripts pass -Force
+    # explicitly so an install refreshes completions to match.
+    [switch]$Force,
+
+    # Test/diagnostic hook: redirect profile writes to this file instead of
+    # the AllUsersAllHosts profile. Bypasses the elevation check.
+    [string]$ProfilePath,
+
+    # Optional explicit list of CLIs to register. Defaults to every
+    # CommandType=Application on PATH.
+    [string[]]$Names
+)
+
+Write-Host 'Configuring PowerShell tab completion for installed CLI tools...'
+. "$PSScriptRoot\Utils.ps1"
+
+# Ensure the PSCompletions fallback module is present (AllUsers). Idempotent.
+Install-PSCompletionsModule -Force:$Force -WhatIf:$WhatIfPreference
+
+# Drive the scan. Register-AllCliCompletions handles enumeration when -Names
+# is empty, and propagates -WhatIf / -Confirm via SupportsShouldProcess.
+$splat = @{ Force = [bool]$Force }
+if ($ProfilePath) { $splat['ProfilePath'] = $ProfilePath }
+if ($Names)       { $splat['Names']       = $Names }
+
+$results = Register-AllCliCompletions @splat -WhatIf:$WhatIfPreference
+
+# Emit a markdown-friendly summary table on the host stream (CI step-summary
+# can pick it up via redirection if desired).
+if ($results) {
+    $results |
+        Sort-Object Source, Cli |
+        Format-Table -AutoSize Cli, Source, Action, Reason |
+        Out-String |
+        Write-Host
+}

--- a/bucket/DeveloperBasePackages.json
+++ b/bucket/DeveloperBasePackages.json
@@ -1,6 +1,6 @@
-﻿{
+{
     "$schema": "https://raw.githubusercontent.com/lukesampson/scoop/master/schema.json",
-    "version": "1.14.001",
+    "version": "1.14.002",
     "url": [
         "https://raw.githubusercontent.com/MarkMichaelis/ScoopBucket/master/bucket/Utils.ps1",
         "https://raw.githubusercontent.com/MarkMichaelis/ScoopBucket/master/bucket/DeveloperBasePackages.ps1"

--- a/bucket/DeveloperBasePackages.ps1
+++ b/bucket/DeveloperBasePackages.ps1
@@ -60,3 +60,14 @@ $WingetPackages.Values | `
 }
 
 
+
+
+# Tab-completion registration: idempotent best-effort. Skipped (with a
+# warning) when the session isn't elevated so a normal scoop reinstall
+# still succeeds for users without admin rights.
+try {
+    Register-AllCliCompletions -Force -Confirm:$false -ErrorAction Stop | Out-Null
+}
+catch {
+    Write-Warning "Skipping CLI tab-completion registration: $($_.Exception.Message)"
+}

--- a/bucket/Gemini.json
+++ b/bucket/Gemini.json
@@ -1,6 +1,6 @@
 {
     "$schema": "https://raw.githubusercontent.com/lukesampson/scoop/master/schema.json",
-    "version": "1.05.000",
+    "version": "1.06.000",
     "url": [
         "https://raw.githubusercontent.com/MarkMichaelis/ScoopBucket/master/bucket/Utils.ps1",
         "https://raw.githubusercontent.com/MarkMichaelis/ScoopBucket/master/bucket/Gemini.ps1"

--- a/bucket/GitConfigBeyondCompare.json
+++ b/bucket/GitConfigBeyondCompare.json
@@ -1,6 +1,6 @@
 ﻿{
     "$schema": "https://raw.githubusercontent.com/lukesampson/scoop/master/schema.json",
-    "version": "1.05.000",
+    "version": "1.06.000",
     "url": [
         "https://raw.githubusercontent.com/MarkMichaelis/ScoopBucket/master/bucket/Utils.ps1",
         "https://raw.githubusercontent.com/MarkMichaelis/ScoopBucket/master/bucket/GitConfigBeyondCompare.ps1"

--- a/bucket/GitConfigVisualStudio.json
+++ b/bucket/GitConfigVisualStudio.json
@@ -1,6 +1,6 @@
 ﻿{
     "$schema": "https://raw.githubusercontent.com/lukesampson/scoop/master/schema.json",
-    "version": "1.03.000",
+    "version": "1.04.000",
     "url": [
         "https://raw.githubusercontent.com/MarkMichaelis/ScoopBucket/master/bucket/Utils.ps1",
         "https://raw.githubusercontent.com/MarkMichaelis/ScoopBucket/master/bucket/GitConfigVisualStudio.ps1"

--- a/bucket/GitConfigure.json
+++ b/bucket/GitConfigure.json
@@ -1,6 +1,6 @@
 ﻿{
     "$schema": "https://raw.githubusercontent.com/lukesampson/scoop/master/schema.json",
-    "version": "1.14.000",
+    "version": "1.15.000",
     "url": [
         "https://raw.githubusercontent.com/MarkMichaelis/ScoopBucket/master/bucket/Utils.ps1",
         "https://raw.githubusercontent.com/MarkMichaelis/ScoopBucket/master/bucket/GitConfigBeyondCompare.ps1",

--- a/bucket/MicrosoftOffice365.json
+++ b/bucket/MicrosoftOffice365.json
@@ -1,6 +1,6 @@
 ﻿{
     "$schema": "https://raw.githubusercontent.com/lukesampson/scoop/master/schema.json",
-    "version": "1.02.000",
+    "version": "1.03.000",
     "url": [
         "https://raw.githubusercontent.com/MarkMichaelis/ScoopBucket/master/bucket/Utils.ps1",
         "https://raw.githubusercontent.com/MarkMichaelis/ScoopBucket/master/bucket/MicrosoftOffice365.ps1"

--- a/bucket/OSBasePackages.json
+++ b/bucket/OSBasePackages.json
@@ -1,6 +1,6 @@
 ﻿{
     "$schema": "https://raw.githubusercontent.com/lukesampson/scoop/master/schema.json",
-    "version": "1.13.001",
+    "version": "1.14.000",
     "url": [
         "https://raw.githubusercontent.com/MarkMichaelis/ScoopBucket/master/bucket/Utils.ps1",
         "https://raw.githubusercontent.com/MarkMichaelis/ScoopBucket/master/bucket/OSBasePackages.ps1"

--- a/bucket/PowerShellCore.json
+++ b/bucket/PowerShellCore.json
@@ -1,6 +1,6 @@
 ﻿{
     "$schema": "https://raw.githubusercontent.com/lukesampson/scoop/master/schema.json",
-    "version": "1.03.000",
+    "version": "1.04.000",
     "url": [
         "https://raw.githubusercontent.com/MarkMichaelis/ScoopBucket/master/bucket/Utils.ps1",
         "https://raw.githubusercontent.com/MarkMichaelis/ScoopBucket/master/bucket/PowerShell.ps1"

--- a/bucket/PowerShellWindows.json
+++ b/bucket/PowerShellWindows.json
@@ -1,6 +1,6 @@
 ﻿{
     "$schema": "https://raw.githubusercontent.com/lukesampson/scoop/master/schema.json",
-    "version": "1.06.000",
+    "version": "1.07.000",
     "url": [
         "https://raw.githubusercontent.com/MarkMichaelis/ScoopBucket/master/bucket/Utils.ps1",
         "https://raw.githubusercontent.com/MarkMichaelis/ScoopBucket/master/bucket/PowerShell.ps1"

--- a/bucket/Utils.Tests.ps1
+++ b/bucket/Utils.Tests.ps1
@@ -149,3 +149,88 @@ Describe 'scoop install wrapper' {
         $results | Should Be "install $mockAppName"
     }
 }
+
+# ----------------------------------------------------------------------------
+# Register-CliCompletion + helpers (Pester v5 style).
+# ----------------------------------------------------------------------------
+
+Describe 'Set-CompletionProfileBlock' -Tag 'Light','Completion' {
+    BeforeAll {
+        . (Join-Path $PSScriptRoot 'Utils.ps1')
+    }
+
+    It 'appends a fresh block when none exists' {
+        $r = Set-CompletionProfileBlock -Content '' -Cli 'gh' -Block 'BODY' -Force
+        $r | Should -Match '# ScoopBucket:CliCompletion:gh:BEGIN v1'
+        $r | Should -Match 'BODY'
+        $r | Should -Match '# ScoopBucket:CliCompletion:gh:END'
+    }
+
+    It 'is idempotent under -Force' {
+        $first  = Set-CompletionProfileBlock -Content ''      -Cli 'gh' -Block 'BODY' -Force
+        $second = Set-CompletionProfileBlock -Content $first  -Cli 'gh' -Block 'BODY' -Force
+        $second | Should -Be $first
+    }
+
+    It 'replaces an existing block when -Force is given' {
+        $seeded = Set-CompletionProfileBlock -Content '' -Cli 'gh' -Block 'OLD' -Force
+        $updated = Set-CompletionProfileBlock -Content $seeded -Cli 'gh' -Block 'NEW' -Force
+        $updated | Should -Match 'NEW'
+        $updated | Should -Not -Match 'OLD'
+    }
+
+    It 'preserves an existing block when -Force is omitted' {
+        $seeded = Set-CompletionProfileBlock -Content '' -Cli 'gh' -Block 'OLD' -Force
+        $kept   = Set-CompletionProfileBlock -Content $seeded -Cli 'gh' -Block 'NEW'
+        $kept | Should -Be $seeded
+    }
+
+    It 'tolerates blocks containing $ and \ characters' {
+        $tricky = 'if ($x -match "\d+") { Register-ArgumentCompleter -CommandName gh -ScriptBlock { $args[0] } }'
+        $r = Set-CompletionProfileBlock -Content '' -Cli 'gh' -Block $tricky -Force
+        $r | Should -Match ([regex]::Escape($tricky))
+    }
+
+    It 'leaves other CLIs untouched when replacing one' {
+        $seeded = Set-CompletionProfileBlock -Content '' -Cli 'gh' -Block 'GH'  -Force
+        $seeded = Set-CompletionProfileBlock -Content $seeded -Cli 'rg' -Block 'RG' -Force
+        $updated = Set-CompletionProfileBlock -Content $seeded -Cli 'gh' -Block 'GH2' -Force
+        $updated | Should -Match 'GH2'
+        $updated | Should -Match 'RG'
+        $updated | Should -Not -Match '(?ms)BEGIN v1\s+GH\s+#'
+    }
+}
+
+Describe 'Register-CliCompletion against a sandbox profile' -Tag 'Light','Completion' {
+    BeforeAll {
+        . (Join-Path $PSScriptRoot 'Utils.ps1')
+        $script:sandbox = Join-Path ([System.IO.Path]::GetTempPath()) ("Utils-CC-" + [guid]::NewGuid().ToString('N'))
+        New-Item -ItemType Directory -Path $script:sandbox -Force | Out-Null
+        $script:profile = Join-Path $script:sandbox 'Profile.ps1'
+    }
+
+    AfterAll {
+        if (Test-Path $script:sandbox) { Remove-Item $script:sandbox -Recurse -Force -ErrorAction SilentlyContinue }
+    }
+
+    It 'returns Skipped for an unknown CLI with no PSCompletions definition' {
+        $r = Register-CliCompletion -Cli 'definitely-not-a-real-cli-xyz' -Force -ProfilePath $script:profile
+        $r.Source | Should -Be 'Skipped'
+        $r.Action | Should -Be 'Skipped'
+    }
+
+    It '-WhatIf does not touch the profile' {
+        if (Test-Path $script:profile) { Remove-Item $script:profile -Force }
+        Register-CliCompletion -Cli 'gh' -Force -WhatIf -ProfilePath $script:profile | Out-Null
+        (Test-Path $script:profile) | Should -Be $false
+    }
+
+    It 'Preserved when re-run without -Force on an existing block' {
+        # Seed with a manually-written block to avoid depending on native gh.
+        $body = "# ScoopBucket:CliCompletion:gh:BEGIN v1`r`nBODY`r`n# ScoopBucket:CliCompletion:gh:END`r`n"
+        [System.IO.File]::WriteAllText($script:profile, $body, [System.Text.UTF8Encoding]::new($false))
+        $r = Register-CliCompletion -Cli 'gh' -ProfilePath $script:profile
+        $r.Action | Should -Be 'Preserved'
+        (Get-Content -Raw -Path $script:profile) | Should -Match 'BODY'
+    }
+}

--- a/bucket/Utils.ps1
+++ b/bucket/Utils.ps1
@@ -490,3 +490,361 @@ function Install-BucketApp {
         scoop install "MarkMichaelis/$Name"
     }
 }
+
+# ============================================================================
+# PowerShell tab-completion registration for installed CLI tools.
+#
+# Two-tier strategy per CLI:
+#   1. Native — emit the verbatim output of `<cli> completion powershell`
+#      (or the curated equivalent in $script:CliCompletionNativeMap) into
+#      a sentinel-delimited block in the AllUsersAllHosts profile.
+#   2. PSCompletions fallback — emit `Import-Module PSCompletions` (once)
+#      and call `psc add <cli>` at registration time so PSCompletions's
+#      own storage retains the binding for future sessions.
+#   3. Skip — no native command and no PSCompletions catalog entry.
+#
+# Persistence: the registration code is embedded directly in
+# `$PSHOME\Profile.ps1` (AllUsersAllHosts), so every PowerShell host for
+# every user picks it up on startup. Per-CLI sentinel blocks
+# (`# ScoopBucket:CliCompletion:<cli>:BEGIN v1` / `:END`) give
+# idempotent per-CLI replace/append semantics.
+#
+# All state-changing operations honour SupportsShouldProcess; the public
+# Completions.ps1 entry point propagates -WhatIf / -Confirm.
+# ============================================================================
+
+# Curated native-completion map. Each entry is the command this helper runs
+# to emit PowerShell registration source for the CLI. Add tools here as
+# they prove out — blind probing of unknown CLIs is intentionally avoided.
+$script:CliCompletionNativeMap = @{
+    'gh'      = { gh completion -s powershell 2>$null }
+    'rg'      = { rg --generate complete-powershell 2>$null }
+    'bw'      = { bw completion --shell powershell 2>$null }
+    'docker'  = { docker completion powershell 2>$null }
+    'copilot' = { copilot completion powershell 2>$null }
+    'gcloud'  = { gcloud --quiet --help-format=ps1 2>$null }  # gcloud ships its own; if this fails the CLI registers itself on shell init
+    'scoop'   = $null  # scoop-completion module handles this separately; treated as PSCompletions fallback
+}
+
+# Sentinel patterns. Bumping the trailing version invalidates older blocks
+# on the next force-refresh.
+$script:CompletionSentinelVersion = 'v1'
+
+function Test-IsElevated {
+    [OutputType([bool])]
+    [CmdletBinding()]
+    param()
+    if (-not $IsWindows -and ($PSVersionTable.PSEdition -eq 'Core')) {
+        # Non-Windows: assume elevated if running as root.
+        return ((whoami) -eq 'root')
+    }
+    $current = [System.Security.Principal.WindowsIdentity]::GetCurrent()
+    $principal = New-Object System.Security.Principal.WindowsPrincipal($current)
+    return $principal.IsInRole([System.Security.Principal.WindowsBuiltInRole]::Administrator)
+}
+
+function Get-CompletionProfilePath {
+    <#
+    .SYNOPSIS
+        Return the AllUsersAllHosts profile path. Throws if not writable;
+        emits Write-Information and returns $null if the host has no
+        AllUsersAllHosts profile (rare; tracked as a separate issue).
+    .PARAMETER OverridePath
+        Test hook: bypass $PROFILE.AllUsersAllHosts and admin checks.
+        Used by Pester to redirect the helper to a sandbox file.
+    #>
+    [OutputType([string])]
+    [CmdletBinding()]
+    param([string]$OverridePath)
+
+    if ($OverridePath) { return $OverridePath }
+
+    $target = $PROFILE.AllUsersAllHosts
+    if ([string]::IsNullOrWhiteSpace($target)) {
+        Write-Information "Host has no AllUsersAllHosts profile path; completion registration skipped. Filed as follow-up." -InformationAction Continue
+        return $null
+    }
+    if (-not (Test-IsElevated)) {
+        throw "Completion registration requires an elevated PowerShell session (target: $target). Re-run from an Administrator prompt."
+    }
+    # Probe writability by ensuring the parent exists and we can open the
+    # file for append. Don't actually write anything.
+    $dir = Split-Path -Parent $target
+    if (-not (Test-Path $dir)) {
+        try { New-Item -ItemType Directory -Path $dir -Force | Out-Null }
+        catch { throw "Cannot create AllUsersAllHosts profile directory '$dir': $($_.Exception.Message)" }
+    }
+    try {
+        $fs = [System.IO.File]::Open($target, [System.IO.FileMode]::OpenOrCreate, [System.IO.FileAccess]::ReadWrite, [System.IO.FileShare]::ReadWrite)
+        $fs.Dispose()
+    } catch {
+        throw "AllUsersAllHosts profile '$target' is not writable: $($_.Exception.Message). Re-run elevated."
+    }
+    return $target
+}
+
+function Resolve-CliCompletionSource {
+    <#
+    .SYNOPSIS
+        For a given CLI, return a hashtable describing how to register
+        completion: @{ Source='Native'|'PSCompletions'|'Skipped';
+                       Code=<powershell text or $null>;
+                       PSCompletionsName=<name or $null> }.
+    .DESCRIPTION
+        Native curated map → PSCompletions catalog probe → Skipped.
+        Catalog probe uses `psc list` if the module is loaded;
+        otherwise treats every unknown CLI as a candidate (PSCompletions
+        will simply error at registration time if it has no definition).
+    #>
+    [OutputType([hashtable])]
+    [CmdletBinding()]
+    param([Parameter(Mandatory)][string]$Cli)
+
+    # Strategy 1: native curated map.
+    if ($script:CliCompletionNativeMap.ContainsKey($Cli)) {
+        $sb = $script:CliCompletionNativeMap[$Cli]
+        if ($sb) {
+            # Capture native output. If the CLI isn't installed, the
+            # subshell errors and we fall through; we still emit a
+            # guarded block so the profile re-evaluates on shell start.
+            $native = $null
+            try { $native = & $sb 2>$null | Out-String } catch { }
+            if ($native -and $native.Trim()) {
+                # Wrap with Get-Command guard so the profile is safe even
+                # when the CLI later gets uninstalled.
+                $guarded = "if (Get-Command $Cli -ErrorAction SilentlyContinue) {`r`n$native}"
+                return @{ Source = 'Native'; Code = $guarded; PSCompletionsName = $null }
+            }
+        }
+    }
+
+    # Strategy 2: PSCompletions fallback.
+    $pscModule = Get-Module -ListAvailable -Name PSCompletions | Select-Object -First 1
+    if ($pscModule) {
+        # Best-effort: try to add the completion now. If PSCompletions
+        # has no definition for this CLI, the add call surfaces an error
+        # which we suppress and treat as "skipped".
+        try {
+            Import-Module PSCompletions -ErrorAction Stop
+            $listOutput = & psc list 2>$null | Out-String
+            if ($listOutput -match "(?im)^\s*$([regex]::Escape($Cli))(\s|$)") {
+                $code = "if (Get-Command psc -ErrorAction SilentlyContinue) {`r`n    Import-Module PSCompletions -ErrorAction SilentlyContinue`r`n}"
+                return @{ Source = 'PSCompletions'; Code = $code; PSCompletionsName = $Cli }
+            }
+        } catch { }
+    }
+
+    return @{ Source = 'Skipped'; Code = $null; PSCompletionsName = $null }
+}
+
+function Read-CompletionProfileContent {
+    [OutputType([string])]
+    [CmdletBinding()]
+    param([Parameter(Mandatory)][string]$Path)
+    if (Test-Path $Path) { return (Get-Content -Path $Path -Raw -Encoding UTF8) }
+    return ''
+}
+
+function Set-CompletionProfileBlock {
+    <#
+    .SYNOPSIS
+        Insert or replace a sentinel-delimited completion block for $Cli
+        in the profile $Content. Returns the new content. Idempotent:
+        identical inputs produce byte-identical output.
+    #>
+    [OutputType([string])]
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)][AllowEmptyString()][string]$Content,
+        [Parameter(Mandatory)][string]$Cli,
+        [Parameter(Mandatory)][string]$Block,
+        [switch]$Force
+    )
+    $ver = $script:CompletionSentinelVersion
+    $begin = "# ScoopBucket:CliCompletion:$Cli`:BEGIN $ver"
+    $end   = "# ScoopBucket:CliCompletion:$Cli`:END"
+    $pattern = "(?ms)^\# ScoopBucket:CliCompletion:$([regex]::Escape($Cli))`:BEGIN \w+.*?^\# ScoopBucket:CliCompletion:$([regex]::Escape($Cli))`:END\r?\n?"
+    $newBlock = "$begin`r`n$Block`r`n$end`r`n"
+    $match = [regex]::Match($Content, $pattern)
+    if ($match.Success) {
+        if (-not $Force) { return $Content }  # preserve existing
+        # String-concat (not regex Replace) so the new block can contain
+        # unescaped $ / \ without being interpreted as substitution syntax.
+        $before = $Content.Substring(0, $match.Index)
+        $after  = $Content.Substring($match.Index + $match.Length)
+        return $before + $newBlock + $after
+    }
+    # Append. Normalise trailing newlines to exactly one before the new block.
+    $trimmed = $Content.TrimEnd("`r","`n")
+    if ($trimmed) { return "$trimmed`r`n`r`n$newBlock" }
+    return $newBlock
+}
+
+function Register-CliCompletion {
+    <#
+    .SYNOPSIS
+        Register PowerShell tab-completion for a single CLI by embedding
+        a sentinel-delimited block in the AllUsersAllHosts profile.
+    .DESCRIPTION
+        Native curated commands preferred; PSCompletions fallback. Idempotent.
+        Honours -WhatIf / -Confirm via SupportsShouldProcess. Requires admin
+        (throws otherwise) unless -ProfilePath overrides.
+    .PARAMETER Cli
+        Bare command name (e.g. 'gh').
+    .PARAMETER Force
+        Overwrite an existing block for the same CLI. Without -Force,
+        existing blocks are preserved (no-op for already-registered CLIs).
+    .PARAMETER ProfilePath
+        Test hook: write to this file instead of AllUsersAllHosts.
+        Bypasses the elevation check.
+    .OUTPUTS
+        PSCustomObject with Cli, Source (Native/PSCompletions/Skipped),
+        Action (Added/Replaced/Preserved/Skipped/WhatIf), and ProfilePath.
+    #>
+    [CmdletBinding(SupportsShouldProcess, ConfirmImpact = 'Medium')]
+    [OutputType([pscustomobject])]
+    param(
+        [Parameter(Mandatory)][string]$Cli,
+        [switch]$Force,
+        [string]$ProfilePath
+    )
+
+    $target = Get-CompletionProfilePath -OverridePath $ProfilePath
+    if (-not $target) {
+        return [pscustomobject]@{
+            Cli = $Cli; Source = 'Skipped'; Action = 'Skipped'; ProfilePath = $null
+            Reason = 'No AllUsersAllHosts profile path available on this host.'
+        }
+    }
+
+    $resolved = Resolve-CliCompletionSource -Cli $Cli
+    if ($resolved.Source -eq 'Skipped') {
+        return [pscustomobject]@{
+            Cli = $Cli; Source = 'Skipped'; Action = 'Skipped'; ProfilePath = $target
+            Reason = "No native completion command in curated map and PSCompletions has no definition for '$Cli'."
+        }
+    }
+
+    # If PSCompletions, ask the module to add the binding now (idempotent
+    # via -Force in PSCompletions's storage).
+    if ($resolved.Source -eq 'PSCompletions') {
+        $pscAction = "psc add $Cli" + ($(if ($Force) { ' (re-add)' } else { '' }))
+        if ($PSCmdlet.ShouldProcess($Cli, $pscAction)) {
+            try {
+                Import-Module PSCompletions -ErrorAction Stop
+                # `psc add` doesn't expose a -Force switch; re-running it
+                # against an already-added CLI is a benign no-op, so a
+                # single unconditional call covers both Force and no-Force
+                # semantics for the PSCompletions side. The sentinel
+                # block in the profile still respects -Force for replace
+                # vs preserve.
+                & psc add $Cli 2>$null | Out-Null
+            } catch {
+                Write-Warning "psc add $Cli failed: $($_.Exception.Message)"
+            }
+        }
+    }
+
+    $content = Read-CompletionProfileContent -Path $target
+    $ver     = $script:CompletionSentinelVersion
+    $pattern = "(?ms)^\# ScoopBucket:CliCompletion:$([regex]::Escape($Cli))`:BEGIN \w+"
+    $existed = [regex]::IsMatch($content, $pattern)
+    if ($existed -and -not $Force) {
+        return [pscustomobject]@{
+            Cli = $Cli; Source = $resolved.Source; Action = 'Preserved'
+            ProfilePath = $target; Reason = 'Existing block preserved; pass -Force to overwrite.'
+        }
+    }
+
+    $shouldProcessAction = if ($existed) { "Replace completion block for '$Cli' ($($resolved.Source))" }
+                           else         { "Add completion block for '$Cli' ($($resolved.Source))" }
+    if (-not $PSCmdlet.ShouldProcess($target, $shouldProcessAction)) {
+        return [pscustomobject]@{
+            Cli = $Cli; Source = $resolved.Source; Action = 'WhatIf'
+            ProfilePath = $target; Reason = '-WhatIf or -Confirm declined.'
+        }
+    }
+
+    $newContent = Set-CompletionProfileBlock -Content $content -Cli $Cli -Block $resolved.Code -Force:$true
+    # Atomic write: temp file + Move-Item ensures we never leave the
+    # profile half-written on failure.
+    $tmp = "$target.tmp"
+    [System.IO.File]::WriteAllText($tmp, $newContent, [System.Text.UTF8Encoding]::new($false))
+    Move-Item -Path $tmp -Destination $target -Force
+
+    return [pscustomobject]@{
+        Cli = $Cli; Source = $resolved.Source
+        Action = $(if ($existed) { 'Replaced' } else { 'Added' })
+        ProfilePath = $target; Reason = $null
+    }
+}
+
+function Install-PSCompletionsModule {
+    <#
+    .SYNOPSIS
+        Idempotently ensure the PSCompletions PowerShell module is installed
+        at AllUsers scope. Skip if already present.
+    .PARAMETER Force
+        Pass -Force to Install-Module for an unconditional refresh.
+    #>
+    [CmdletBinding(SupportsShouldProcess, ConfirmImpact = 'Medium')]
+    param([switch]$Force)
+
+    if (-not $Force -and (Get-Module -ListAvailable -Name PSCompletions)) {
+        Write-Verbose 'PSCompletions module already installed; skipping.'
+        return
+    }
+    if ($PSCmdlet.ShouldProcess('PSCompletions module', "Install-Module -Scope AllUsers$(if ($Force) { ' -Force' })")) {
+        try {
+            $params = @{ Name = 'PSCompletions'; Scope = 'AllUsers'; AllowClobber = $true; ErrorAction = 'Stop' }
+            if ($Force) { $params['Force'] = $true }
+            Install-Module @params
+        } catch {
+            Write-Warning "Install-Module PSCompletions failed: $($_.Exception.Message). PSCompletions fallback will be unavailable."
+        }
+    }
+}
+
+function Register-AllCliCompletions {
+    <#
+    .SYNOPSIS
+        Enumerate every CLI on the machine (Get-Command -CommandType Application,
+        de-duped by base name) and call Register-CliCompletion for each.
+    .DESCRIPTION
+        Idempotent. Default behaviour: only register CLIs that don't already
+        have a profile block. Pass -Force to overwrite existing blocks.
+        Returns the per-CLI result objects for the summary table.
+    .PARAMETER Force
+        Forwarded to Register-CliCompletion. Default $false (no -Force flag).
+    .PARAMETER ProfilePath
+        Test hook for Pester: redirect writes to a sandbox file.
+    .PARAMETER Names
+        Test hook: bypass Get-Command enumeration and use this list instead.
+    #>
+    [CmdletBinding(SupportsShouldProcess, ConfirmImpact = 'Medium')]
+    [OutputType([pscustomobject[]])]
+    param(
+        [switch]$Force,
+        [string]$ProfilePath,
+        [string[]]$Names
+    )
+
+    if (-not $Names) {
+        $Names = Get-Command -CommandType Application -ErrorAction SilentlyContinue |
+            Select-Object -ExpandProperty Name -Unique |
+            ForEach-Object { [System.IO.Path]::GetFileNameWithoutExtension($_) } |
+            Sort-Object -Unique
+    }
+
+    $results = foreach ($n in $Names) {
+        # Forward both Force and the parent's ShouldProcess preferences so
+        # -WhatIf / -Confirm propagate through.
+        Register-CliCompletion -Cli $n -Force:$Force -ProfilePath $ProfilePath `
+            -WhatIf:$WhatIfPreference -Confirm:$false
+    }
+
+    # Summary
+    $byAction = $results | Group-Object Action | ForEach-Object { "$($_.Name)=$($_.Count)" }
+    Write-Host "Completion registration summary: $($byAction -join ', ')"
+    return @($results)
+}


### PR DESCRIPTION
Adds an idempotent, admin-gated PowerShell tab-completion registration system for installed CLI tools.

## What

- `Utils.ps1`  new helpers (`Register-CliCompletion`, `Register-AllCliCompletions`, `Install-PSCompletionsModule`, `Set-CompletionProfileBlock`, `Resolve-CliCompletionSource`, `Get-CompletionProfilePath`, `Test-IsElevated`). Curated native-completion map: `gh`, `rg`, `bw`, `docker`, `copilot`, `gcloud`. PSCompletions (`abgox/PSCompletions`) as fallback. Skipped + reasoned when neither applies. Every state-changing op opts in to `SupportsShouldProcess` with `ConfirmImpact='Medium'`; atomic writes; byte-identical idempotency.
- **New bundle** `Completions.ps1` + `CliCompletions.json`  retroactive machine-wide scan. Exposes the `register-all-cli-completions` shim.
- **Bundle wiring**  `AIAgents.ps1`, `ClientBasePackages.ps1`, `DeveloperBasePackages.ps1` call `Register-AllCliCompletions -Force` after their installs (try/catch so non-elevated reinstalls still succeed). Patch-segment manifest bumps on those three.
- **Pester coverage**  Set-CompletionProfileBlock + Register-CliCompletion in `Utils.Tests.ps1`; `CliCompletions.Tests.ps1` (manifest + bundle script in sandbox profile); `CompletionPinned.Tests.ps1` (curated map locked); opt-in `CompletionIdempotency.Tests.ps1` (byte-identical 2 runs, preservation, `-WhatIf`).
- **CI**  two new enforcing steps in `validate-installs.yml`.
- **Docs**  new `CLI tab-completion registration` section in README.

## Semantics

- Resolution order: curated native command  PSCompletions  skipped (with reason).
- Sentinel blocks `# ScoopBucket:CliCompletion:<cli>:BEGIN v1`  `:END` written to `\C:\Users\Mark\OneDrive - IntelliTect\Documents\PowerShell\Microsoft.PowerShell_profile.ps1.AllUsersAllHosts`.
- `-Force` defaults to `\False` (PowerShell convention). Bundle installers pass `-Force` explicitly. End-user `register-all-cli-completions` defaults to gap-fill only.
- `\C:\Users\Mark\OneDrive - IntelliTect\Documents\PowerShell\Microsoft.PowerShell_profile.ps1.AllUsersAllHosts` requires admin  non-elevated bundle installs warn and continue.

## Notes

Only the 3 bundles whose `.ps1` files actually changed get patch bumps; the Utils.ps1 helper additions are treated as a non-breaking library extension. If the project prefers a full sweep of every manifest dot-sourcing Utils.ps1, happy to follow up.

Local: 19/19 new completion tests pass + 9/9 new helper tests in Utils.Tests.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>