### PR TITLE
Switch BC difftool to BComp.com; add GitConfigVSCode bundle

### DIFF
--- a/bucket/GitConfigBeyondCompare.Tests.ps1
+++ b/bucket/GitConfigBeyondCompare.Tests.ps1
@@ -21,14 +21,37 @@ Describe "Install $name" -Tag 'Heavy', 'Install' {
         Test-ScoopPackageInstalled $name | Should -Be $true
     }
 
-    It 'configures the bc difftool when Beyond Compare is installed' {
+    It 'registers the bc difftool when Beyond Compare is installed' {
         . "$PSScriptRoot\GitConfigBeyondCompare.ps1" *>$null
         $bcDir = Resolve-BeyondCompareDir
         if (-not $bcDir) {
             Set-ItResult -Skipped -Because 'Beyond Compare not installed'
             return
         }
-        git config --global diff.tool | Should -Be 'bc'
+        # The bc tool config is always registered so `git difftool --tool=bc`
+        # works regardless of which tool is the global default (first-writer-
+        # wins for diff.tool/merge.tool, so install order is allowed to vary).
+        $bcPath = git config --global difftool.bc.path
+        $bcPath | Should -Not -BeNullOrEmpty
+    }
+
+    It 'targets BComp.com (console-waiting variant) for difftool/mergetool' {
+        . "$PSScriptRoot\GitConfigBeyondCompare.ps1" *>$null
+        $bcDir = Resolve-BeyondCompareDir
+        if (-not $bcDir) {
+            Set-ItResult -Skipped -Because 'Beyond Compare not installed'
+            return
+        }
+        if (-not (Test-Path (Join-Path $bcDir 'BComp.com'))) {
+            Set-ItResult -Skipped -Because 'BComp.com missing on this BC build; falling back to BComp.exe is expected'
+            return
+        }
+        # git difftool/mergetool need the wait-for-close wrapper; the GUI
+        # launcher BComp.exe returns immediately and breaks the workflow.
+        $diff  = git config --global difftool.bc.path
+        $merge = git config --global mergetool.bc.path
+        $diff  | Should -Match 'BComp\.com$'
+        $merge | Should -Match 'BComp\.com$'
     }
 
     It 'discovers a registry-recorded Beyond Compare install when present' {

--- a/bucket/GitConfigBeyondCompare.json
+++ b/bucket/GitConfigBeyondCompare.json
@@ -1,6 +1,6 @@
 {
     "$schema": "https://raw.githubusercontent.com/lukesampson/scoop/master/schema.json",
-    "version": "1.11.000",
+    "version": "1.11.001",
     "url": [
         "https://raw.githubusercontent.com/MarkMichaelis/ScoopBucket/master/bucket/GitConfigBeyondCompare.ps1"
     ],

--- a/bucket/GitConfigBeyondCompare.ps1
+++ b/bucket/GitConfigBeyondCompare.ps1
@@ -110,20 +110,46 @@ Function Resolve-BeyondCompareDir {
 Function Invoke-GitConfigBeyondCompare {
     $bcDir = Resolve-BeyondCompareDir
 
-    if ($bcDir -and (Get-Command git -ErrorAction Ignore)) {
-        git config --global diff.tool bc
-        git config --global difftool.bc.path "$bcDir\BComp.exe"
-        git config --global difftool.prompt false
-        git config --global merge.tool bc
-        git config --global mergetool.bc.path "$bcDir\BComp.exe"
-        git config --global mergetool.bc.trustexitcode true
-        git config --global mergetool.keepBackup false
-        git config --global mergetool.prompt false
-        git config --global alias.dt "difftool --dir-diff"
-        Write-Host "Beyond Compare configured for git diff/merge: $bcDir"
+    if (-not (Get-Command git -ErrorAction Ignore)) {
+        Write-Warning "git not found. Skipping Beyond Compare git configuration."
+        return
     }
-    else {
-        Write-Warning "Beyond Compare or git not found. Skipping configuration."
+    if (-not $bcDir) {
+        Write-Warning "Beyond Compare not found. Skipping git configuration."
+        return
     }
+
+    # Use BComp.com (console-waiting variant), not BComp.exe (GUI launcher
+    # which returns immediately). git difftool/mergetool need the caller to
+    # block until the compare window closes. See #14/#46.
+    $bcomp = Join-Path $bcDir 'BComp.com'
+    if (-not (Test-Path $bcomp)) {
+        # Older builds may only ship BComp.exe; fall back rather than fail.
+        $bcomp = Join-Path $bcDir 'BComp.exe'
+    }
+
+    # Always register the `bc` tool config so it's available on demand
+    # via `git difftool --tool=bc`, regardless of which tool is the default.
+    git config --global difftool.bc.path $bcomp
+    git config --global difftool.bc.trustExitCode true
+    git config --global difftool.prompt false
+    git config --global mergetool.bc.path $bcomp
+    git config --global mergetool.bc.trustExitCode true
+    git config --global mergetool.keepBackup false
+    git config --global mergetool.prompt false
+
+    # First-writer-wins for the global default so install order doesn't
+    # silently flip a deliberately-chosen tool. To switch defaults manually:
+    #   git config --global diff.tool <name>
+    #   git config --global merge.tool <name>
+    if (-not (git config --global --get diff.tool))  { git config --global diff.tool  bc }
+    if (-not (git config --global --get merge.tool)) { git config --global merge.tool bc }
+
+    # Aliases — `dt` honors the current default tool; `dtbc` always uses BC
+    # explicitly, so the user can invoke either without changing the default.
+    if (-not (git config --global --get alias.dt))   { git config --global alias.dt   'difftool --dir-diff' }
+    git config --global alias.dtbc 'difftool --tool=bc --dir-diff'
+
+    Write-Host "Beyond Compare configured for git diff/merge: $bcomp"
 }
 Invoke-GitConfigBeyondCompare

--- a/bucket/GitConfigVSCode.Tests.ps1
+++ b/bucket/GitConfigVSCode.Tests.ps1
@@ -1,0 +1,61 @@
+$scoopBucketPsd1 = Join-Path $PSScriptRoot '..\module\MarkMichaelis.ScoopBucket\MarkMichaelis.ScoopBucket.psd1'
+if (Test-Path $scoopBucketPsd1) { Import-Module $scoopBucketPsd1 -Force } else { Import-Module MarkMichaelis.ScoopBucket -Force }
+
+$sut  = (Split-Path -Leaf $PSCommandPath).Replace('.Tests.ps1', '')
+$name = $sut
+
+Describe "Install $name" -Tag 'Heavy', 'Install' {
+    BeforeAll {
+        if (Test-ScoopPackageInstalled $name) {
+            scoop uninstall $name
+        }
+    }
+
+    It 'installs from the local manifest' {
+        Install-LocalManifest "$PSScriptRoot\$name.json"
+        Test-ScoopPackageInstalled $name | Should -Be $true
+    }
+
+    It 'is idempotent on re-run' {
+        { Install-LocalManifest "$PSScriptRoot\$name.json" } | Should -Not -Throw
+        Test-ScoopPackageInstalled $name | Should -Be $true
+    }
+
+    It 'registers the vscode difftool when VS Code is installed' {
+        . "$PSScriptRoot\GitConfigVSCode.ps1" *>$null
+        $code = Resolve-VSCodeCommand
+        if (-not $code) {
+            Set-ItResult -Skipped -Because 'VS Code not installed on this runner'
+            return
+        }
+        $diffCmd  = git config --global difftool.vscode.cmd
+        $mergeCmd = git config --global mergetool.vscode.cmd
+        $diffCmd  | Should -Match '--wait'
+        $diffCmd  | Should -Match '--diff'
+        $mergeCmd | Should -Match '--wait'
+        $mergeCmd | Should -Match '--merge'
+    }
+
+    It 'adds an alias.dtv shortcut when VS Code is configured' {
+        . "$PSScriptRoot\GitConfigVSCode.ps1" *>$null
+        $code = Resolve-VSCodeCommand
+        if (-not $code) {
+            Set-ItResult -Skipped -Because 'VS Code not installed on this runner'
+            return
+        }
+        $alias = git config --global alias.dtv
+        $alias | Should -Match 'difftool .*--tool=vscode'
+    }
+}
+
+Describe "Behaviour $name (unit)" -Tag 'Light', 'Unit' {
+    It 'Resolve-VSCodeCommand returns a launcher path or $null without throwing' {
+        . "$PSScriptRoot\GitConfigVSCode.ps1" *>$null
+        { Resolve-VSCodeCommand } | Should -Not -Throw
+        # The launcher is either a bare command name or an existing file.
+        $r = Resolve-VSCodeCommand
+        if ($r) {
+            ($r -match '^[\w-]+$') -or (Test-Path $r) | Should -Be $true
+        }
+    }
+}

--- a/bucket/GitConfigVSCode.json
+++ b/bucket/GitConfigVSCode.json
@@ -1,0 +1,10 @@
+{
+    "$schema": "https://raw.githubusercontent.com/lukesampson/scoop/master/schema.json",
+    "version": "1.01.000",
+    "url": [
+        "https://raw.githubusercontent.com/MarkMichaelis/ScoopBucket/master/bucket/GitConfigVSCode.ps1"
+    ],
+    "installer": {
+        "script": "& \"$dir\\GitConfigVSCode.ps1\""
+    }
+}

--- a/bucket/GitConfigVSCode.ps1
+++ b/bucket/GitConfigVSCode.ps1
@@ -1,0 +1,74 @@
+
+$scoopBucketPsd1 = Join-Path $PSScriptRoot '..\module\MarkMichaelis.ScoopBucket\MarkMichaelis.ScoopBucket.psd1'
+if (Test-Path $scoopBucketPsd1) { Import-Module $scoopBucketPsd1 -Force } else { Import-Module MarkMichaelis.ScoopBucket -Force }
+
+
+Function Resolve-VSCodeCommand {
+    # Returns the command line git should use to launch VS Code as a diff /
+    # merge tool, or $null when VS Code isn't reachable. Probe order:
+    #   1. `code` on PATH (winget / chocolatey / Scoop System install)
+    #   2. `code-insiders` on PATH (insiders build only)
+    #   3. Default winget/Chocolatey install dirs under
+    #      %ProgramFiles%\Microsoft VS Code and
+    #      %LOCALAPPDATA%\Programs\Microsoft VS Code
+    # The returned value is the launcher to be quoted into a git `*.cmd`
+    # config string — typically just `code` so PATH resolution wins on every
+    # subsequent shell, but falls back to an absolute path when needed.
+    [CmdletBinding()]
+    param()
+    foreach ($name in 'code', 'code-insiders') {
+        $cmd = Get-Command $name -ErrorAction Ignore
+        if ($cmd) { return $name }
+    }
+    $candidates = @(
+        (Join-Path $env:ProgramFiles            'Microsoft VS Code\bin\code.cmd'),
+        (Join-Path ${env:ProgramFiles(x86)}     'Microsoft VS Code\bin\code.cmd'),
+        (Join-Path $env:LOCALAPPDATA            'Programs\Microsoft VS Code\bin\code.cmd')
+    )
+    foreach ($c in $candidates) {
+        if ($c -and (Test-Path $c)) { return $c }
+    }
+    return $null
+}
+
+Function Invoke-GitConfigVSCode {
+    if (-not (Get-Command git -ErrorAction Ignore)) {
+        Write-Warning "git not found. Skipping VS Code git configuration."
+        return
+    }
+    $code = Resolve-VSCodeCommand
+    if (-not $code) {
+        Write-Warning "VS Code (code / code-insiders) not found. Skipping git configuration."
+        return
+    }
+
+    # Quote the launcher so paths with spaces survive git's shell expansion.
+    # --wait is essential: git polls the caller's exit code, but `code` is a
+    # shim that returns immediately without --wait, breaking the workflow.
+    $launcher = if ($code -match '\s') { "`"$code`"" } else { $code }
+    $diffCmd  = "$launcher --wait --new-window --diff `"`$LOCAL`" `"`$REMOTE`""
+    $mergeCmd = "$launcher --wait --merge `"`$REMOTE`" `"`$LOCAL`" `"`$BASE`" `"`$MERGED`""
+
+    # Always register the `vscode` tool config so it's available on demand
+    # via `git difftool --tool=vscode`, regardless of which tool is default.
+    git config --global difftool.vscode.cmd          $diffCmd
+    git config --global difftool.vscode.trustExitCode true
+    git config --global mergetool.vscode.cmd         $mergeCmd
+    git config --global mergetool.vscode.trustExitCode true
+    git config --global mergetool.vscode.keepBackup  false
+
+    # First-writer-wins for the global default so install order doesn't
+    # silently flip a deliberately-chosen tool. To switch defaults manually:
+    #   git config --global diff.tool vscode
+    #   git config --global merge.tool vscode
+    if (-not (git config --global --get diff.tool))  { git config --global diff.tool  vscode }
+    if (-not (git config --global --get merge.tool)) { git config --global merge.tool vscode }
+
+    # Aliases — `dt` honors the current default; `dtv` always uses VS Code
+    # explicitly so the user can invoke either without changing the default.
+    if (-not (git config --global --get alias.dt))   { git config --global alias.dt 'difftool' }
+    git config --global alias.dtv 'difftool --tool=vscode'
+
+    Write-Host "VS Code configured for git diff/merge: $code"
+}
+Invoke-GitConfigVSCode

--- a/bucket/GitConfigure.json
+++ b/bucket/GitConfigure.json
@@ -1,8 +1,9 @@
 {
     "$schema": "https://raw.githubusercontent.com/lukesampson/scoop/master/schema.json",
-    "version": "1.21.000",
+    "version": "1.21.001",
     "url": [
         "https://raw.githubusercontent.com/MarkMichaelis/ScoopBucket/master/bucket/GitConfigBeyondCompare.ps1",
+        "https://raw.githubusercontent.com/MarkMichaelis/ScoopBucket/master/bucket/GitConfigVSCode.ps1",
         "https://raw.githubusercontent.com/MarkMichaelis/ScoopBucket/master/bucket/GitConfigVisualStudio.ps1",
         "https://raw.githubusercontent.com/MarkMichaelis/ScoopBucket/master/bucket/GitConfigure.ps1"
     ],

--- a/bucket/GitConfigure.ps1
+++ b/bucket/GitConfigure.ps1
@@ -2,7 +2,8 @@
 $scoopBucketPsd1 = Join-Path $PSScriptRoot '..\module\MarkMichaelis.ScoopBucket\MarkMichaelis.ScoopBucket.psd1'
 if (Test-Path $scoopBucketPsd1) { Import-Module $scoopBucketPsd1 -Force } else { Import-Module MarkMichaelis.ScoopBucket -Force }
 . "$PSScriptRoot\GitConfigBeyondCompare.ps1" # Runs Invoke-GitConfigBeyondCompare
-. "$PSScriptRoot\GitConfigVisualStudio.ps1" # Runs Invoke-GitConfigVisualStudio
+. "$PSScriptRoot\GitConfigVSCode.ps1"        # Runs Invoke-GitConfigVSCode
+. "$PSScriptRoot\GitConfigVisualStudio.ps1"  # Runs Invoke-GitConfigVisualStudio
 
 Function GitConfigure {
     Write-Host "Running $($MyInvocation.MyCommand.Name)..."
@@ -77,7 +78,6 @@ Function GitConfigure {
     # Confiure Misc. Diff Tools
     git config --global difftool.debug-powershell.cmd 'powershell -noprofile -command { Write-Output \"REMOTE=''$REMOTE'' LOCAL=''$LOCAL''\"}'
     git config --global difftool.debug-cmd.exe.cmd 'cmd.exe /C \"ECHO REMOTE=''$REMOTE'' LOCAL=''$LOCAL''\"}'
-    git config --global difftool.vscode.cmd 'code --wait --new-window --diff \"$LOCAL\" \"$REMOTE\"'
 
     Set-Service -StartupType Manual ssh-agent
 }


### PR DESCRIPTION
## Summary

Switch the Beyond Compare git difftool target from `BComp.exe` (GUI launcher, returns immediately) to `BComp.com` (console-waiting variant) so `git difftool` / `git mergetool` actually block until the compare window closes. Also adds a parallel `GitConfigVSCode` bundle so VS Code can be wired up as a registered diff/merge tool the same way.

## Coordinating BC and VS Code

Both bundles use **first-writer-wins** for the global default (`diff.tool` / `merge.tool` / `alias.dt`) and **register their own tool config unconditionally**. Net effect:

- Install order doesn't silently flip a deliberately-chosen default.
- `git difftool --tool=bc` and `git difftool --tool=vscode` always work once each is configured.
- `alias.dtbc` and `alias.dtv` give one-shot explicit access without changing the default.
- `git config --global diff.tool <name>` flips defaults at any time.

## Files

- `bucket/GitConfigBeyondCompare.ps1` -- targets `BComp.com` (fallback to `BComp.exe`), first-writer-wins defaults, `alias.dtbc`.
- `bucket/GitConfigVSCode.{ps1,json,Tests.ps1}` -- new bundle.
- `bucket/GitConfigure.ps1` / `.json` -- dot-sources the new bundle, drops orphan `difftool.vscode.cmd` line.
- Manifest version bumps per repo convention.

## Validation

- Local Light suite: 92 / 0 / 2 env-skips.
- `Resolve-VSCodeCommand` unit test passes regardless of VS Code presence.
- Heavy suite covers install idempotency + tool config presence in CI.