### PR TITLE
feat(bucket): expose PSCompletions as a first-class installable package

### DIFF
--- a/bucket/ManifestTestHints.ps1
+++ b/bucket/ManifestTestHints.ps1
@@ -65,6 +65,11 @@
                                         [bool]$value
                                     } }
 
+    # --- PowerShell modules ------------------------------------------------
+    PSCompletions              = @{ Verify = 'Custom'; PreserveIfInstalled = $true
+                                    Script = { [bool](Get-Module -ListAvailable -Name PSCompletions) }
+                                    Reason = "PSGallery module; verification is module discoverability via Get-Module -ListAvailable. PreserveIfInstalled skips a destructive `scoop uninstall` (there is no scoop record to remove) — the harness still validates idempotency on the second invoke." }
+
     # --- Manual / heavyweight installs -------------------------------------
     ChatGPT                    = @{ Verify = 'Custom'; Manual = $true
                                     Script = { Test-Path (Join-Path $env:LOCALAPPDATA 'Programs\ChatGPT\ChatGPT.exe') }

--- a/bucket/PSCompletions.json
+++ b/bucket/PSCompletions.json
@@ -1,0 +1,10 @@
+{
+    "$schema": "https://raw.githubusercontent.com/lukesampson/scoop/master/schema.json",
+    "version": "1.01.000",
+    "url": [
+        "https://raw.githubusercontent.com/MarkMichaelis/ScoopBucket/master/bucket/PSCompletions.ps1"
+    ],
+    "installer": {
+        "script": "& \"$dir\\PSCompletions.ps1\""
+    }
+}

--- a/bucket/PSCompletions.ps1
+++ b/bucket/PSCompletions.ps1
@@ -1,0 +1,28 @@
+$scoopBucketPsd1 = Join-Path $PSScriptRoot '..\module\MarkMichaelis.ScoopBucket\MarkMichaelis.ScoopBucket.psd1'
+if (Test-Path $scoopBucketPsd1) { Import-Module $scoopBucketPsd1 -Force } else { Import-Module MarkMichaelis.ScoopBucket -Force }
+
+# PSCompletions powers the PSCompletions-backed tab completion fallback
+# used by Register-PackageCompletion for CLIs whose `<tool> completion`
+# subcommand emits nothing usable in PowerShell (bw, copilot, gcloud — see
+# #73). Invoke-PackageInstall lazy-installs the module the first time a
+# package with Completion='pscompletions'/'auto' is processed, but exposing
+# it as a first-class declarative package means users can:
+#   * Tab-complete its name in `Install-Package <Tab>`.
+#   * Install it explicitly via `Install-Package PSCompletions` when
+#     they don't yet need any of the CLIs that would lazy-pull it.
+$Packages = [Package[]]@(
+    [Package]@{
+        Name                = 'PSCompletions'
+        Installer           = 'custom'
+        Completion          = 'none'
+        Notes               = 'PowerShell module from PSGallery; required for the PSCompletions-backed completion fallback.'
+        CustomInstallScript = {
+            Install-PSCompletionsModule -Confirm:$false
+        }
+        VerifyScript        = {
+            [bool](Get-Module -ListAvailable -Name PSCompletions)
+        }
+    }
+)
+
+Invoke-PackageInstall -Packages $Packages -Bundle 'PSCompletions'


### PR DESCRIPTION
## Why

Until now `PSCompletions` (the PSGallery module that powers the fallback tab-completion path for CLIs whose `<tool> completion` subcommand is silent  bw, copilot, gcloud, etc.) was installable only as a side-effect of either:

- importing `bucket/PowerShell.ps1` (direct `Install-PSCompletionsModule` call), or
- running `Install-Package` against any *other* package whose `Completion` is `pscompletions`/`auto` (Invoke-PackageInstall's lazy-install block).

That meant `Install-Package PSCompletions<Tab>` produced no completion - the regex completer (`Get-PackageNameSuggestion`) only sees names declared as `[Package]@{ Name = '...' }` in bundle `*.ps1` files.

## What

- `bucket/PSCompletions.ps1` - new single-package declarative bundle. `Installer='custom'` + `CustomInstallScript` calling the pre-existing idempotent `Install-PSCompletionsModule` helper, plus a `VerifyScript` re-checking `Get-Module -ListAvailable`.
- `bucket/PSCompletions.json` - standard single-file scoop manifest delegating to the sibling `.ps1` (mirrors Aspire / ChatGPT pattern).
- `bucket/ManifestTestHints.ps1` - new `PSCompletions` hint (`Verify='Custom'`, `PreserveIfInstalled`). The data-driven harness now exercises install + idempotent + verify for it on Heavy runs.

## What stays

- The eager call in `bucket/PowerShell.ps1` (`Install-PSCompletionsModule -Confirm:$false`) is unchanged - bootstrap of a fresh box should still pull it before any individual CLI install.
- Invoke-PackageInstall's lazy auto-install branch is unchanged - still covers users who never run `Install-Package PSCompletions` directly.

## Verification

- Get-PackageNameSuggestion -WordToComplete 'PSC' returns `PSCompletions`.
- Light suite green locally (after Test-ManifestVersionBumps -Fix bumped the new manifest from 1.00.000  1.01.000).