### PR TITLE
Fix Install-Package -Name filter being silently bypassed

### DIFF
--- a/bucket/InstallPackageFilter.Tests.ps1
+++ b/bucket/InstallPackageFilter.Tests.ps1
@@ -1,0 +1,67 @@
+#requires -Version 7.0
+#requires -Modules @{ ModuleName = 'Pester'; ModuleVersion = '5.0.0' }
+
+# Pester regression test: Install-Package -Name <pkg> must filter the
+# dispatched bundle down to <pkg> + its DependsOn closure. Earlier the
+# bundle's first-line `Import-Module ... -Force` re-exported the
+# module's Invoke-PackageInstall into the global function table,
+# overwriting the launch script's filter shim, and the bundle's
+# trailing `Invoke-PackageInstall -Packages $Packages` ran the
+# unfiltered driver  installing every package in the bundle.
+
+BeforeAll {
+    $script:repoRoot   = Split-Path -Parent $PSScriptRoot
+    $script:moduleRoot = Join-Path $script:repoRoot 'module\MarkMichaelis.ScoopBucket'
+    $script:psd1       = Join-Path $script:moduleRoot 'MarkMichaelis.ScoopBucket.psd1'
+
+    Import-Module $script:psd1 -Force
+
+    # Build a throwaway bucket dir with a single bundle containing 3
+    # packages. The bundle mirrors the real bundles' shape: top-level
+    # Import-Module of the working-tree module, $Packages literal, and
+    # a trailing Invoke-PackageInstall call.
+    $script:tmpBucket = Join-Path ([System.IO.Path]::GetTempPath()) ("ScoopBucket-test-$([guid]::NewGuid().ToString('N'))")
+    New-Item -ItemType Directory -Path $script:tmpBucket | Out-Null
+
+    $bundleText = @"
+`$scoopBucketPsd1 = '$($script:psd1 -replace "'","''")'
+if (Test-Path `$scoopBucketPsd1) { Import-Module `$scoopBucketPsd1 -Force } else { Import-Module MarkMichaelis.ScoopBucket -Force }
+
+`$Packages = [Package[]]@(
+    [Package]@{ Name = 'alpha'; Installer = 'winget'; Id = 'Test.Alpha' }
+    [Package]@{ Name = 'bravo'; Installer = 'winget'; Id = 'Test.Bravo'; DependsOn = @('alpha') }
+    [Package]@{ Name = 'charlie'; Installer = 'winget'; Id = 'Test.Charlie' }
+)
+
+Invoke-PackageInstall -Packages `$Packages -Bundle 'TestBundle'
+"@
+    Set-Content -Path (Join-Path $script:tmpBucket 'TestBundle.ps1') -Value $bundleText -Encoding UTF8
+}
+
+AfterAll {
+    if ($script:tmpBucket -and (Test-Path $script:tmpBucket)) {
+        Remove-Item -LiteralPath $script:tmpBucket -Recurse -Force -ErrorAction Ignore
+    }
+}
+
+Describe 'Install-Package -Name filter' -Tag 'Light', 'Module' {
+    It 'dispatches only the requested package when no DependsOn closure' {
+        $output = Install-Package -Name 'charlie' -DryRun -SkipCompletion -BucketPath $script:tmpBucket *>&1 |
+            Out-String
+
+        $output | Should -Match '=== Invoke-PackageInstall: TestBundle \(1 packages\) ==='
+        $output | Should -Match '\[install\] \[winget\] charlie'
+        $output | Should -Not -Match '\[install\] \[winget\] alpha'
+        $output | Should -Not -Match '\[install\] \[winget\] bravo'
+    }
+
+    It 'dispatches the requested package plus its transitive DependsOn closure' {
+        $output = Install-Package -Name 'bravo' -DryRun -SkipCompletion -BucketPath $script:tmpBucket *>&1 |
+            Out-String
+
+        $output | Should -Match '=== Invoke-PackageInstall: TestBundle \(2 packages\) ==='
+        $output | Should -Match '\[install\] \[winget\] alpha'
+        $output | Should -Match '\[install\] \[winget\] bravo'
+        $output | Should -Not -Match '\[install\] \[winget\] charlie'
+    }
+}

--- a/module/MarkMichaelis.ScoopBucket/Public/Install-Package.ps1
+++ b/module/MarkMichaelis.ScoopBucket/Public/Install-Package.ps1
@@ -105,12 +105,28 @@ function Install-Package {
 Import-Module '$modulePsd1' -Force
 `$names = '$namesJson' | ConvertFrom-Json
 `$realDriver = Get-Command Invoke-PackageInstall -Module MarkMichaelis.ScoopBucket
-function Invoke-PackageInstall {
-    [CmdletBinding()]
-    param([Parameter(Mandatory)][object[]]`$Packages, [Parameter(Mandatory)][string]`$Bundle, [Parameter(ValueFromRemainingArguments)]`$Remaining)
-    & `$realDriver -Packages `$Packages -Bundle `$Bundle -Name @(`$names) $flagsStr
+
+# We can't simply `& '$bundlePath'` and intercept its trailing
+# `Invoke-PackageInstall` call: the bundle's first line re-imports
+# the module, which replaces our shim in the global function table
+# with the module's exported version, defeating any `-Name` filter
+# we tried to inject.
+#
+# Instead, read the bundle text, strip its top-level `Import-Module`
+# (we already imported the module above) and its terminal
+# `Invoke-PackageInstall ...` line (we'll call the real driver
+# ourselves with the filter applied), execute the remainder so
+# `\`$Packages` becomes available, then dispatch with our filter.
+`$bundleText = Get-Content -Raw -LiteralPath '$($entry.BundlePath)'
+`$bundleStripped = `$bundleText -replace '(?ms)^\s*\`$scoopBucketPsd1\s*=.*?Import-Module\s+MarkMichaelis\.ScoopBucket\s+-Force\s*\}\s*', ''
+`$bundleStripped = `$bundleStripped -replace '(?m)^\s*Invoke-PackageInstall\s+-Packages\s+\`$Packages\s+-Bundle\s+''[^'']+''\s*`$', ''
+`$Packages = `$null
+. ([scriptblock]::Create(`$bundleStripped))
+if (`$null -eq `$Packages) {
+    Write-Error "Install-Package: bundle '$($entry.Bundle)' did not assign `\`$Packages."
+    return
 }
-& '$($entry.BundlePath)'
+& `$realDriver -Packages `$Packages -Bundle '$($entry.Bundle)' -Name @(`$names) $flagsStr
 "@
         $tmp = Join-Path $env:TEMP "ScoopBucket-install-$($entry.Bundle)-$PID.ps1"
         try {


### PR DESCRIPTION
## Symptom

`Install-Package 'Beyond Compare'` installed every package in DeveloperBasePackages.ps1 (Node.js, dotnet, Visual Studio, Python, Aspire, ...) instead of just Beyond Compare.

## Root cause

The launch script Install-Package generates wrapped `Invoke-PackageInstall` with a shim that injected the `-Name` filter, then dot-invoked the bundle via `& $bundlePath`. But the bundle's first line is `Import-Module $scoopBucketPsd1 -Force`, which re-imports the module and re-registers its exported `Invoke-PackageInstall` in the global function table  **silently overwriting the shim**. The bundle's trailing `Invoke-PackageInstall -Packages $Packages` then ran the unfiltered driver.

Attempts to proxy `Import-Module` failed: `Microsoft.PowerShell.Core\Import-Module` inside the proxy still recursed into our global override (PS function resolution doesn't honour the module-qualified name when a global function of the same simple name exists).

## Fix

Stop intercepting the terminal call. Instead, read the bundle text, strip its leading `Import-Module` block and trailing `Invoke-PackageInstall` line, dot-source the remainder so `$Packages` (with its live ScriptBlocks) becomes available, then call the real driver ourselves with `-Name` (and any `-DryRun / -SkipCompletion` flags) applied.

## Test

New `bucket/InstallPackageFilter.Tests.ps1` (Light suite, 2 tests):
- Creates a 3-package throwaway bundle in a temp `BucketPath`.
- Asserts `Install-Package -Name charlie` dispatches exactly 1.
- Asserts `Install-Package -Name bravo` dispatches bravo + its transitive DependsOn closure (alpha) = 2 packages, never charlie.

## Local verification

`Install-Package 'Beyond Compare' -DryRun -SkipCompletion` now reports `=== Invoke-PackageInstall: DeveloperBasePackages (1 packages) ===` and `[install] [scoop] Beyond Compare` only. `Install-Package 'Aspire' -DryRun -SkipCompletion` reports 3 packages (Aspire + dotnet + Visual Studio per its DependsOn closure).