### PR TITLE
fix(completion): repair PSCompletions-backed CLIs after-the-fact

### DIFF
--- a/bucket/PSCompletions.json
+++ b/bucket/PSCompletions.json
@@ -1,6 +1,6 @@
 {
     "$schema": "https://raw.githubusercontent.com/lukesampson/scoop/master/schema.json",
-    "version": "1.01.000",
+    "version": "1.02.000",
     "url": [
         "https://raw.githubusercontent.com/MarkMichaelis/ScoopBucket/master/bucket/PSCompletions.ps1"
     ],

--- a/bucket/PSCompletions.ps1
+++ b/bucket/PSCompletions.ps1
@@ -22,6 +22,16 @@ $Packages = [Package[]]@(
         VerifyScript        = {
             [bool](Get-Module -ListAvailable -Name PSCompletions)
         }
+        # Once PSCompletions is in place, retroactively register
+        # sentinel blocks for any CLI that was installed BEFORE
+        # PSCompletions existed (the `bw <Tab>` repair scenario from #73).
+        PostInstallScript   = {
+            try {
+                Update-PackageCompletion | Out-Null
+            } catch {
+                Write-Warning "PSCompletions PostInstallScript: Update-PackageCompletion failed: $($_.Exception.Message)"
+            }
+        }
     }
 )
 

--- a/bucket/UpdatePackageCompletion.Tests.ps1
+++ b/bucket/UpdatePackageCompletion.Tests.ps1
@@ -1,0 +1,165 @@
+#requires -Version 7.0
+#requires -Modules @{ ModuleName = 'Pester'; ModuleVersion = '5.0.0' }
+
+# Tests for Update-PackageCompletion — the post-PSCompletions-install
+# repair cmdlet that rewrites sentinel blocks for already-installed
+# CLIs whose Completion mode is 'pscompletions' (or 'auto' without a
+# NativeCommandScript). Covers the bw <Tab> repair scenario from #73
+# follow-up.
+
+BeforeAll {
+    $script:repoRoot   = Split-Path -Parent $PSScriptRoot
+    $script:moduleRoot = Join-Path $script:repoRoot 'module\MarkMichaelis.ScoopBucket'
+    $script:psd1       = Join-Path $script:moduleRoot 'MarkMichaelis.ScoopBucket.psd1'
+
+    Import-Module $script:psd1 -Force
+
+    # Throwaway bucket with one declarative bundle that exercises every
+    # eligible / non-eligible Completion shape:
+    #   pscompletions-bw       — pscompletions mode (eligible)
+    #   pscompletions-other    — pscompletions mode but CLI NOT on PATH (skipped)
+    #   auto-no-native         — auto mode, no NativeCommandScript (eligible)
+    #   auto-with-native       — auto mode, with NativeCommandScript  (skipped — repair can't rebuild native)
+    #   none-mode              — Completion='none' (ignored entirely)
+    #   no-clicommands         — Completion='auto' but CliCommands=@() (ignored)
+    $script:tmpBucket = Join-Path ([System.IO.Path]::GetTempPath()) ("ScoopBucket-update-completion-$([guid]::NewGuid().ToString('N'))")
+    New-Item -ItemType Directory -Path $script:tmpBucket | Out-Null
+
+    # Pick a CLI that's guaranteed to be on PATH on every dev / CI Win
+    # box for the eligible cases ('cmd.exe' resolves on all Windows
+    # hosts; 'pwsh' resolves wherever Pester 7 runs).
+    $script:onPathCli  = 'pwsh'
+    $script:offPathCli = 'definitely-not-a-real-cli-' + [guid]::NewGuid().ToString('N').Substring(0,8)
+
+    $bundleText = @"
+`$scoopBucketPsd1 = '$($script:psd1 -replace "'","''")'
+if (Test-Path `$scoopBucketPsd1) { Import-Module `$scoopBucketPsd1 -Force } else { Import-Module MarkMichaelis.ScoopBucket -Force }
+
+`$Packages = [Package[]]@(
+    [Package]@{
+        Name        = 'PscompletionsBw'
+        Installer   = 'winget'
+        Id          = 'Test.PscompletionsBw'
+        CliCommands = @('$($script:onPathCli)')
+        Completion  = 'pscompletions'
+    }
+    [Package]@{
+        Name        = 'PscompletionsOffPath'
+        Installer   = 'winget'
+        Id          = 'Test.PscompletionsOffPath'
+        CliCommands = @('$($script:offPathCli)')
+        Completion  = 'pscompletions'
+    }
+    [Package]@{
+        Name        = 'AutoNoNative'
+        Installer   = 'winget'
+        Id          = 'Test.AutoNoNative'
+        CliCommands = @('$($script:onPathCli)-twin')
+        Completion  = 'auto'
+    }
+    [Package]@{
+        Name                = 'AutoWithNative'
+        Installer           = 'winget'
+        Id                  = 'Test.AutoWithNative'
+        CliCommands         = @('$($script:onPathCli)-native')
+        Completion          = 'auto'
+        NativeCommandScript = { 'completion-source' }
+    }
+    [Package]@{
+        Name        = 'NoneMode'
+        Installer   = 'winget'
+        Id          = 'Test.NoneMode'
+        CliCommands = @('$($script:onPathCli)-none')
+        Completion  = 'none'
+    }
+    [Package]@{
+        Name      = 'NoCliCommands'
+        Installer = 'winget'
+        Id        = 'Test.NoCliCommands'
+    }
+)
+
+Invoke-PackageInstall -Packages `$Packages -Bundle 'UpdateCompletionBundle'
+"@
+    Set-Content -Path (Join-Path $script:tmpBucket 'UpdateCompletionBundle.ps1') -Value $bundleText -Encoding UTF8
+
+    # Make AutoNoNative's CLI resolve via Get-Command by dropping a shim
+    # PS1 into a folder we then prepend to $env:PATH for the duration
+    # of this Describe block.
+    $script:shimDir = Join-Path $script:tmpBucket '_shims'
+    New-Item -ItemType Directory -Path $script:shimDir | Out-Null
+    foreach ($shimName in @("$($script:onPathCli)-twin.ps1", "$($script:onPathCli)-native.ps1", "$($script:onPathCli)-none.ps1")) {
+        Set-Content -Path (Join-Path $script:shimDir $shimName) -Value '# stub' -Encoding UTF8
+    }
+    $script:savedPath = $env:PATH
+    $env:PATH = "$script:shimDir;$env:PATH"
+
+    # Per-test fresh profile so block-already-exists state is isolated.
+    $script:profilePath = Join-Path $script:tmpBucket 'profile.ps1'
+}
+
+AfterAll {
+    if ($script:savedPath) { $env:PATH = $script:savedPath }
+    if ($script:tmpBucket -and (Test-Path $script:tmpBucket)) {
+        Remove-Item -LiteralPath $script:tmpBucket -Recurse -Force -ErrorAction Ignore
+    }
+}
+
+Describe 'Update-PackageCompletion eligibility classification' -Tag 'Light' {
+    BeforeEach {
+        if (Test-Path $script:profilePath) { Remove-Item -LiteralPath $script:profilePath -Force }
+    }
+
+    It 'skips pscompletions packages whose CLI is not on PATH' {
+        $results = Update-PackageCompletion -BucketPath $script:tmpBucket `
+            -ProfilePath $script:profilePath -WhatIf
+        $offPath = $results | Where-Object Cli -EQ $script:offPathCli
+        $offPath | Should -Not -BeNullOrEmpty
+        $offPath.Action | Should -Be 'Skipped'
+        $offPath.Reason | Should -Match 'not on PATH'
+    }
+
+    It "skips Completion='auto' packages with a NativeCommandScript" {
+        $results = Update-PackageCompletion -BucketPath $script:tmpBucket `
+            -ProfilePath $script:profilePath -WhatIf
+        $native = $results | Where-Object Cli -EQ "$($script:onPathCli)-native"
+        $native | Should -Not -BeNullOrEmpty
+        $native.Action | Should -Be 'Skipped'
+        $native.Reason | Should -Match 'native scriptblock'
+    }
+
+    It "ignores Completion='none' and packages without CliCommands" {
+        $results = Update-PackageCompletion -BucketPath $script:tmpBucket `
+            -ProfilePath $script:profilePath -WhatIf
+        ($results | Where-Object Cli -EQ "$($script:onPathCli)-none") | Should -BeNullOrEmpty
+        ($results | Where-Object Package -EQ 'NoCliCommands')          | Should -BeNullOrEmpty
+    }
+
+    It 'reports WhatIf for eligible CLIs (pscompletions + auto-no-native) when -WhatIf supplied' {
+        $results = Update-PackageCompletion -BucketPath $script:tmpBucket `
+            -ProfilePath $script:profilePath -WhatIf
+        $bw = $results | Where-Object Cli -EQ $script:onPathCli
+        $bw | Should -Not -BeNullOrEmpty
+        $bw.Action | Should -Be 'WhatIf'
+        $bw.Mode   | Should -Be 'pscompletions'
+
+        $twin = $results | Where-Object Cli -EQ "$($script:onPathCli)-twin"
+        $twin | Should -Not -BeNullOrEmpty
+        $twin.Action | Should -Be 'WhatIf'
+        # auto-mode without NativeCommandScript collapses to pscompletions
+        # because that's the only registration path we can safely repair.
+        $twin.Mode | Should -Be 'pscompletions'
+    }
+
+    It "preserves existing sentinel blocks unless -Force is passed" {
+        # Pre-seed the profile with a block for the eligible CLI.
+        $existing = "# ScoopBucket:CliCompletion:$($script:onPathCli):BEGIN v1`r`n# (existing)`r`n# ScoopBucket:CliCompletion:$($script:onPathCli):END`r`n"
+        Set-Content -Path $script:profilePath -Value $existing -Encoding UTF8
+
+        $results = Update-PackageCompletion -BucketPath $script:tmpBucket `
+            -ProfilePath $script:profilePath -WhatIf
+        $bw = $results | Where-Object Cli -EQ $script:onPathCli
+        $bw.Action | Should -Be 'Preserved'
+        $bw.Reason | Should -Match 'pass -Force'
+    }
+}

--- a/module/MarkMichaelis.ScoopBucket/MarkMichaelis.ScoopBucket.psd1
+++ b/module/MarkMichaelis.ScoopBucket/MarkMichaelis.ScoopBucket.psd1
@@ -23,6 +23,7 @@
         'Install-Package',
         'Get-Package',
         'Invoke-PackageInstall',
+        'Update-PackageCompletion',
         'Add-MachinePath',
         'Update-PathFromRegistry',
         'Test-IsElevated',

--- a/module/MarkMichaelis.ScoopBucket/Private/Get-BundlePackages.ps1
+++ b/module/MarkMichaelis.ScoopBucket/Private/Get-BundlePackages.ps1
@@ -123,7 +123,7 @@ try {
 
         $tmp = Join-Path $env:TEMP "ScoopBucket-getbundle-$bundleName-$PID.ps1"
         try {
-            Set-Content -Path $tmp -Value $probe -Encoding UTF8
+            Set-Content -Path $tmp -Value $probe -Encoding UTF8 -WhatIf:$false
             $pwsh = (Get-Process -Id $PID).Path
             if (-not $pwsh) { $pwsh = 'pwsh' }
             $output = & $pwsh -NoProfile -NonInteractive -ExecutionPolicy Bypass -File $tmp 2>$null

--- a/module/MarkMichaelis.ScoopBucket/Private/Invoke-BundleScript.ps1
+++ b/module/MarkMichaelis.ScoopBucket/Private/Invoke-BundleScript.ps1
@@ -30,7 +30,7 @@ function Invoke-BundleScript {
     .PARAMETER Names
         Optional -Name filter. When omitted the whole bundle installs.
 
-    .PARAMETER DryRun, SkipCompletion
+    .PARAMETER DryRun, SkipCompletion, ForceCompletion
         Passed through to `Invoke-PackageInstall`.
     #>
     [CmdletBinding()]
@@ -39,7 +39,8 @@ function Invoke-BundleScript {
         [Parameter(Mandatory)][string]$Bundle,
         [string[]]$Names,
         [switch]$DryRun,
-        [switch]$SkipCompletion
+        [switch]$SkipCompletion,
+        [switch]$ForceCompletion
     )
 
     if ($Names -and $Names.Count -gt 0) {
@@ -52,8 +53,9 @@ function Invoke-BundleScript {
     $modulePsd1 = Join-Path (Split-Path -Parent (Split-Path -Parent $PSScriptRoot)) 'MarkMichaelis.ScoopBucket\MarkMichaelis.ScoopBucket.psd1'
 
     $flags = @()
-    if ($DryRun)         { $flags += '-DryRun' }
-    if ($SkipCompletion) { $flags += '-SkipCompletion' }
+    if ($DryRun)          { $flags += '-DryRun' }
+    if ($SkipCompletion)  { $flags += '-SkipCompletion' }
+    if ($ForceCompletion) { $flags += '-ForceCompletion' }
     $flagsStr = $flags -join ' '
 
     $nameFilterLiteral = ''

--- a/module/MarkMichaelis.ScoopBucket/Public/Install-Package.ps1
+++ b/module/MarkMichaelis.ScoopBucket/Public/Install-Package.ps1
@@ -35,6 +35,13 @@ function Install-Package {
     .PARAMETER SkipCompletion
         Don't attempt completion registration.
 
+    .PARAMETER ForceCompletion
+        Re-register every CLI's tab-completion block even when a
+        sentinel block already exists in the AllUsersAllHosts profile.
+        Use this to repair completion for a CLI that was installed
+        before PSCompletions was available (the classic `bw <Tab>`
+        repair scenario).
+
     .PARAMETER BucketPath
         Override the auto-detected bucket directory.
 
@@ -49,6 +56,7 @@ function Install-Package {
         [Parameter(Mandatory, Position = 0)][string[]]$Name,
         [switch]$DryRun,
         [switch]$SkipCompletion,
+        [switch]$ForceCompletion,
         [string]$BucketPath
     )
 
@@ -139,7 +147,8 @@ function Install-Package {
     # --- Dispatch (a): Package.Name flow with -Name filter -----------------
     foreach ($entry in $byBundle.Values) {
         Invoke-BundleScript -BundlePath $entry.BundlePath -Bundle $entry.Bundle `
-            -Names $entry.Names -DryRun:$DryRun -SkipCompletion:$SkipCompletion
+            -Names $entry.Names -DryRun:$DryRun -SkipCompletion:$SkipCompletion `
+            -ForceCompletion:$ForceCompletion
     }
 
     # --- Dispatch (b): full-bundle install (no -Name filter) ---------------
@@ -147,7 +156,8 @@ function Install-Package {
         Write-Host ""
         Write-Host "Install-Package: dispatching bundle '$($b.Bundle)' (all packages)..."
         Invoke-BundleScript -BundlePath $b.BundlePath -Bundle $b.Bundle `
-            -DryRun:$DryRun -SkipCompletion:$SkipCompletion
+            -DryRun:$DryRun -SkipCompletion:$SkipCompletion `
+            -ForceCompletion:$ForceCompletion
     }
 
     # --- Dispatch (c): scoop install fallback for bare manifests -----------

--- a/module/MarkMichaelis.ScoopBucket/Public/Update-PackageCompletion.ps1
+++ b/module/MarkMichaelis.ScoopBucket/Public/Update-PackageCompletion.ps1
@@ -1,0 +1,168 @@
+function Update-PackageCompletion {
+    <#
+    .SYNOPSIS
+        Repair / refresh tab-completion sentinel blocks for every
+        Package in the bucket whose CliCommand is on PATH and whose
+        Completion mode requests PSCompletions-backed completion.
+
+    .DESCRIPTION
+        Solves the "I installed Bitwarden CLI, then installed
+        PSCompletions, but `bw <Tab>` still only completes files"
+        scenario.
+
+        The cause: when the CLI was originally installed, PSCompletions
+        was missing, so Register-PackageCompletion fell through to its
+        'Skipped' branch and never wrote a sentinel block. Installing
+        PSCompletions afterwards doesn't retroactively re-register the
+        already-installed CLIs.
+
+        Update-PackageCompletion walks every declarative bundle via
+        Get-BundlePackages, finds Packages whose Completion mode is
+        'pscompletions' (or 'auto' without a NativeCommandScript) and
+        whose CliCommands resolve via Get-Command, then calls
+        Register-PackageCompletion for each. Existing sentinel blocks
+        are preserved unless -Force is passed.
+
+        Called automatically by the PSCompletions bundle's
+        PostInstallScript so `Install-Package PSCompletions` heals
+        already-installed CLIs in one shot.
+
+    .PARAMETER BucketPath
+        Override the auto-detected bucket directory (forwarded to
+        Get-BundlePackages).
+
+    .PARAMETER Force
+        Re-register every eligible CLI even when a sentinel block
+        already exists. Without -Force, CLIs that already have a block
+        are left alone.
+
+    .PARAMETER ProfilePath
+        Test hook: read/write this file instead of
+        $PROFILE.AllUsersAllHosts. Bypasses elevation check.
+
+    .OUTPUTS
+        PSCustomObject[] — one record per (Cli, Package) candidate,
+        with Cli, Package, Bundle, Mode, Action (Registered | Preserved
+        | Skipped | WhatIf), Source (Native | PSCompletions | Skipped),
+        and Reason fields.
+    #>
+    [CmdletBinding(SupportsShouldProcess, ConfirmImpact = 'Medium')]
+    [OutputType([pscustomobject[]])]
+    param(
+        [string]$BucketPath,
+        [switch]$Force,
+        [string]$ProfilePath
+    )
+
+    $bundleArgs = @{}
+    if ($BucketPath) { $bundleArgs['BucketPath'] = $BucketPath }
+    $bundles = Get-BundlePackages @bundleArgs
+
+    # Resolve the profile we will read for "block already exists?"
+    # checks. When -ProfilePath supplied use it as-is; otherwise pull
+    # the AllUsersAllHosts profile path WITHOUT the elevation check
+    # — we only need to READ it here. Register-PackageCompletion will
+    # do its own elevation check when it tries to WRITE.
+    $profileTarget = $ProfilePath
+    if (-not $profileTarget) { $profileTarget = $PROFILE.AllUsersAllHosts }
+    $existingContent = ''
+    if ($profileTarget -and (Test-Path $profileTarget)) {
+        $raw = Get-Content -Path $profileTarget -Raw -Encoding UTF8 -ErrorAction SilentlyContinue
+        if ($null -ne $raw) { $existingContent = $raw }
+    }
+
+    $results = New-Object System.Collections.Generic.List[object]
+
+    foreach ($b in $bundles) {
+        foreach ($p in $b.Packages) {
+            if (-not $p.CliCommands -or $p.CliCommands.Count -eq 0) { continue }
+            $mode = "$($p.Completion)"
+            if ([string]::IsNullOrWhiteSpace($mode)) { $mode = 'auto' }
+            if ($mode -notin @('pscompletions','auto')) { continue }
+
+            # 'auto' with a native scriptblock is best-handled by the
+            # original install path which has the actual native command.
+            # We can only safely repair pscompletions-mode CLIs here.
+            $effectiveMode = $mode
+            if ($mode -eq 'auto') {
+                if ($p.HasNativeCommandScript) {
+                    foreach ($cli in $p.CliCommands) {
+                        $results.Add([pscustomobject]@{
+                            Cli = $cli; Package = $p.Name; Bundle = $b.Bundle
+                            Mode = $mode; Action = 'Skipped'; Source = 'Skipped'
+                            Reason = "Package declares Completion='auto' with a native scriptblock; re-run Install-Package -ForceCompletion to refresh native completion."
+                        })
+                    }
+                    continue
+                }
+                $effectiveMode = 'pscompletions'
+            }
+
+            foreach ($cli in $p.CliCommands) {
+                if (-not (Get-Command $cli -ErrorAction SilentlyContinue)) {
+                    $results.Add([pscustomobject]@{
+                        Cli = $cli; Package = $p.Name; Bundle = $b.Bundle
+                        Mode = $effectiveMode; Action = 'Skipped'; Source = 'Skipped'
+                        Reason = "CLI '$cli' not on PATH."
+                    })
+                    continue
+                }
+
+                $blockPattern = "(?ms)^\# ScoopBucket:CliCompletion:$([regex]::Escape($cli))`:BEGIN \w+"
+                $alreadyHas   = [regex]::IsMatch($existingContent, $blockPattern)
+                if ($alreadyHas -and -not $Force) {
+                    $results.Add([pscustomobject]@{
+                        Cli = $cli; Package = $p.Name; Bundle = $b.Bundle
+                        Mode = $effectiveMode; Action = 'Preserved'; Source = 'Existing'
+                        Reason = 'Sentinel block already in profile; pass -Force to refresh.'
+                    })
+                    continue
+                }
+
+                $action = "Register PSCompletions block for '$cli'"
+                if (-not $PSCmdlet.ShouldProcess($profileTarget, $action)) {
+                    $results.Add([pscustomobject]@{
+                        Cli = $cli; Package = $p.Name; Bundle = $b.Bundle
+                        Mode = $effectiveMode; Action = 'WhatIf'; Source = 'Skipped'
+                        Reason = '-WhatIf or -Confirm declined.'
+                    })
+                    continue
+                }
+
+                $registerArgs = @{
+                    Cli   = $cli
+                    Mode  = $effectiveMode
+                    Force = $true   # Always overwrite during repair.
+                }
+                if ($ProfilePath) { $registerArgs['ProfilePath'] = $ProfilePath }
+
+                try {
+                    $r = Register-PackageCompletion @registerArgs
+                    $results.Add([pscustomobject]@{
+                        Cli = $cli; Package = $p.Name; Bundle = $b.Bundle
+                        Mode = $effectiveMode
+                        Action = $(if ($r.Source -eq 'Skipped') { 'Skipped' } else { 'Registered' })
+                        Source = $r.Source
+                        Reason = $r.Reason
+                    })
+                } catch {
+                    $results.Add([pscustomobject]@{
+                        Cli = $cli; Package = $p.Name; Bundle = $b.Bundle
+                        Mode = $effectiveMode; Action = 'Skipped'; Source = 'Skipped'
+                        Reason = "Register-PackageCompletion threw: $($_.Exception.Message)"
+                    })
+                }
+            }
+        }
+    }
+
+    $arr = $results.ToArray()
+    $byAction = $arr | Group-Object Action | ForEach-Object { "$($_.Name)=$($_.Count)" }
+    if ($byAction) {
+        Write-Host "Update-PackageCompletion: $($byAction -join ', ')"
+    } else {
+        Write-Host 'Update-PackageCompletion: no eligible CLIs found.'
+    }
+
+    return ,$arr
+}


### PR DESCRIPTION
## Problem

Installed Bitwarden CLI first, then PSCompletions — but `bw <Tab>` still only completes files.

**Cause:** when `bw` was installed, PSCompletions wasn't available, so `Register-PackageCompletion` hit its 'Skipped' branch (no native completion, no catalog fallback) and never wrote a sentinel block to the AllUsersAllHosts profile. Installing PSCompletions afterwards doesn't retroactively re-register already-installed CLIs.

## Fix (three layers)

1. **`Install-Package -ForceCompletion`** — manual override on a single package. Useful for the `Completion='auto'`+NativeCommandScript cases (e.g. `gh`) where native output regresses upstream and the sentinel block in the profile is stale.
2. **`Update-PackageCompletion`** (new public cmdlet) — sweeps the bucket, finds Packages with Completion in ('pscompletions','auto') whose CliCommands are on PATH, and re-registers their PSCompletions blocks. Preserves existing blocks unless `-Force`; deliberately skips `Completion='auto'` + NativeCommandScript packages (only the install path has the actual scriptblock).
3. **PSCompletions PostInstallScript** — wires (2) into `Install-Package PSCompletions` so installing PSCompletions itself heals every already-installed CLI in one shot. This is the path the user's flow now lands in: `Install-Package PSCompletions` after the fact retroactively registers `bw`.

Layer (3) calls (2). Layer (2) is exported so users can re-sweep without reinstalling the module (e.g. after a `psc update` brings a new CLI into the catalog). Layer (1) handles the case (2) can't (native scriptblocks lost across child processes).

## Other changes

- `Get-BundlePackages`: probe `Set-Content` now uses `-WhatIf:$false` so it still writes the temp probe file when the caller runs under `-WhatIf` (regression exposed by the new tests).
- `bucket/PSCompletions.json` bumped 1.01.000 -> 1.02.000 for the PostInstallScript addition.

## Tests (Light)

- New `bucket/UpdatePackageCompletion.Tests.ps1` (5 tests): pscompletions-but-off-path skipped; auto+native skipped; none/no-clicommands ignored; eligible CLIs report WhatIf; existing sentinel blocks preserved.
- Full Light suite locally: **116 pass / 0 fail / 3 skipped**.

## Manual repair

For users hitting this today:
```
Install-Package PSCompletions    # heals everything automatically now
# or, surgically:
Install-Package 'Bitwarden CLI' -ForceCompletion
```
