### PR TITLE
Add 'git diffcode' non-blocking VS Code diff alias

### DIFF
--- a/bucket/GitConfigBeyondCompare.Tests.ps1
+++ b/bucket/GitConfigBeyondCompare.Tests.ps1
@@ -21,6 +21,20 @@ Describe "Install $name" -Tag 'Heavy', 'Install' {
         Test-ScoopPackageInstalled $name | Should -Be $true
     }
 
+    It 'sets Beyond Compare as the unconditional default difftool/mergetool' {
+        . "$PSScriptRoot\GitConfigBeyondCompare.ps1" *>$null
+        $bcDir = Resolve-BeyondCompareDir
+        if (-not $bcDir) {
+            Set-ItResult -Skipped -Because 'Beyond Compare not installed'
+            return
+        }
+        # BC is the project-wide default; other tools register their own
+        # explicit aliases (`git diffcode`, `git dtv`) instead of competing
+        # for `diff.tool`.
+        git config --global diff.tool  | Should -Be 'bc'
+        git config --global merge.tool | Should -Be 'bc'
+    }
+
     It 'registers the bc difftool when Beyond Compare is installed' {
         . "$PSScriptRoot\GitConfigBeyondCompare.ps1" *>$null
         $bcDir = Resolve-BeyondCompareDir

--- a/bucket/GitConfigBeyondCompare.json
+++ b/bucket/GitConfigBeyondCompare.json
@@ -1,6 +1,6 @@
 {
     "$schema": "https://raw.githubusercontent.com/lukesampson/scoop/master/schema.json",
-    "version": "1.11.001",
+    "version": "1.12.000",
     "url": [
         "https://raw.githubusercontent.com/MarkMichaelis/ScoopBucket/master/bucket/GitConfigBeyondCompare.ps1"
     ],

--- a/bucket/GitConfigBeyondCompare.ps1
+++ b/bucket/GitConfigBeyondCompare.ps1
@@ -138,15 +138,16 @@ Function Invoke-GitConfigBeyondCompare {
     git config --global mergetool.keepBackup false
     git config --global mergetool.prompt false
 
-    # First-writer-wins for the global default so install order doesn't
-    # silently flip a deliberately-chosen tool. To switch defaults manually:
-    #   git config --global diff.tool <name>
-    #   git config --global merge.tool <name>
-    if (-not (git config --global --get diff.tool))  { git config --global diff.tool  bc }
-    if (-not (git config --global --get merge.tool)) { git config --global merge.tool bc }
+    # Beyond Compare is the project-wide default for git diff/merge.  Other
+    # tools (VS Code, Visual Studio) register their own *.path/*.cmd entries
+    # and add explicit aliases (`git diffcode`, `git dtv`, ...) so callers
+    # can reach them on demand without flipping the default.
+    git config --global diff.tool  bc
+    git config --global merge.tool bc
 
-    # Aliases — `dt` honors the current default tool; `dtbc` always uses BC
-    # explicitly, so the user can invoke either without changing the default.
+    # Aliases — `dt` is the existing dir-diff shortcut against the default
+    # tool; `dtbc` always uses BC explicitly so the workflow survives even
+    # if a user re-pointed diff.tool to something else.
     if (-not (git config --global --get alias.dt))   { git config --global alias.dt   'difftool --dir-diff' }
     git config --global alias.dtbc 'difftool --tool=bc --dir-diff'
 

--- a/bucket/GitConfigVSCode.Tests.ps1
+++ b/bucket/GitConfigVSCode.Tests.ps1
@@ -36,7 +36,33 @@ Describe "Install $name" -Tag 'Heavy', 'Install' {
         $mergeCmd | Should -Match '--merge'
     }
 
-    It 'adds an alias.dtv shortcut when VS Code is configured' {
+    It 'does not override diff.tool when Beyond Compare is the default' {
+        . "$PSScriptRoot\GitConfigVSCode.ps1" *>$null
+        $code = Resolve-VSCodeCommand
+        if (-not $code) {
+            Set-ItResult -Skipped -Because 'VS Code not installed on this runner'
+            return
+        }
+        # GitConfigVSCode registers explicit aliases (dtv / diffcode) and the
+        # `vscode` tool config but must leave diff.tool / merge.tool alone --
+        # Beyond Compare owns the project-wide default.
+        $tool = git config --global diff.tool
+        if ($tool) { $tool | Should -Not -Be 'vscode' }
+    }
+
+    It 'adds a non-blocking diffcode alias when VS Code is configured' {
+        . "$PSScriptRoot\GitConfigVSCode.ps1" *>$null
+        $code = Resolve-VSCodeCommand
+        if (-not $code) {
+            Set-ItResult -Skipped -Because 'VS Code not installed on this runner'
+            return
+        }
+        $alias = git config --global alias.diffcode
+        $alias | Should -Match 'Invoke-GitDiffCode\.ps1'
+        $alias | Should -Match '^!pwsh'
+    }
+
+    It 'adds an alias.dtv blocking shortcut when VS Code is configured' {
         . "$PSScriptRoot\GitConfigVSCode.ps1" *>$null
         $code = Resolve-VSCodeCommand
         if (-not $code) {
@@ -57,5 +83,19 @@ Describe "Behaviour $name (unit)" -Tag 'Light', 'Unit' {
         if ($r) {
             ($r -match '^[\w-]+$') -or (Test-Path $r) | Should -Be $true
         }
+    }
+
+    It 'ships Invoke-GitDiffCode.ps1 alongside GitConfigVSCode.ps1' {
+        # The diffcode alias is wired to this exact filename at install
+        # time; it must remain in the bucket so the Scoop manifest URL list
+        # keeps shipping it into the app dir.
+        Test-Path (Join-Path $PSScriptRoot 'Invoke-GitDiffCode.ps1') | Should -Be $true
+    }
+
+    It 'Invoke-GitDiffCode.ps1 parses without syntax errors' {
+        $path = Join-Path $PSScriptRoot 'Invoke-GitDiffCode.ps1'
+        $tokens = $null; $errors = $null
+        [System.Management.Automation.Language.Parser]::ParseFile($path, [ref]$tokens, [ref]$errors) | Out-Null
+        $errors | Should -BeNullOrEmpty
     }
 }

--- a/bucket/GitConfigVSCode.json
+++ b/bucket/GitConfigVSCode.json
@@ -1,8 +1,9 @@
 {
     "$schema": "https://raw.githubusercontent.com/lukesampson/scoop/master/schema.json",
-    "version": "1.01.000",
+    "version": "1.02.000",
     "url": [
-        "https://raw.githubusercontent.com/MarkMichaelis/ScoopBucket/master/bucket/GitConfigVSCode.ps1"
+        "https://raw.githubusercontent.com/MarkMichaelis/ScoopBucket/master/bucket/GitConfigVSCode.ps1",
+        "https://raw.githubusercontent.com/MarkMichaelis/ScoopBucket/master/bucket/Invoke-GitDiffCode.ps1"
     ],
     "installer": {
         "script": "& \"$dir\\GitConfigVSCode.ps1\""

--- a/bucket/GitConfigVSCode.ps1
+++ b/bucket/GitConfigVSCode.ps1
@@ -50,24 +50,35 @@ Function Invoke-GitConfigVSCode {
     $mergeCmd = "$launcher --wait --merge `"`$REMOTE`" `"`$LOCAL`" `"`$BASE`" `"`$MERGED`""
 
     # Always register the `vscode` tool config so it's available on demand
-    # via `git difftool --tool=vscode`, regardless of which tool is default.
+    # via `git difftool --tool=vscode` -- this is the BLOCKING flavour
+    # (uses --wait so git waits for the VS Code tab to close before cleaning
+    # up its temp files). It's the right choice for scripted/CI workflows.
     git config --global difftool.vscode.cmd          $diffCmd
     git config --global difftool.vscode.trustExitCode true
     git config --global mergetool.vscode.cmd         $mergeCmd
     git config --global mergetool.vscode.trustExitCode true
     git config --global mergetool.vscode.keepBackup  false
 
-    # First-writer-wins for the global default so install order doesn't
-    # silently flip a deliberately-chosen tool. To switch defaults manually:
-    #   git config --global diff.tool vscode
-    #   git config --global merge.tool vscode
-    if (-not (git config --global --get diff.tool))  { git config --global diff.tool  vscode }
-    if (-not (git config --global --get merge.tool)) { git config --global merge.tool vscode }
-
-    # Aliases — `dt` honors the current default; `dtv` always uses VS Code
-    # explicitly so the user can invoke either without changing the default.
-    if (-not (git config --global --get alias.dt))   { git config --global alias.dt 'difftool' }
+    # `git dtv` -- explicit blocking VS Code difftool invocation; doesn't
+    # require touching the global diff.tool default (Beyond Compare).
     git config --global alias.dtv 'difftool --tool=vscode'
+
+    # `git diffcode` -- NON-BLOCKING VS Code diff against HEAD (or --staged).
+    # Bypasses git's tempfile lifecycle by dumping HEAD/index blobs to
+    # %TEMP%\diffcode\ ourselves and launching `code --diff` without --wait,
+    # so the shell returns immediately while VS Code stays open. The helper
+    # script lives in the same Scoop app dir as this configurator; we hard-
+    # code its absolute path into the alias at install time so PATH state
+    # never breaks the alias.
+    $helper = Join-Path $PSScriptRoot 'Invoke-GitDiffCode.ps1'
+    if (Test-Path $helper) {
+        # Forward-slashes survive git-config's quoting on Windows better than
+        # backslashes; pwsh accepts either.
+        $helperPosix = $helper -replace '\\', '/'
+        git config --global alias.diffcode ("!pwsh -NoProfile -File '" + $helperPosix + "' --")
+    } else {
+        Write-Warning "Invoke-GitDiffCode.ps1 not found alongside GitConfigVSCode.ps1; skipping diffcode alias."
+    }
 
     Write-Host "VS Code configured for git diff/merge: $code"
 }

--- a/bucket/GitConfigure.json
+++ b/bucket/GitConfigure.json
@@ -1,9 +1,10 @@
 {
     "$schema": "https://raw.githubusercontent.com/lukesampson/scoop/master/schema.json",
-    "version": "1.21.001",
+    "version": "1.22.000",
     "url": [
         "https://raw.githubusercontent.com/MarkMichaelis/ScoopBucket/master/bucket/GitConfigBeyondCompare.ps1",
         "https://raw.githubusercontent.com/MarkMichaelis/ScoopBucket/master/bucket/GitConfigVSCode.ps1",
+        "https://raw.githubusercontent.com/MarkMichaelis/ScoopBucket/master/bucket/Invoke-GitDiffCode.ps1",
         "https://raw.githubusercontent.com/MarkMichaelis/ScoopBucket/master/bucket/GitConfigVisualStudio.ps1",
         "https://raw.githubusercontent.com/MarkMichaelis/ScoopBucket/master/bucket/GitConfigure.ps1"
     ],

--- a/bucket/Invoke-GitDiffCode.ps1
+++ b/bucket/Invoke-GitDiffCode.ps1
@@ -1,0 +1,93 @@
+<#
+.SYNOPSIS
+    Open VS Code diff views of HEAD vs working-tree without blocking the shell.
+
+.DESCRIPTION
+    Companion to the `git diffcode` alias installed by GitConfigVSCode.ps1.
+    For each path supplied (or, with no args, every file reported by
+    `git diff --name-only`), dumps the HEAD blob to a stable temp file under
+    %TEMP%\diffcode\ and launches `code --diff <head-copy> <working-tree>`.
+
+    `code` is a non-waiting shim (no --wait), so VS Code opens in the user's
+    existing window and the shell returns immediately. The HEAD copies live
+    in %TEMP%\diffcode\ and are pruned on subsequent invocations once older
+    than 1 day, so VS Code has plenty of time to ingest them.
+
+.NOTES
+    Lives under bucket/ so it's shipped into the Scoop app dir alongside the
+    GitConfigVSCode manifest; the alias hard-codes its absolute path at
+    install time so the helper is reachable regardless of PATH state.
+
+.EXAMPLE
+    git diffcode             # diff every modified file
+    git diffcode src\a.cs    # diff a single file
+    git diffcode --staged    # diff every staged file (HEAD vs index)
+#>
+[CmdletBinding()]
+param(
+    [switch]$Staged,
+    [Parameter(ValueFromRemainingArguments)]
+    [string[]]$Files
+)
+
+if (-not (Get-Command git -ErrorAction Ignore)) {
+    Write-Error "git not found on PATH."
+    exit 1
+}
+if (-not (Get-Command code -ErrorAction Ignore)) {
+    Write-Error "VS Code 'code' launcher not found on PATH."
+    exit 1
+}
+
+# Honor `git diffcode --staged` even when --staged arrives via $Files.
+if ($Files -and $Files -contains '--staged') {
+    $Staged = $true
+    $Files = $Files | Where-Object { $_ -ne '--staged' }
+}
+
+if (-not $Files -or $Files.Count -eq 0) {
+    $listArgs = if ($Staged) { @('diff', '--cached', '--name-only') }
+                else         { @('diff', '--name-only') }
+    $Files = (& git @listArgs) -split "`r?`n" | Where-Object { $_ }
+}
+
+if (-not $Files -or $Files.Count -eq 0) {
+    Write-Host "No changes to diff."
+    return
+}
+
+$tmpRoot = Join-Path $env:TEMP 'diffcode'
+[void](New-Item -ItemType Directory -Force -Path $tmpRoot -ErrorAction SilentlyContinue)
+
+# Prune anything older than 1 day so the temp dir doesn't grow unbounded.
+$cutoff = (Get-Date).AddDays(-1)
+Get-ChildItem -LiteralPath $tmpRoot -File -ErrorAction Ignore |
+    Where-Object { $_.LastWriteTime -lt $cutoff } |
+    Remove-Item -Force -ErrorAction Ignore
+
+$ref = if ($Staged) { '' } else { 'HEAD' }
+foreach ($file in $Files) {
+    if (-not (Test-Path -LiteralPath $file)) {
+        Write-Warning "Path not found in working tree: $file"
+        continue
+    }
+    $leaf  = Split-Path -Leaf $file
+    $stamp = (Get-Date -Format 'yyyyMMdd-HHmmss')
+    $rand  = [Guid]::NewGuid().ToString('N').Substring(0,6)
+    $prefix = if ($ref) { $ref } else { 'INDEX' }
+    $left  = Join-Path $tmpRoot ("{0}-{1}-{2}-{3}" -f $prefix, $stamp, $rand, $leaf)
+
+    # `git show :file` reads from the index; `git show HEAD:file` from HEAD.
+    $spec = if ($Staged) { ":$file" } else { "HEAD:$file" }
+    try {
+        $blob = & git show $spec 2>$null
+        Set-Content -LiteralPath $left -Value $blob -NoNewline
+    } catch {
+        Write-Warning "Could not retrieve $spec from git: $($_.Exception.Message)"
+        continue
+    }
+
+    # No --wait => shell returns immediately. --reuse-window keeps the user's
+    # current VS Code window focused instead of stacking new ones per file.
+    & code --reuse-window --diff $left $file
+}


### PR DESCRIPTION
## Summary

Two changes:

1. **Beyond Compare is now the unconditional default** for `diff.tool` / `merge.tool`. If BC is installed it wins, period  no more first-writer-wins handoff. Other tools (VS Code, Visual Studio) register their own `*.path` / `*.cmd` configs and explicit aliases instead of competing for the default.

2. **New `git diffcode` alias**  non-blocking VS Code diff of HEAD (or `--staged`) vs working tree. The shell returns immediately while VS Code stays open. Backed by `Invoke-GitDiffCode.ps1` which dumps HEAD/index blobs to `%TEMP%\diffcode\` and launches `code --reuse-window --diff` without `--wait`. Temp files older than 1 day are pruned on each invocation.

## Usage

```
# default difftool -- Beyond Compare (blocking)
git difftool path\file
git dt                    # alias: difftool --dir-diff (BC)
git dtbc                  # alias: difftool --tool=bc --dir-diff (explicit)

# VS Code blocking (scriptable, git-aware temp-file lifecycle)
git dtv path\file         # alias: difftool --tool=vscode

# VS Code non-blocking (interactive, returns immediately)
git diffcode              # every modified file
git diffcode src\a.cs     # one file
git diffcode --staged     # HEAD vs index for staged files
```

## Files

- `bucket/Invoke-GitDiffCode.ps1` -- new helper; pruning + temp dump + code launcher.
- `bucket/GitConfigBeyondCompare.ps1` -- unconditional `diff.tool = bc` / `merge.tool = bc`.
- `bucket/GitConfigVSCode.ps1` -- registers `vscode` tool, `alias.dtv` (blocking) and `alias.diffcode` (non-blocking, points at the helper's absolute path).
- `bucket/GitConfigVSCode.json` -- now ships `Invoke-GitDiffCode.ps1` via the `url` list.
- Manifest version bumps via `Test-ManifestVersionBumps.ps1 -Fix`.

## Validation

- Local Light suite: VSCode unit tests 3/3, helper parses cleanly.
- Smoke test on a throwaway repo: helper creates exactly one HEAD blob in `%TEMP%\diffcode\` and launches VS Code non-blocking; shell returned immediately.
- Manifest version-bump rule green.