### PR TITLE
feat(install-package): cover bundles + bare-json manifests

### DIFF
--- a/bucket/InstallPackageFilter.Tests.ps1
+++ b/bucket/InstallPackageFilter.Tests.ps1
@@ -36,6 +36,19 @@ if (Test-Path `$scoopBucketPsd1) { Import-Module `$scoopBucketPsd1 -Force } else
 Invoke-PackageInstall -Packages `$Packages -Bundle 'TestBundle'
 "@
     Set-Content -Path (Join-Path $script:tmpBucket 'TestBundle.ps1') -Value $bundleText -Encoding UTF8
+
+    # Sibling .json so the completer's manifest-name scan picks up
+    # 'TestBundle' as a bundle name (mirrors the production layout
+    # where every bundle .ps1 has a sibling .json so scoop can install
+    # it).
+    $bundleManifest = @{
+        '$schema'  = 'https://raw.githubusercontent.com/lukesampson/scoop/master/schema.json'
+        version   = '1.00.000'
+        url       = @('https://example.invalid/test-bundle')
+        installer = @{ script = @('& "$dir\\TestBundle.ps1"') }
+    }
+    Set-Content -LiteralPath (Join-Path $script:tmpBucket 'TestBundle.json') `
+        -Value ($bundleManifest | ConvertTo-Json -Depth 4) -Encoding UTF8
 }
 
 AfterAll {
@@ -63,5 +76,62 @@ Describe 'Install-Package -Name filter' -Tag 'Light', 'Module' {
         $output | Should -Match '\[install\] \[winget\] alpha'
         $output | Should -Match '\[install\] \[winget\] bravo'
         $output | Should -Not -Match '\[install\] \[winget\] charlie'
+    }
+}
+
+Describe 'Install-Package <BundleName> dispatch' -Tag 'Light', 'Module' {
+    # The user types the bundle name (e.g. `Install-Package OSBasePackages`)
+    # instead of an individual package name. We install every package in
+    # that bundle — no -Name filter, full $Packages collection.
+
+    It 'installs every package in the bundle when given the bundle name' {
+        $output = Install-Package -Name 'TestBundle' -DryRun -SkipCompletion -BucketPath $script:tmpBucket *>&1 |
+            Out-String
+
+        $output | Should -Match "dispatching bundle 'TestBundle' \(all packages\)"
+        $output | Should -Match '=== Invoke-PackageInstall: TestBundle \(3 packages\) ==='
+        $output | Should -Match '\[install\] \[winget\] alpha'
+        $output | Should -Match '\[install\] \[winget\] bravo'
+        $output | Should -Match '\[install\] \[winget\] charlie'
+    }
+}
+
+Describe 'Install-Package <BareManifest> fallback' -Tag 'Light', 'Module' {
+    # A `<name>.json` exists in the bucket but no [Package] declares it
+    # and no declarative bundle owns it. Install-Package must fall
+    # through to `scoop install <name>` so the manifest's
+    # installer.script runs verbatim.
+
+    BeforeAll {
+        # Drop a json with no sibling .ps1 into the temp bucket.
+        $manifest = @{
+            '$schema'  = 'https://raw.githubusercontent.com/lukesampson/scoop/master/schema.json'
+            version   = '1.00.000'
+            url       = @('https://example.invalid/bare-manifest')
+            installer = @{ script = @('Write-Host bare-manifest install') }
+        }
+        Set-Content -LiteralPath (Join-Path $script:tmpBucket 'BareManifestPkg.json') `
+            -Value ($manifest | ConvertTo-Json -Depth 4) -Encoding UTF8
+    }
+
+    It 'lists bundle, package, and bare-manifest names in the completer' {
+        $names = & (Get-Module MarkMichaelis.ScoopBucket) {
+            param($p) Get-PackageNameSuggestion -BucketPath $p
+        } $script:tmpBucket
+        $names | Should -Contain 'TestBundle'
+        $names | Should -Contain 'alpha'
+        $names | Should -Contain 'BareManifestPkg'
+    }
+
+    It 'logs scoop-install dispatch under -DryRun without invoking scoop' {
+        $output = Install-Package -Name 'BareManifestPkg' -DryRun -SkipCompletion -BucketPath $script:tmpBucket *>&1 |
+            Out-String
+        $output | Should -Match "dispatching manifest 'BareManifestPkg' via scoop install"
+        $output | Should -Match '\[DryRun\] scoop install BareManifestPkg'
+    }
+
+    It 'throws a helpful error when neither package, bundle, nor manifest matches' {
+        { Install-Package -Name 'NoSuchThing' -DryRun -SkipCompletion -BucketPath $script:tmpBucket } |
+            Should -Throw -ExpectedMessage "*no bundle declares a package named 'NoSuchThing'*"
     }
 }

--- a/bucket/PackageNameCompletion.Tests.ps1
+++ b/bucket/PackageNameCompletion.Tests.ps1
@@ -33,6 +33,28 @@ Describe 'Get-PackageNameSuggestion' -Tag 'Light' {
         $names | Should -Contain 'Windows Terminal'
     }
 
+    It 'includes declarative bundle names so Install-Package <BundleName> tab-completes' {
+        # `Install-Package OSBasePackages` installs every package in
+        # the OSBasePackages bundle. The completer must surface every
+        # bundle that ships a `<bundle>.json` manifest.
+        $names = & (Get-Module MarkMichaelis.ScoopBucket) { Get-PackageNameSuggestion }
+        foreach ($bundle in 'OSBasePackages','DeveloperBasePackages','ClientBasePackages','MicrosoftOffice365','AIAgents') {
+            $names | Should -Contain $bundle
+        }
+    }
+
+    It 'includes bare-json manifest names (no [Package] / imperative .ps1) so they tab-complete' {
+        # Manifests with no declarative [Package] entry — bare json
+        # (Codex, dotnet, GeminiCli, ...) and imperative .ps1 bundles
+        # (Chocolatey, Gemini, ClaudeExcel, ...) — must still tab-
+        # complete so users can `Install-Package <name>` rather than
+        # falling back to `scoop install`.
+        $names = & (Get-Module MarkMichaelis.ScoopBucket) { Get-PackageNameSuggestion }
+        foreach ($manifest in 'Codex','dotnet','Chocolatey','Gemini','ClaudeExcel','WSL-Ubuntu-2004') {
+            $names | Should -Contain $manifest
+        }
+    }
+
     It 'narrows by case-insensitive prefix' {
         $matches = & (Get-Module MarkMichaelis.ScoopBucket) { Get-PackageNameSuggestion -WordToComplete 'beyon' }
         $matches | Should -Contain 'Beyond Compare'

--- a/module/MarkMichaelis.ScoopBucket/Private/Get-PackageNameSuggestion.ps1
+++ b/module/MarkMichaelis.ScoopBucket/Private/Get-PackageNameSuggestion.ps1
@@ -41,9 +41,12 @@ function Get-PackageNameSuggestion {
         Where-Object { $_.Name -notmatch '\.Tests\.ps1$' } |
         Where-Object { $_.Name -ne 'Utils.ps1' -and $_.Name -ne 'Invoke-Tests.ps1' }
 
-    if (-not $bundleFiles) { return @() }
+    $manifestFiles = Get-ChildItem -Path $BucketPath -Filter '*.json' -File -ErrorAction SilentlyContinue
 
-    $latestMtimeTicks = ($bundleFiles | Measure-Object -Property LastWriteTimeUtc -Maximum).Maximum.Ticks
+    if (-not $bundleFiles -and -not $manifestFiles) { return @() }
+
+    $mtimeInputs = @($bundleFiles) + @($manifestFiles)
+    $latestMtimeTicks = ($mtimeInputs | Measure-Object -Property LastWriteTimeUtc -Maximum).Maximum.Ticks
     $cacheKey = "$BucketPath|$latestMtimeTicks"
 
     if ($script:PackageNameCacheKey -ne $cacheKey) {
@@ -61,6 +64,17 @@ function Get-PackageNameSuggestion {
             foreach ($m in $rx.Matches($text)) {
                 $null = $names.Add($m.Groups[1].Value)
             }
+        }
+        # Also surface every <name>.json manifest basename. This covers:
+        #   - Bundles (OSBasePackages, DeveloperBasePackages, ...) — the
+        #     bundle name itself is installable via Install-Package and
+        #     fans out to every package in the bundle.
+        #   - Bare-json manifests (no .ps1, or .ps1 with no [Package]) —
+        #     Codex, dotnet, Chocolatey, Gemini, ClaudeExcel, GitConfigure,
+        #     WSL-Ubuntu-*, McAfeeUninstall, ... — installable by passing
+        #     the manifest through to `scoop install`.
+        foreach ($f in $manifestFiles) {
+            $null = $names.Add($f.BaseName)
         }
         $script:PackageNameCache = @($names) | Sort-Object
         $script:PackageNameCacheKey = $cacheKey

--- a/module/MarkMichaelis.ScoopBucket/Private/Invoke-BundleScript.ps1
+++ b/module/MarkMichaelis.ScoopBucket/Private/Invoke-BundleScript.ps1
@@ -1,0 +1,96 @@
+function Invoke-BundleScript {
+    <#
+    .SYNOPSIS
+        Internal: launch a declarative bundle .ps1 in a child pwsh and
+        invoke its captured `$Packages` collection through the real
+        `Invoke-PackageInstall` driver, optionally filtered by -Name.
+
+    .DESCRIPTION
+        Extracted from `Install-Package` so the same dispatch machinery
+        serves both:
+          (a) `Install-Package <PackageName>` — passes a -Name filter
+              so DependsOn closure runs but unrelated packages don't.
+          (b) `Install-Package <BundleName>`  — omits -Name so the
+              entire bundle installs.
+
+        We can't dot-source the bundle in-proc because the bundle's
+        first line re-imports the module, which would replace any local
+        Invoke-PackageInstall shim we'd tried to inject. Instead we
+        strip the bundle's Import-Module preamble and its terminal
+        `Invoke-PackageInstall -Packages $Packages -Bundle '...'` call,
+        evaluate the remainder so `$Packages` is assigned, and dispatch
+        manually with the filter applied.
+
+    .PARAMETER BundlePath
+        Absolute path to the bundle's `.ps1` file.
+
+    .PARAMETER Bundle
+        Bundle name (used for logging only).
+
+    .PARAMETER Names
+        Optional -Name filter. When omitted the whole bundle installs.
+
+    .PARAMETER DryRun, SkipCompletion
+        Passed through to `Invoke-PackageInstall`.
+    #>
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)][string]$BundlePath,
+        [Parameter(Mandatory)][string]$Bundle,
+        [string[]]$Names,
+        [switch]$DryRun,
+        [switch]$SkipCompletion
+    )
+
+    if ($Names -and $Names.Count -gt 0) {
+        Write-Host ""
+        Write-Host "Install-Package: dispatching $($Names -join ', ') via $Bundle..."
+    }
+
+    $pwsh = (Get-Process -Id $PID).Path
+    if (-not $pwsh) { $pwsh = 'pwsh' }
+    $modulePsd1 = Join-Path (Split-Path -Parent (Split-Path -Parent $PSScriptRoot)) 'MarkMichaelis.ScoopBucket\MarkMichaelis.ScoopBucket.psd1'
+
+    $flags = @()
+    if ($DryRun)         { $flags += '-DryRun' }
+    if ($SkipCompletion) { $flags += '-SkipCompletion' }
+    $flagsStr = $flags -join ' '
+
+    $nameFilterLiteral = ''
+    if ($Names -and $Names.Count -gt 0) {
+        $namesJson = ($Names | ConvertTo-Json -Compress)
+        $nameFilterLiteral = "`$names = '$namesJson' | ConvertFrom-Json"
+        $nameFilterArg = '-Name @($names)'
+    } else {
+        $nameFilterArg = ''
+    }
+
+    $launch = @"
+`$ErrorActionPreference='Continue'
+Import-Module '$modulePsd1' -Force
+$nameFilterLiteral
+`$realDriver = Get-Command Invoke-PackageInstall -Module MarkMichaelis.ScoopBucket
+
+# Strip the bundle's `Import-Module` preamble (already imported above)
+# and its terminal `Invoke-PackageInstall ...` line (we dispatch
+# ourselves below, with `-Name` filter applied when requested).
+`$bundleText = Get-Content -Raw -LiteralPath '$BundlePath'
+`$bundleStripped = `$bundleText -replace '(?ms)^\s*\`$scoopBucketPsd1\s*=.*?Import-Module\s+MarkMichaelis\.ScoopBucket\s+-Force\s*\}\s*', ''
+`$bundleStripped = `$bundleStripped -replace '(?m)^\s*Invoke-PackageInstall\s+-Packages\s+\`$Packages\s+-Bundle\s+''[^'']+''\s*`$', ''
+`$Packages = `$null
+. ([scriptblock]::Create(`$bundleStripped))
+if (`$null -eq `$Packages) {
+    Write-Error "Install-Package: bundle '$Bundle' did not assign `\`$Packages."
+    return
+}
+& `$realDriver -Packages `$Packages -Bundle '$Bundle' $nameFilterArg $flagsStr
+"@
+
+    $tmp = Join-Path $env:TEMP "ScoopBucket-install-$Bundle-$PID.ps1"
+    try {
+        Set-Content -Path $tmp -Value $launch -Encoding UTF8
+        & $pwsh -NoProfile -ExecutionPolicy Bypass -File $tmp
+    } finally {
+        Remove-Item -Path $tmp -ErrorAction Ignore
+    }
+}

--- a/module/MarkMichaelis.ScoopBucket/Public/Install-Package.ps1
+++ b/module/MarkMichaelis.ScoopBucket/Public/Install-Package.ps1
@@ -56,9 +56,41 @@ function Install-Package {
     if ($BucketPath) { $bundleArgs['BucketPath'] = $BucketPath }
     $bundles = Get-BundlePackages @bundleArgs
 
-    # Group every requested name by the bundle it lives in.
-    $byBundle = @{}
+    # Resolve the effective bucket directory once for manifest fallbacks
+    # below (case (c) — `scoop install <name>` for bare json manifests
+    # and imperative `.ps1` bundles).
+    $effectiveBucket = $BucketPath
+    if (-not $effectiveBucket) {
+        $effectiveBucket = Resolve-BucketPath -CallerScriptRoot $PSScriptRoot
+    }
+
+    # Index lookups: bundle name → bundle entry (only declarative bundles
+    # i.e. bundles with at least one [Package] captured by
+    # Get-BundlePackages); package name → bundle entry.
+    $bundleIndex = @{}
+    foreach ($b in $bundles) {
+        if ($b.Packages -and $b.Packages.Count -gt 0) {
+            $bundleIndex[$b.Bundle] = $b
+        }
+    }
+
+    # Classify each requested name into one of three dispatch buckets:
+    #   ByName    — Package.Name match within a declarative bundle.
+    #               Carries forward existing -Name-filtered dispatch.
+    #   FullBundle — Bundle name match (declarative bundle, install
+    #               every package it declares).
+    #   Manifest  — `<name>.json` exists but no [Package] match and no
+    #               declarative-bundle match. Falls through to
+    #               `scoop install <name>` so the manifest's
+    #               `installer.script` runs verbatim.
+    $byBundle      = @{}
+    $fullBundles   = New-Object System.Collections.Generic.List[object]
+    $manifestNames = New-Object System.Collections.Generic.List[string]
+
     foreach ($needed in $Name) {
+        # (a) Exact Package.Name match wins over bundle / manifest
+        # matches — most precise intent, and what the historical contract
+        # already implied.
         $found = $false
         foreach ($b in $bundles) {
             foreach ($p in $b.Packages) {
@@ -70,70 +102,66 @@ function Install-Package {
                             Names      = [System.Collections.Generic.List[string]]::new()
                         }
                     }
-                    $byBundle[$b.BundlePath].Names.Add($needed)
+                    $byBundle[$b.BundlePath].Names.Add($p.Name)
                     $found = $true
                     break
                 }
             }
             if ($found) { break }
         }
-        if (-not $found) {
-            throw "Install-Package: no bundle declares a package named '$needed'."
+        if ($found) { continue }
+
+        # (b) Bundle name match — install every package in the bundle.
+        $bundleMatch = $null
+        foreach ($key in $bundleIndex.Keys) {
+            if ($key -ieq $needed) { $bundleMatch = $bundleIndex[$key]; break }
         }
+        if ($bundleMatch) {
+            $fullBundles.Add($bundleMatch)
+            continue
+        }
+
+        # (c) Bare manifest fallback — any `<name>.json` we haven't
+        # otherwise classified, including imperative `.ps1` bundles
+        # (Chocolatey, Gemini, ClaudeExcel, PowerShell, ...) whose
+        # `Get-BundlePackages` Packages array is empty.
+        if ($effectiveBucket) {
+            $manifestPath = Join-Path $effectiveBucket ("$needed.json")
+            if (Test-Path $manifestPath) {
+                $manifestNames.Add($needed)
+                continue
+            }
+        }
+
+        throw "Install-Package: no bundle declares a package named '$needed' and no '$needed.json' manifest was found in the bucket."
     }
 
+    # --- Dispatch (a): Package.Name flow with -Name filter -----------------
     foreach ($entry in $byBundle.Values) {
+        Invoke-BundleScript -BundlePath $entry.BundlePath -Bundle $entry.Bundle `
+            -Names $entry.Names -DryRun:$DryRun -SkipCompletion:$SkipCompletion
+    }
+
+    # --- Dispatch (b): full-bundle install (no -Name filter) ---------------
+    foreach ($b in $fullBundles) {
         Write-Host ""
-        Write-Host "Install-Package: dispatching $($entry.Names -join ', ') via $($entry.Bundle)..."
-        # We dot-source the bundle but pre-override its
-        # Invoke-PackageInstall call by hooking before it runs.
-        # Simplest reliable approach: run the bundle's installer in a
-        # child runspace with the bucket's module imported and an
-        # injected -Name filter.
+        Write-Host "Install-Package: dispatching bundle '$($b.Bundle)' (all packages)..."
+        Invoke-BundleScript -BundlePath $b.BundlePath -Bundle $b.Bundle `
+            -DryRun:$DryRun -SkipCompletion:$SkipCompletion
+    }
 
-        $pwsh = (Get-Process -Id $PID).Path
-        if (-not $pwsh) { $pwsh = 'pwsh' }
-        $modulePsd1 = Join-Path (Split-Path -Parent (Split-Path -Parent $PSScriptRoot)) 'MarkMichaelis.ScoopBucket\MarkMichaelis.ScoopBucket.psd1'
-        $namesJson = ($entry.Names | ConvertTo-Json -Compress)
-        $flags = @()
-        if ($DryRun)         { $flags += '-DryRun' }
-        if ($SkipCompletion) { $flags += '-SkipCompletion' }
-        $flagsStr = $flags -join ' '
-
-        $launch = @"
-`$ErrorActionPreference='Continue'
-Import-Module '$modulePsd1' -Force
-`$names = '$namesJson' | ConvertFrom-Json
-`$realDriver = Get-Command Invoke-PackageInstall -Module MarkMichaelis.ScoopBucket
-
-# We can't simply `& '$bundlePath'` and intercept its trailing
-# `Invoke-PackageInstall` call: the bundle's first line re-imports
-# the module, which replaces our shim in the global function table
-# with the module's exported version, defeating any `-Name` filter
-# we tried to inject.
-#
-# Instead, read the bundle text, strip its top-level `Import-Module`
-# (we already imported the module above) and its terminal
-# `Invoke-PackageInstall ...` line (we'll call the real driver
-# ourselves with the filter applied), execute the remainder so
-# `\`$Packages` becomes available, then dispatch with our filter.
-`$bundleText = Get-Content -Raw -LiteralPath '$($entry.BundlePath)'
-`$bundleStripped = `$bundleText -replace '(?ms)^\s*\`$scoopBucketPsd1\s*=.*?Import-Module\s+MarkMichaelis\.ScoopBucket\s+-Force\s*\}\s*', ''
-`$bundleStripped = `$bundleStripped -replace '(?m)^\s*Invoke-PackageInstall\s+-Packages\s+\`$Packages\s+-Bundle\s+''[^'']+''\s*`$', ''
-`$Packages = `$null
-. ([scriptblock]::Create(`$bundleStripped))
-if (`$null -eq `$Packages) {
-    Write-Error "Install-Package: bundle '$($entry.Bundle)' did not assign `\`$Packages."
-    return
-}
-& `$realDriver -Packages `$Packages -Bundle '$($entry.Bundle)' -Name @(`$names) $flagsStr
-"@
-        $tmp = Join-Path $env:TEMP "ScoopBucket-install-$($entry.Bundle)-$PID.ps1"
-        try {
-            Set-Content -Path $tmp -Value $launch -Encoding UTF8
-            & $pwsh -NoProfile -ExecutionPolicy Bypass -File $tmp
-        } finally {
-            Remove-Item -Path $tmp -ErrorAction Ignore
+    # --- Dispatch (c): scoop install fallback for bare manifests -----------
+    foreach ($n in $manifestNames) {
+        Write-Host ""
+        Write-Host "Install-Package: dispatching manifest '$n' via scoop install (no declarative [Package] match)..."
+        if ($DryRun) {
+            Write-Host "  [DryRun] scoop install $n"
+            continue
         }
+        # Delegate to scoop. We pass the bare name (assumes the
+        # MarkMichaelis bucket has been added — see
+        # `Install-Package AddMarkMichaelisScoopBucket`); scoop will
+        # resolve and run the manifest's installer.script.
+        & scoop install $n
     }
 }


### PR DESCRIPTION
Closes #73 follow-up (and ongoing).

Make every installable artefact in this bucket reachable by `Install-Package <Tab>` and dispatchable by `Install-Package <name>`.

### What changes for the user
- `Install-Package <Tab>` now lists, in addition to per-package names: declarative bundle names (`OSBasePackages`, `DeveloperBasePackages`, `ClientBasePackages`, `MicrosoftOffice365`, `AIAgents`, `Aspire`, `ChatGPT`, `PSCompletions`, ...) and bare-json manifest names (`Codex`, `dotnet`, `GeminiCli`, `Claude`, `ClaudeCode`, `AdobeLightroomClassic`, `Chocolatey`, `Gemini`, `ClaudeExcel`, `PowerShell`, `WSL-Ubuntu-*`, `VisualStudio2026Enterprise`, ...).
- `Install-Package <bundleName>` runs the entire bundle (no -Name filter).
- `Install-Package <bareManifest>` delegates to `scoop install <name>` so the manifest's installer.script runs verbatim.

### Implementation
- `Get-PackageNameSuggestion` returns union of `[Package].Name` regex matches and `bucket/<name>.json` basenames; cache key now folds in `.json` mtimes too.
- `Install-Package` gains a 3-case dispatch (Package.Name -> existing -Name flow; bundle -> full-bundle install; bare manifest -> `scoop install`).
- Bundle-launch logic factored into new private `Invoke-BundleScript.ps1` shared by both dispatch paths.

### Tests (Light)
- `PackageNameCompletion.Tests.ps1` asserts bundle + bare-manifest names appear in completer output against the real bucket.
- `InstallPackageFilter.Tests.ps1` adds: bundle-name dispatch installs every package in the bundle; bare-manifest dispatch logs the scoop-install path under -DryRun; error path throws with a helpful message.

Local Light suite: green.