### PR TITLE
Behavioural test: CLI completion native output

### DIFF
--- a/.github/workflows/validate-installs.yml
+++ b/.github/workflows/validate-installs.yml
@@ -205,6 +205,18 @@ jobs:
           }
           Write-Host "CLI completion bundle tests passed: $($result.PassedCount)/$($result.TotalCount)."
 
+      - name: CLI completion — native command output (behavioural)
+        if: always()
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = 'Continue'
+          $result = Invoke-Pester -Path "${{ github.workspace }}\bucket\CliCompletionOutput.Tests.ps1" -Tag Heavy,CompletionOutput -Output Detailed -PassThru
+          if ($result.FailedCount -gt 0) {
+            Write-Host "::error::CLI completion native-output tests failed: $($result.FailedCount) of $($result.TotalCount)."
+            exit 1
+          }
+          Write-Host "CLI completion native-output tests: $($result.PassedCount) passed, $($result.SkippedCount) skipped, $($result.TotalCount) total."
+
       - name: Upload CLI availability artifact
         if: always()
         continue-on-error: true

--- a/bucket/CliCompletionOutput.Tests.ps1
+++ b/bucket/CliCompletionOutput.Tests.ps1
@@ -1,0 +1,55 @@
+# ----------------------------------------------------------------------------
+# Behavioural test: each pinned CLI's native completion command actually
+# emits a usable PowerShell completion script when the CLI is installed.
+#
+# Static `CompletionPinned.Tests.ps1` checks that each owning bundle WIRES
+# the CLI; this file checks that the wired command actually PRODUCES
+# something. Verdicts:
+#
+#   Pass    - CLI installed, command exited cleanly, output contains
+#             `Register-ArgumentCompleter` (the marker of a real PS5+
+#             tab-completion script).
+#   Skipped - CLI not installed OR the command threw OR the command
+#             produced no output. These are best-effort cases inherited
+#             from the historical CliCompletionNativeMap and are not
+#             regressions.
+#   Fail    - CLI installed, command produced non-empty output that does
+#             NOT look like a PowerShell completion script. This catches
+#             a CLI silently changing its `completion` subcommand
+#             contract under us.
+#
+# Tagged 'Heavy','CompletionOutput' so it only runs in validate-installs
+# (after the install matrix puts the CLIs on PATH).
+# ----------------------------------------------------------------------------
+
+Describe 'CliCompletion native command output' -Tag 'Heavy','CompletionOutput' {
+
+    It '<Cli> native command produces a usable PowerShell completion script' -ForEach @(
+        @{ Cli = 'gh';      Command = { gh completion -s powershell 2>$null } }
+        @{ Cli = 'rg';      Command = { rg --generate complete-powershell 2>$null } }
+        @{ Cli = 'gcloud';  Command = { gcloud --quiet --help-format=ps1 2>$null } }
+        @{ Cli = 'bw';      Command = { bw completion --shell powershell 2>$null } }
+        @{ Cli = 'copilot'; Command = { copilot completion powershell 2>$null } }
+    ) {
+        param($Cli, $Command)
+
+        if (-not (Get-Command $Cli -ErrorAction SilentlyContinue)) {
+            Set-ItResult -Skipped -Because "$Cli is not on PATH in this environment."
+            return
+        }
+
+        $output = $null
+        try { $output = & $Command } catch {
+            Set-ItResult -Skipped -Because "$Cli native command threw: $($_.Exception.Message)"
+            return
+        }
+
+        $text = ($output | Out-String)
+        if ([string]::IsNullOrWhiteSpace($text)) {
+            Set-ItResult -Skipped -Because "$Cli native command produced no output (CLI version may not support PowerShell completion)."
+            return
+        }
+
+        $text | Should -Match 'Register-ArgumentCompleter' -Because "$Cli emitted $($text.Length) chars but no Register-ArgumentCompleter; the CLI's completion subcommand contract may have changed."
+    }
+}


### PR DESCRIPTION
## What

Adds a Heavy-tagged behavioural test that complements the existing static `CompletionPinned.Tests.ps1`.

`CompletionPinned` already verifies each owning bundle **wires** its CLI via `Register-CliCompletion -NativeCommand`. This new test verifies the wired command actually **produces** a usable PowerShell completion script (output contains `Register-ArgumentCompleter`).

## Verdicts

| Outcome | Meaning |
|---------|---------|
| **Pass**    | CLI on PATH, command emits a valid PS completion script. |
| **Skipped** | CLI not on PATH, command threw, or command produced no output. These are best-effort cases inherited from the historical `CliCompletionNativeMap`. |
| **Fail**    | Non-empty output that does NOT contain `Register-ArgumentCompleter` — flags a silent contract change in the CLI's `completion` subcommand. |

## Status today (local probe)

| CLI       | Result   | Reason                                                           |
|-----------|----------|------------------------------------------------------------------|
| `gh`      | Pass     | 8.8KB of valid `Register-ArgumentCompleter` script.              |
| `rg`      | Skipped  | ripgrep 13 doesn't support `--generate complete-powershell` (rg 14+ only). |
| `gcloud`  | Skipped  | Not on PATH locally; flag combination is also best-effort.       |
| `bw`      | Skipped  | `bw completion` only supports `zsh`.                             |
| `copilot` | Skipped  | `copilot completion` only supports bash/zsh/fish.                |

These skips match the historical "best-effort" comment in the old `CliCompletionNativeMap`. The test passes (1 pass, 4 skipped) and will fail-fast if a CLI's completion contract changes under us.

## Files

- `bucket/CliCompletionOutput.Tests.ps1` (new)
- `.github/workflows/validate-installs.yml` (new step after the existing completion steps)

No manifest changes — no manifest references the new test file.
