### PR TITLE
Fix package-name completer missing one-line [Package] literals

### DIFF
--- a/bucket/PackageNameCompletion.Tests.ps1
+++ b/bucket/PackageNameCompletion.Tests.ps1
@@ -20,6 +20,19 @@ Describe 'Get-PackageNameSuggestion' -Tag 'Light' {
         $names | Should -Contain 'Beyond Compare'
     }
 
+    It 'includes packages declared via one-line [Package]@{ Name = ...; ... } literals' {
+        # Regression: the prior `^\s*Name\s*=\s*` anchor only matched
+        # multi-line literals (Name on its own line). One-liners like
+        # `[Package]@{ Name = 'Visual Studio Code'; ... }` were silently
+        # absent from completion.
+        $names = & (Get-Module MarkMichaelis.ScoopBucket) { Get-PackageNameSuggestion }
+        $names | Should -Contain 'Visual Studio Code'
+        $names | Should -Contain 'Visual Studio'
+        $names | Should -Contain 'Bitwarden'
+        $names | Should -Contain '7-Zip'
+        $names | Should -Contain 'Windows Terminal'
+    }
+
     It 'narrows by case-insensitive prefix' {
         $matches = & (Get-Module MarkMichaelis.ScoopBucket) { Get-PackageNameSuggestion -WordToComplete 'beyon' }
         $matches | Should -Contain 'Beyond Compare'

--- a/module/MarkMichaelis.ScoopBucket/Private/Get-PackageNameSuggestion.ps1
+++ b/module/MarkMichaelis.ScoopBucket/Private/Get-PackageNameSuggestion.ps1
@@ -48,12 +48,13 @@ function Get-PackageNameSuggestion {
 
     if ($script:PackageNameCacheKey -ne $cacheKey) {
         $names = [System.Collections.Generic.HashSet[string]]::new([System.StringComparer]::OrdinalIgnoreCase)
-        # Match `Name = 'value'` or `Name = "value"`. We intentionally
-        # don't try to scope to the inside of a [Package]@{...} literal —
-        # the only place `Name = '...'` appears in bundles in practice
-        # is inside Package literals; any false positives would just be
-        # ignored by Install-Package's strict name match at run time.
-        $rx = [regex]'(?m)^\s*Name\s*=\s*[''"]([^''"]+)[''"]'
+        # Match `Name = 'value'` or `Name = "value"` anywhere on a line.
+        # Bundles use both multi-line literals (Name on its own line) and
+        # one-line `[Package]@{ Name = '...'; ...}` literals — anchoring
+        # to ^ excluded the one-liners. The `\b` keeps us off the middle
+        # of identifiers (e.g. `BundleName=`). False positives are
+        # harmless: Install-Package's strict name match ignores them.
+        $rx = [regex]'(?m)\bName\s*=\s*[''"]([^''"]+)[''"]'
         foreach ($f in $bundleFiles) {
             $text = Get-Content -Raw -LiteralPath $f.FullName -ErrorAction SilentlyContinue
             if (-not $text) { continue }


### PR DESCRIPTION
The regex in `Get-PackageNameSuggestion` required `Name=` at the start of a line, so packages declared as single-line literals like `[Package]@{ Name = 'Visual Studio Code'; ... }` were silently skipped by tab completion.

**Fix:** drop the `^\s*` anchor; use `\bName\s*=` so both multi-line and one-line forms match. Coverage goes from ~20 to 61 names.

**Repro before fix:** `Install-Package -Name <tab>` did not offer `Visual Studio Code`, `Bitwarden`, `7-Zip`, `Windows Terminal`, etc.

**Test:** added an `It` block in `PackageNameCompletion.Tests.ps1` asserting each of those names is now returned.