### PR TITLE
Fix [Package] cross-scope cast failure in Resolve-PackageOrder

### DIFF
--- a/bucket/PackageOrder.Tests.ps1
+++ b/bucket/PackageOrder.Tests.ps1
@@ -126,3 +126,37 @@ Describe 'Resolve-PackageOrder — error cases' -Tag 'Light', 'Module' {
             Should -Throw -ExpectedMessage "*cycle or unresolved*"
     }
 }
+
+Describe 'Resolve-PackageOrder  cross-scope [Package] identity' -Tag 'Light', 'Module' {
+    It 'accepts [Package] instances created in a different scope chain' {
+        # Regression for the dual-class-identity bug: the [Package] class
+        # is loaded once via the module manifest's ScriptsToProcess (into
+        # the caller scope) and again by the psm1 (into module scope), so
+        # a [Package] from scope A is NOT assignment-compatible with
+        # [Package] in scope B. Internal helpers must therefore type
+        # their array parameters as [object[]], not [Package[]].
+        $foreignClassPath = Join-Path ([System.IO.Path]::GetTempPath()) "Package-foreign-$PID-$([guid]::NewGuid().ToString('N')).ps1"
+        Copy-Item -LiteralPath $script:classPath -Destination $foreignClassPath -Force
+        try {
+            $foreignPkgs = & {
+                . $foreignClassPath
+                ,@(
+                    [Package]@{ Name = 'a'; Installer = 'scoop'; Id = 'main/a' },
+                    [Package]@{ Name = 'b'; Installer = 'scoop'; Id = 'main/b'; DependsOn = @('a') }
+                )
+            }
+
+            # Sanity: $foreignPkgs and our local [Package] are different
+            # type identities (same simple Name 'Package').
+            $foreignType = $foreignPkgs[0].GetType()
+            $foreignType.Name | Should -Be 'Package'
+
+            # The fix under test: [object[]] parameter accepts them.
+            $result = Resolve-PackageOrder -Packages $foreignPkgs
+            ($result | ForEach-Object Name) -join ',' | Should -Be 'a,b'
+        }
+        finally {
+            Remove-Item -LiteralPath $foreignClassPath -ErrorAction Ignore
+        }
+    }
+}

--- a/module/MarkMichaelis.ScoopBucket/Private/Resolve-PackageOrder.ps1
+++ b/module/MarkMichaelis.ScoopBucket/Private/Resolve-PackageOrder.ps1
@@ -11,9 +11,16 @@ function Resolve-PackageOrder {
         by original array index.
     #>
     [CmdletBinding()]
-    [OutputType([Package[]])]
+    [OutputType([object[]])]
     param(
-        [Parameter(Mandatory)][Package[]] $Packages,
+        # Use [object[]] (not [Package[]]) so callers from a different
+        # scope chain don't trip the dual-class-identity issue: the
+        # [Package] class is loaded both by ScriptsToProcess (caller
+        # scope) and the psm1 (module scope), and a [Package] from one
+        # scope is not assignment-compatible with [Package] in the
+        # other. Invoke-PackageInstall already validates each element
+        # has GetType().Name -eq 'Package' before reaching us.
+        [Parameter(Mandatory)][object[]] $Packages,
         [string[]] $Name,
         [string[]] $Skip
     )
@@ -73,7 +80,7 @@ function Resolve-PackageOrder {
         [string[]]@($filtered | ForEach-Object { $_.Name }),
         [System.StringComparer]::OrdinalIgnoreCase
     )
-    $result = [System.Collections.Generic.List[Package]]::new()
+    $result = [System.Collections.Generic.List[object]]::new()
 
     while ($remaining.Count -gt 0) {
         $ready = @($filtered |


### PR DESCRIPTION
## Symptom

```
PS> Install-Package 'Beyond Compare'
Install-Package: dispatching Beyond Compare via DeveloperBasePackages...
Invoke-PackageInstall: D:\Git\ScoopBucket\bucket\DeveloperBasePackages.ps1:56
  56 |  Invoke-PackageInstall -Packages $Packages -Bundle 'DeveloperBasePackages'
     | Cannot process argument transformation on parameter 'Packages'.
     | Cannot convert the "[choco] Node.js (nodejs)" value of type "Package" to type "Package".
```

## Root cause

The `[Package]` class is loaded twice into any session that imports the module:
1. `ScriptsToProcess` in the .psd1 dot-sources `Classes\Package.ps1` into the **caller scope** so bundles can write `[Package]@{...}` literals.
2. The .psm1 dot-sources the same file into the **module scope** so internal helpers can reference `[Package]` in parameter signatures.

Each dot-source produces a distinct CLR type. Both have `GetType().Name == 'Package'` but they are **not** assignment-compatible. `Resolve-PackageOrder` declared `[Package[]] $Packages` against the *module-scope* type, while bundle scripts produce instances of the *caller-scope* type  hence the cryptic "cannot convert Package to Package" parameter-binding failure.

## Fix

Type `Resolve-PackageOrder`'s parameter (and its internal `List`) as `[object[]] / [object]`, matching `Invoke-PackageInstall`'s existing pattern. The caller already validates each element via `GetType().Name -eq 'Package'`.

## Test

New regression test in `bucket/PackageOrder.Tests.ps1` copies the class file to a temp location, instantiates `[Package]` in a sub-scope (so the type identity is distinct from the test's), and verifies `Resolve-PackageOrder` accepts those foreign-scope instances.

End-to-end smoke verified: `Install-Package 'Beyond Compare' -DryRun` no longer throws and reaches per-package dispatch.