### PR TITLE
Escape embedded single quotes in package-name Tab completions

### DIFF
--- a/bucket/PackageNameCompletion.Tests.ps1
+++ b/bucket/PackageNameCompletion.Tests.ps1
@@ -67,4 +67,37 @@ Describe 'Install-Package / Get-Package -Name argument completer' -Tag 'Light' {
             $m.CompletionText | Should -Match "^'.*'$"
         }
     }
+
+    It "doubles embedded single quotes so apostrophe names parse" {
+        # The completer runs through the bucket index and we don't
+        # ship any apostrophe names today, so exercise the registered
+        # scriptblock directly with a synthetic suggester to prove the
+        # escaping logic itself.
+        $sb = (Get-Command Register-ArgumentCompleter -ErrorAction Ignore)
+        $module = Get-Module MarkMichaelis.ScoopBucket
+        $module | Should -Not -BeNullOrEmpty
+
+        # Pull the registered completer's scriptblock and invoke it with
+        # a synthetic name list via a temporary override of
+        # Get-PackageNameSuggestion in module scope.
+        $result = & $module {
+            $original = Get-Item Function:\Get-PackageNameSuggestion -ErrorAction Ignore
+            try {
+                Set-Item Function:\Get-PackageNameSuggestion -Value { param($WordToComplete) "O'Reilly Books" }
+                $line = "Install-Package -Name oreilly"
+                TabExpansion2 -inputScript $line -cursorColumn $line.Length
+            } finally {
+                if ($original) {
+                    Set-Item Function:\Get-PackageNameSuggestion -Value $original.ScriptBlock
+                }
+            }
+        }
+        $texts = $result.CompletionMatches.CompletionText
+        $texts | Should -Contain "'O''Reilly Books'"
+        # And the suggestion must actually parse as a single string
+        # token — round-trip via Invoke-Expression.
+        foreach ($t in $texts) {
+            { Invoke-Expression "`$null = $t" } | Should -Not -Throw
+        }
+    }
 }

--- a/module/MarkMichaelis.ScoopBucket/Private/Register-PackageNameCompleter.ps1
+++ b/module/MarkMichaelis.ScoopBucket/Private/Register-PackageNameCompleter.ps1
@@ -23,10 +23,15 @@ function Register-PackageNameCompleter {
             return
         }
         foreach ($name in $suggestions) {
-            # Quote names that contain whitespace so PowerShell parses
-            # them as a single argument.
-            if ($name -match '\s') {
-                $completionText = "'$name'"
+            # Quote names that contain whitespace (or apostrophes) so
+            # PowerShell parses them as a single argument. Inside a
+            # single-quoted string, an embedded `'` must be escaped as
+            # `''` per the PowerShell language spec — without that,
+            # completing a name like O'Reilly produces a parse error
+            # the moment the user accepts the suggestion.
+            if ($name -match "[\s']") {
+                $escaped = $name -replace "'", "''"
+                $completionText = "'$escaped'"
             } else {
                 $completionText = $name
             }


### PR DESCRIPTION
Code review of the recent completion work caught a latent bug: when the argument completer wraps a name with whitespace in single quotes to form a single PowerShell argument, an embedded apostrophe (a hypothetical 'O''Reilly Books' package) would emit invalid syntax ('O'Reilly Books') and produce a parser error the moment the user accepts the suggestion.

**Fix** doubles embedded single quotes per the PowerShell language spec, and also quotes any name containing an apostrophe (not just whitespace).

**Test** added to ucket/PackageNameCompletion.Tests.ps1 exercises the registered scriptblock with a synthetic `Get-PackageNameSuggestion` override that returns an apostrophe name, asserts the doubled-quote output, and round-trips the result through `Invoke-Expression` to prove it parses.

Light Pester suite locally: **87 passed / 0 failed / 2 environment-skips**.

No package currently ships with an apostrophe in its `Name`, but the fix is essentially free.