### PR TITLE
Relocate CI test artifacts to $env:TEMP\ScoopBucket\

### DIFF
--- a/.github/scripts/Get-PackageCommands.ps1
+++ b/.github/scripts/Get-PackageCommands.ps1
@@ -19,12 +19,14 @@
 
     For each (Source, PackageId, ExpectedCli) tuple, `Get-Command` is used
     to determine whether the CLI is currently on PATH on this machine.
-    Results are written to `cli-availability.json` in the repo root,
-    printed as a Markdown table to stdout, and appended to the
-    `GITHUB_STEP_SUMMARY` file when that env var is set.
+    Results are written via the module's `Save-Artifact` helper to
+    `$env:TEMP\ScoopBucket\cli-availability\latest.json` (plus a
+    rotating timestamped snapshot), printed as a Markdown table to
+    stdout, and appended to the `GITHUB_STEP_SUMMARY` file when that
+    env var is set.
 
     The script is idempotent and has no side effects beyond writing
-    `cli-availability.json` (gitignored). It returns the array of records
+    into the temp artifact directory. It returns the array of records
     so callers (e.g. the Pester scaffold) can inspect them.
 
 .PARAMETER BucketPath
@@ -32,8 +34,12 @@
     Defaults to the bucket directory of the repo this script lives in.
 
 .PARAMETER OutputJson
-    Path for the JSON artifact. Defaults to `cli-availability.json` at
-    the repo root.
+    Optional explicit path for the JSON artifact. When omitted the
+    script routes through the module's `Save-Artifact` helper, which
+    writes a rotating snapshot plus stable `latest.json` under
+    `$env:TEMP\ScoopBucket\cli-availability\` (keeps 5 newest, prunes
+    anything older than 1 day). Pass `-OutputJson <path>` only if you
+    need the file at a specific location (e.g. ad-hoc debugging).
 
 .PARAMETER Quiet
     If set, suppress the Markdown table written to stdout. The JSON file
@@ -54,7 +60,11 @@ $ErrorActionPreference = 'Stop'
 
 $repoRoot = Split-Path -Parent (Split-Path -Parent $PSScriptRoot)
 if (-not $BucketPath)  { $BucketPath  = Join-Path $repoRoot 'bucket' }
-if (-not $OutputJson)  { $OutputJson  = Join-Path $repoRoot 'cli-availability.json' }
+
+# Make Save-Artifact (and the rest of the module) available regardless of
+# whether the declarative Get-Package path below succeeds.
+$modulePath = Join-Path $repoRoot 'module\MarkMichaelis.ScoopBucket\MarkMichaelis.ScoopBucket.psd1'
+Import-Module $modulePath -Force -ErrorAction Stop
 
 # ---------------------------------------------------------------------------
 # Override map: package identifier -> expected short CLI name (or $null when
@@ -472,8 +482,15 @@ foreach ($file in $bundleScripts) {
 # Sort for stable output.
 $sorted = @($records | Sort-Object Source, Package, SourceScript)
 
-# Persist JSON artifact (overwrite each run).
-$sorted | ConvertTo-Json -Depth 5 | Set-Content -Path $OutputJson -Encoding UTF8
+# Persist JSON artifact. When -OutputJson is passed explicitly we honour
+# that path (back-compat for ad-hoc callers); otherwise route through
+# Save-Artifact so the file lands in $env:TEMP\ScoopBucket\cli-availability\
+# with rotation (5 newest, <1 day) and a stable latest.json.
+if ($OutputJson) {
+    $sorted | ConvertTo-Json -Depth 5 | Set-Content -Path $OutputJson -Encoding UTF8
+} else {
+    $null = Save-Artifact -Kind 'cli-availability' -Data $sorted -Depth 5
+}
 
 # Build Markdown table.
 $considered      = @($sorted | Where-Object { $_.ExpectedCli })

--- a/.github/scripts/Test-Installs.ps1
+++ b/.github/scripts/Test-Installs.ps1
@@ -673,6 +673,12 @@ $repoRoot = if ($env:GITHUB_WORKSPACE) { $env:GITHUB_WORKSPACE } `
             else { Split-Path (Split-Path $PSScriptRoot -Parent) -Parent }
 $bucketPath = Join-Path $repoRoot 'bucket'
 
+# Ensure Save-Artifact is available for the results-writing steps below
+# (the declarative Get-Package import above is inside a try/catch, so we
+# also import unconditionally here).
+$modulePath = Join-Path $repoRoot 'module\MarkMichaelis.ScoopBucket\MarkMichaelis.ScoopBucket.psd1'
+Import-Module $modulePath -Force -ErrorAction Stop
+
 if (-not (Test-Path $bucketPath)) {
     Write-Error "Bucket directory not found at: $bucketPath"
     exit 1
@@ -945,9 +951,10 @@ $total    = $script:Results.Count
 
 Write-Host "Total: $total | Passed: $passed | Failed: $failed | Untested: $untested"
 
-# Write JSON results file
-$resultsPath = Join-Path $repoRoot 'test-results.json'
-$script:Results | ConvertTo-Json -Depth 5 | Set-Content -Path $resultsPath -Encoding UTF8
+# Write JSON results file via the module's Save-Artifact helper
+# (rotating snapshot + stable latest.json under
+# $env:TEMP\ScoopBucket\test-results\).
+$resultsPath = Save-Artifact -Kind 'test-results' -Data $script:Results -Depth 5
 Write-Host "Results written to: $resultsPath"
 
 # Set output for downstream steps
@@ -1016,10 +1023,13 @@ if ($failed -gt 0) {
     # cancelled mid-run.  The try block starts just before the install loop.
     # ========================================================================
     Write-Host "`n========== Writing partial results (finally block) ==========" -ForegroundColor Yellow
-    $partialPath = Join-Path $repoRoot 'test-results.json'
-    if ($script:Results.Count -gt 0 -and -not (Test-Path $partialPath)) {
-        $script:Results | ConvertTo-Json -Depth 5 | Set-Content -Path $partialPath -Encoding UTF8
-        Write-Host "Partial results written to: $partialPath"
+    if ($script:Results.Count -gt 0) {
+        try {
+            $partialPath = Save-Artifact -Kind 'test-results' -Data $script:Results -Depth 5
+            Write-Host "Partial results written to: $partialPath"
+        } catch {
+            Write-Warning "Save-Artifact failed in finally block: $($_.Exception.Message)"
+        }
     }
     if ($env:GITHUB_OUTPUT -and -not (Select-String -Path $env:GITHUB_OUTPUT -Pattern 'has_failures' -Quiet -ErrorAction SilentlyContinue)) {
         $anyFail = @($script:Results | Where-Object Status -eq 'fail').Count -gt 0

--- a/.github/workflows/validate-installs.yml
+++ b/.github/workflows/validate-installs.yml
@@ -57,6 +57,19 @@ jobs:
           fetch-depth: 0
           ref: ${{ github.ref }}
 
+      - name: Resolve artifact paths
+        shell: pwsh
+        run: |
+          # All CI test artifacts land under $env:TEMP\ScoopBucket\<kind>\
+          # (managed by the module's Save-Artifact helper: rotates 5
+          # newest snapshots and prunes anything older than 1 day).
+          # Export the root so downstream steps can read latest.json and
+          # so upload-artifact can reference an absolute path.
+          $artifactDir = Join-Path $env:TEMP 'ScoopBucket'
+          New-Item -ItemType Directory -Path $artifactDir -Force | Out-Null
+          "ARTIFACT_DIR=$artifactDir" | Out-File -FilePath $env:GITHUB_ENV -Append -Encoding utf8
+          Write-Host "Artifact dir: $artifactDir"
+
       - name: Accept winget source agreements
         shell: pwsh
         run: |
@@ -127,9 +140,10 @@ jobs:
         shell: pwsh
         run: |
           $ErrorActionPreference = 'Continue'
-          $results = & "${{ github.workspace }}\.github\scripts\Get-PackageCommands.ps1" -Quiet
-          if ($null -eq $results) { $results = @() }
-          $results | ConvertTo-Json -Depth 6 | Set-Content -Path "${{ github.workspace }}\cli-availability.json" -Encoding UTF8
+          # Get-PackageCommands.ps1 now self-writes via Save-Artifact to
+          # $env:TEMP\ScoopBucket\cli-availability\latest.json (plus
+          # rotating timestamped snapshots).
+          & "${{ github.workspace }}\.github\scripts\Get-PackageCommands.ps1" -Quiet | Out-Null
           # Run the Pester scaffold (also non-failing).
           Invoke-Pester -Path "${{ github.workspace }}\bucket\PackageCommands.Tests.ps1" -Tag Heavy -Output Detailed -PassThru | Out-Null
 
@@ -138,7 +152,7 @@ jobs:
         continue-on-error: true
         shell: pwsh
         run: |
-          $jsonPath = "${{ github.workspace }}\cli-availability.json"
+          $jsonPath = Join-Path $env:ARTIFACT_DIR 'cli-availability\latest.json'
           if (-not (Test-Path $jsonPath)) {
             "## CLI availability discovery`n`n_No results produced._" | Out-File -FilePath $env:GITHUB_STEP_SUMMARY -Append -Encoding utf8
             return
@@ -223,7 +237,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: cli-availability
-          path: cli-availability.json
+          path: ${{ env.ARTIFACT_DIR }}/cli-availability/latest.json
           retention-days: 30
 
       - name: Ensure issue labels exist
@@ -242,7 +256,7 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          $results = Get-Content "${{ github.workspace }}\test-results.json" | ConvertFrom-Json
+          $results = Get-Content (Join-Path $env:ARTIFACT_DIR 'test-results\latest.json') | ConvertFrom-Json
           $failures = $results | Where-Object { $_.Status -eq 'fail' }
           $runUrl = "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
 
@@ -345,5 +359,5 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: install-validation-results
-          path: test-results.json
+          path: ${{ env.ARTIFACT_DIR }}/test-results/latest.json
           retention-days: 30

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,0 @@
-cli-availability.json

--- a/README.md
+++ b/README.md
@@ -239,12 +239,18 @@ See #45 for the tracking issue. Rolling out in three phases:
 - **Phase 1 — Local discovery.** A `Get-PackageCommands.ps1` helper
   parses every `bucket\*.ps1` for winget / scoop / choco / module
   install patterns, derives a probable CLI short name per package, runs
-  `Get-Command` against it, and writes `cli-availability.json`.
+  `Get-Command` against it, and persists the result via the module's
+  `Save-Artifact` helper to `$env:TEMP\ScoopBucket\cli-availability\`
+  (a rotating snapshot plus a stable `latest.json`; the helper keeps
+  the 5 newest snapshots and prunes anything older than 1 day, so
+  local diagnostic runs never accumulate in the working tree).
 - **Phase 2 — CI integration.** A Pester `Heavy`-tagged test
   (`bucket\PackageCommands.Tests.ps1`) runs the discovery script after
-  the validate-installs job, uploads `cli-availability.json` as an
-  artifact, and posts a Markdown summary to `GITHUB_STEP_SUMMARY`. The
-  test does **not** fail the build at this phase — it only reports.
+  the validate-installs job, uploads
+  `$env:TEMP\ScoopBucket\cli-availability\latest.json` as the
+  `cli-availability` workflow artifact, and posts a Markdown summary
+  to `GITHUB_STEP_SUMMARY`. The test does **not** fail the build at
+  this phase — it only reports.
 - **Phase 3 — Enforcement.** The test asserts availability for an
   explicit allow-list of "must-have CLI" packages (those covered by the
   rule above). Packages with non-obvious CLI names register themselves

--- a/bucket/Save-Artifact.Tests.ps1
+++ b/bucket/Save-Artifact.Tests.ps1
@@ -1,0 +1,92 @@
+<#
+.SYNOPSIS
+    Light-suite tests for MarkMichaelis.ScoopBucket\Save-Artifact.
+
+.DESCRIPTION
+    Verifies the artifact-rotation contract used by CI diagnostic
+    producers (Get-PackageCommands.ps1, Test-Installs.ps1):
+
+      - writes a timestamped file plus stable latest.json
+      - keeps at most 5 newest timestamped files per kind directory
+      - prunes timestamped files whose LastWriteTime is older than 1 day
+      - never prunes latest.json even when backdated
+#>
+
+BeforeAll {
+    $script:repoRoot = Split-Path -Parent $PSScriptRoot
+    $script:psd1     = Join-Path $script:repoRoot 'module\MarkMichaelis.ScoopBucket\MarkMichaelis.ScoopBucket.psd1'
+    Import-Module $script:psd1 -Force -ErrorAction Stop
+}
+
+Describe 'Save-Artifact' -Tag 'Light', 'Module' {
+
+    BeforeEach {
+        $script:root     = Join-Path $TestDrive ([guid]::NewGuid().Guid)
+        $script:kindDir  = Join-Path (Join-Path $script:root 'ScoopBucket') 'unit-test'
+    }
+
+    It 'writes a timestamped file and latest.json and returns the timestamped path' {
+        $payload = [pscustomobject]@{ a = 1; b = 'two' }
+        $path = Save-Artifact -Kind 'unit-test' -Data $payload -Root $script:root
+
+        $path                   | Should -Match 'unit-test-\d{8}-\d{6}'
+        Test-Path -LiteralPath $path | Should -BeTrue
+
+        $latest = Join-Path $script:kindDir 'latest.json'
+        Test-Path -LiteralPath $latest | Should -BeTrue
+
+        $stampedContent = (Get-Content -LiteralPath $path -Raw | ConvertFrom-Json)
+        $latestContent  = (Get-Content -LiteralPath $latest -Raw | ConvertFrom-Json)
+        $stampedContent.a | Should -Be 1
+        $latestContent.b  | Should -Be 'two'
+    }
+
+    It 'overwrites latest.json with the most recent payload' {
+        $null = Save-Artifact -Kind 'unit-test' -Data @{ which = 'first' }  -Root $script:root
+        Start-Sleep -Milliseconds 1100  # ensure distinct second-resolution stamp
+        $null = Save-Artifact -Kind 'unit-test' -Data @{ which = 'second' } -Root $script:root
+
+        $latest = Get-Content -LiteralPath (Join-Path $script:kindDir 'latest.json') -Raw | ConvertFrom-Json
+        $latest.which | Should -Be 'second'
+    }
+
+    It 'keeps at most 5 timestamped files after 6+ writes' {
+        for ($i = 1; $i -le 7; $i++) {
+            $null = Save-Artifact -Kind 'unit-test' -Data @{ i = $i } -Root $script:root
+            Start-Sleep -Milliseconds 1100  # distinct UTC-second stamps
+        }
+
+        $stamped = Get-ChildItem -LiteralPath $script:kindDir -Filter 'unit-test-*.json' -File
+        $stamped.Count | Should -Be 5
+
+        # latest.json is still there alongside the 5 stamped files.
+        Test-Path -LiteralPath (Join-Path $script:kindDir 'latest.json') | Should -BeTrue
+    }
+
+    It 'prunes timestamped files older than 1 day even when fewer than 5 exist' {
+        $null = Save-Artifact -Kind 'unit-test' -Data @{ keep = $true } -Root $script:root
+
+        # Plant a "fossil" timestamped file 2 days old, then take a second
+        # snapshot (which triggers the prune pass).
+        $fossil = Join-Path $script:kindDir 'unit-test-19990101-000000.json'
+        Set-Content -LiteralPath $fossil -Value '{"fossil":true}' -Encoding UTF8
+        $twoDaysAgoUtc = [DateTime]::UtcNow.AddDays(-2)
+        (Get-Item -LiteralPath $fossil).LastWriteTimeUtc = $twoDaysAgoUtc
+
+        $null = Save-Artifact -Kind 'unit-test' -Data @{ trigger = 'prune' } -Root $script:root
+
+        Test-Path -LiteralPath $fossil | Should -BeFalse
+    }
+
+    It 'never prunes latest.json even when its LastWriteTime is backdated' {
+        $null = Save-Artifact -Kind 'unit-test' -Data @{ marker = 'original' } -Root $script:root
+        $latest = Join-Path $script:kindDir 'latest.json'
+        (Get-Item -LiteralPath $latest).LastWriteTimeUtc = [DateTime]::UtcNow.AddDays(-30)
+
+        # Subsequent writes overwrite latest.json with fresh content + mtime;
+        # the file itself must still exist.
+        $null = Save-Artifact -Kind 'unit-test' -Data @{ marker = 'fresh' } -Root $script:root
+        Test-Path -LiteralPath $latest | Should -BeTrue
+        (Get-Content -LiteralPath $latest -Raw | ConvertFrom-Json).marker | Should -Be 'fresh'
+    }
+}

--- a/module/MarkMichaelis.ScoopBucket/MarkMichaelis.ScoopBucket.psd1
+++ b/module/MarkMichaelis.ScoopBucket/MarkMichaelis.ScoopBucket.psd1
@@ -9,7 +9,7 @@
 #
 @{
     RootModule        = 'MarkMichaelis.ScoopBucket.psm1'
-    ModuleVersion     = '1.0.0'
+    ModuleVersion     = '1.1.0'
     GUID              = 'b7e8a4c2-9f3d-4b76-8e6a-1c5d2f7b9e10'
     Author            = 'Mark Michaelis'
     CompanyName       = 'IntelliTect'
@@ -41,7 +41,8 @@
         'Register-CliCompletion',
         'Install-PSCompletionsModule',
         'Register-AllCliCompletions',
-        'Invoke-CliCompletionsSweep'
+        'Invoke-CliCompletionsSweep',
+        'Save-Artifact'
     )
     CmdletsToExport   = @()
     VariablesToExport = @()
@@ -52,7 +53,7 @@
             Tags         = @('Scoop', 'Winget', 'Chocolatey', 'PackageManagement', 'Install')
             LicenseUri   = 'https://github.com/MarkMichaelis/ScoopBucket/blob/main/LICENSE'
             ProjectUri   = 'https://github.com/MarkMichaelis/ScoopBucket'
-            ReleaseNotes = '1.0.0 — Module renamed from `ScoopBucket` to `MarkMichaelis.ScoopBucket` to namespace it against any future user-bucket modules and avoid collision with generic Scoop tooling. Public surface unchanged; bundle scripts now Import-Module MarkMichaelis.ScoopBucket. The console-waiting Beyond Compare shim is renamed from `bcompc` to `bcomp.com`.'
+            ReleaseNotes = '1.1.0 — Adds Save-Artifact for CI diagnostic producers. Persists rotating JSON snapshots under $env:TEMP\ScoopBucket\<Kind>\ with a stable latest.json; retains at most 5 newest stamped files per kind and prunes anything older than 1 day. Replaces the previous practice of writing cli-availability.json / test-results.json into the repo root. 1.0.0 — Module renamed from `ScoopBucket` to `MarkMichaelis.ScoopBucket` to namespace it against any future user-bucket modules and avoid collision with generic Scoop tooling. Public surface unchanged; bundle scripts now Import-Module MarkMichaelis.ScoopBucket. The console-waiting Beyond Compare shim is renamed from `bcompc` to `bcomp.com`.'
         }
     }
 }

--- a/module/MarkMichaelis.ScoopBucket/Public/Save-Artifact.ps1
+++ b/module/MarkMichaelis.ScoopBucket/Public/Save-Artifact.ps1
@@ -1,0 +1,126 @@
+function Save-Artifact {
+    <#
+    .SYNOPSIS
+        Persist a CI/test diagnostic artifact under
+        `<Root>\<RepoName>\<Kind>\` with rotation + age pruning.
+
+    .DESCRIPTION
+        Serializes `$Data` once to JSON and writes two files in the
+        kind directory:
+
+          - `<Kind>-<UTC yyyyMMdd-HHmmss>.json`  (rotating snapshot)
+          - `latest.json`                        (stable path; always
+                                                 overwritten with the
+                                                 most recent payload)
+
+        Then applies a retention policy to the directory:
+
+          1. Delete any timestamped file whose `LastWriteTime` is
+             older than 1 day.
+          2. Of the remaining timestamped files, keep only the 5
+             newest by `LastWriteTime`.
+          3. `latest.json` is exempt from both rules.
+
+        Producer scripts call this in place of writing diagnostic
+        JSON into the repo root, keeping the working tree clean and
+        bounding disk usage on busy dev boxes / runners.
+
+    .PARAMETER Kind
+        Logical artifact name (e.g. `cli-availability`,
+        `test-results`). Becomes a subdirectory and the timestamped
+        filename prefix.
+
+    .PARAMETER Data
+        Object to serialize via `ConvertTo-Json -Depth $Depth`. Pass
+        a single object (it will be wrapped if it isn't already an
+        array). `$null` is permitted and serializes to `null`.
+
+    .PARAMETER Depth
+        `ConvertTo-Json -Depth`. Defaults to 5; bump for nested
+        payloads (e.g. CLI-availability is 6).
+
+    .PARAMETER Root
+        Root directory under which `<RepoName>\<Kind>` lives.
+        Defaults to `$env:TEMP`.
+
+    .PARAMETER RepoName
+        Override the auto-detected repo name. Defaults to
+        `ScoopBucket`; producer scripts always have this constant.
+
+    .OUTPUTS
+        [string] The absolute path of the timestamped file.
+
+    .EXAMPLE
+        Save-Artifact -Kind 'cli-availability' -Data $results -Depth 6
+    #>
+    [CmdletBinding()]
+    [OutputType([string])]
+    param(
+        [Parameter(Mandatory)]
+        [ValidateNotNullOrEmpty()]
+        [string] $Kind,
+
+        [Parameter(Mandatory)]
+        [AllowNull()]
+        $Data,
+
+        [int] $Depth = 5,
+
+        [string] $Root,
+
+        [string] $RepoName = 'ScoopBucket'
+    )
+
+    if (-not $Root) { $Root = $env:TEMP }
+    if (-not $Root) {
+        throw "Save-Artifact: cannot resolve a writable root (\$env:TEMP is empty). Pass -Root explicitly."
+    }
+
+    $kindDir = Join-Path (Join-Path $Root $RepoName) $Kind
+    if (-not (Test-Path -LiteralPath $kindDir)) {
+        New-Item -ItemType Directory -Path $kindDir -Force | Out-Null
+    }
+
+    $stamp     = [DateTime]::UtcNow.ToString('yyyyMMdd-HHmmss')
+    $fileName  = "{0}-{1}.json" -f $Kind, $stamp
+    $stamped   = Join-Path $kindDir $fileName
+    $latest    = Join-Path $kindDir 'latest.json'
+
+    $json = $Data | ConvertTo-Json -Depth $Depth
+    if ($null -eq $json) { $json = 'null' }
+
+    # If a same-second invocation already wrote the timestamped file
+    # (rapid back-to-back calls in tests / tight loops), disambiguate
+    # with a short suffix. Retry until we land on a free path so two
+    # calls landing in the same UTC second can't overwrite each other.
+    if (Test-Path -LiteralPath $stamped) {
+        do {
+            $suffix   = '{0}-{1:x4}' -f [DateTime]::UtcNow.ToString('fff'), (Get-Random -Maximum 0x10000)
+            $fileName = "{0}-{1}-{2}.json" -f $Kind, $stamp, $suffix
+            $stamped  = Join-Path $kindDir $fileName
+        } while (Test-Path -LiteralPath $stamped)
+    }
+
+    Set-Content -LiteralPath $stamped -Value $json -Encoding UTF8
+    Set-Content -LiteralPath $latest  -Value $json -Encoding UTF8
+
+    # Retention: prune by age first, then cap by count. latest.json is
+    # always exempt — it's the stable reader contract.
+    $cutoff = [DateTime]::UtcNow.AddDays(-1)
+    $timestamped = Get-ChildItem -LiteralPath $kindDir -File -Filter "$Kind-*.json" -ErrorAction SilentlyContinue
+    foreach ($f in $timestamped) {
+        if ($f.LastWriteTimeUtc -lt $cutoff) {
+            Remove-Item -LiteralPath $f.FullName -Force -ErrorAction SilentlyContinue
+        }
+    }
+
+    $remaining = Get-ChildItem -LiteralPath $kindDir -File -Filter "$Kind-*.json" -ErrorAction SilentlyContinue |
+        Sort-Object LastWriteTimeUtc -Descending
+    if ($remaining.Count -gt 5) {
+        foreach ($f in $remaining[5..($remaining.Count - 1)]) {
+            Remove-Item -LiteralPath $f.FullName -Force -ErrorAction SilentlyContinue
+        }
+    }
+
+    return $stamped
+}


### PR DESCRIPTION
## Summary
Replace the practice of dropping `cli-availability.json` and `test-results.json` into the repo root with a new module helper `Save-Artifact` that persists rotating JSON snapshots under `\$env:TEMP\ScoopBucket\<Kind>\` with a stable `latest.json`.

## Retention policy (per kind directory)
1. Delete any timestamped file with `LastWriteTime` older than **1 day**.
2. Of the remaining timestamped files, keep at most **5 newest**.
3. `latest.json` is **exempt**  it's the stable read path for consumers.

## Changes
- **New:** `module/MarkMichaelis.ScoopBucket/Public/Save-Artifact.ps1` (and 5-case Pester suite in `bucket/Save-Artifact.Tests.ps1`).
- Module manifest bumps to **1.1.0** and exports `Save-Artifact`.
- `.github/scripts/Get-PackageCommands.ps1` and `Test-Installs.ps1` now route their JSON writes through `Save-Artifact`. Both also import the module unconditionally so the helper is reachable even when other module-loading paths fail.
- `.github/workflows/validate-installs.yml` gains a `Resolve artifact paths` step that exports `ARTIFACT_DIR=\$env:TEMP\ScoopBucket` to `\$GITHUB_ENV`; downstream readers and both `actions/upload-artifact` steps reference `\${{ env.ARTIFACT_DIR }}/<kind>/latest.json`.
- `.gitignore` (only entry was `cli-availability.json`) is removed.
- README updated to describe the new artifact location and retention policy.

## Verification
- `Invoke-Pester bucket\Save-Artifact.Tests.ps1`  5/0 passing.
- Full Light suite  **92 passed / 0 failed / 2 environment-skipped** (same skips as `main`).
- Hand-ran `Get-PackageCommands.ps1` 7 times in a row: kind dir holds exactly 5 stamped files + `latest.json`, repo root stays clean.

## Self-review fix
Code-review sub-agent flagged a same-millisecond collision in the disambiguation branch; replaced the static `-fff` suffix with a `Get-Random`-driven retry loop that probes `Test-Path` until it lands on a free path.