### PR TITLE
fix(completion): ship real end-to-end completion tests and native bw/gcloud completers

### DIFF
--- a/.github/scripts/Update-PSCompletionsCatalog.ps1
+++ b/.github/scripts/Update-PSCompletionsCatalog.ps1
@@ -1,0 +1,40 @@
+#requires -Version 7.0
+<#
+.SYNOPSIS
+    Refresh bucket/PSCompletionsCatalog.json from the upstream
+    abgox/PSCompletions completions/ directory.
+
+.DESCRIPTION
+    The CompletionContract Light test (Bundles.Tests.ps1) cross-checks
+    every Package declared with Completion='pscompletions' against the
+    cached list of available PSCompletions catalog entries. Run this
+    script whenever the upstream catalog changes (or on a schedule) to
+    refresh the snapshot.
+
+.EXAMPLE
+    pwsh -File .github/scripts/Update-PSCompletionsCatalog.ps1
+#>
+[CmdletBinding()]
+param(
+    [string]$OutPath = (Join-Path (Split-Path -Parent (Split-Path -Parent $PSScriptRoot)) 'bucket\PSCompletionsCatalog.json')
+)
+
+$ErrorActionPreference = 'Stop'
+
+$apiUrl = 'https://api.github.com/repos/abgox/PSCompletions/contents/completions'
+Write-Host "Fetching $apiUrl ..."
+$headers = @{ 'User-Agent' = 'ScoopBucket-Update-PSCompletionsCatalog' }
+if ($env:GITHUB_TOKEN) { $headers['Authorization'] = "token $env:GITHUB_TOKEN" }
+
+$entries = Invoke-RestMethod -Uri $apiUrl -Headers $headers
+$names = @($entries | Where-Object { $_.type -eq 'dir' } | Select-Object -ExpandProperty name | Sort-Object)
+
+$payload = [ordered]@{
+    Source         = $apiUrl
+    RefreshScript  = '.github/scripts/Update-PSCompletionsCatalog.ps1'
+    Completions    = $names
+}
+
+$json = ($payload | ConvertTo-Json -Depth 4)
+Set-Content -Path $OutPath -Value $json -Encoding UTF8
+Write-Host "Wrote $($names.Count) entries to $OutPath"

--- a/bucket/AIAgents.json
+++ b/bucket/AIAgents.json
@@ -1,6 +1,6 @@
 {
     "$schema": "https://raw.githubusercontent.com/lukesampson/scoop/master/schema.json",
-    "version": "1.14.000",
+    "version": "1.15.000",
     "url": [
         "https://raw.githubusercontent.com/MarkMichaelis/ScoopBucket/master/bucket/AIAgents.ps1"
     ],

--- a/bucket/AIAgents.ps1
+++ b/bucket/AIAgents.ps1
@@ -85,9 +85,8 @@ $Packages = [Package[]]@(
         Installer   = 'scoop'
         Id          = 'MarkMichaelis/GitHubCopilotCli'
         CliCommands = @('copilot')
-        Completion  = 'pscompletions'
         DependsOn   = @('Node.js')
-        Notes       = '`copilot completion` only supports bash/zsh/fish; no native PowerShell completion command. PSCompletions fallback (#73).'
+        Notes       = '`copilot completion` only supports bash/zsh/fish; not in PSCompletions catalog. No PS completion shipped — track upstream (#73).'
     }
 )
 

--- a/bucket/Bundles.Tests.ps1
+++ b/bucket/Bundles.Tests.ps1
@@ -123,6 +123,29 @@ Describe 'Declarative bundles (data-driven)' -Tag 'Light','Bundle' {
         }
     }
 
+    It '<Pkg.Name> (<Bundle>) declares ExpectedCompletions for every CLI when Completion != none' -ForEach $script:pkgCases {
+        if ($Pkg.Completion -in @('native','pscompletions','auto')) {
+            $Pkg.ExpectedCompletions | Should -Not -BeNullOrEmpty
+            foreach ($cli in @($Pkg.CliCommands)) {
+                $Pkg.ExpectedCompletions.ContainsKey($cli) | Should -BeTrue -Because "every CliCommands entry needs an ExpectedCompletions entry so completion can be verified end-to-end"
+                @($Pkg.ExpectedCompletions[$cli]).Count | Should -BeGreaterThan 0
+            }
+        }
+    }
+
+    It "<Pkg.Name> (<Bundle>) Completion='pscompletions' CLI is in upstream PSCompletions catalog" -ForEach $script:pkgCases {
+        if ($Pkg.Completion -ne 'pscompletions') { return }
+        $catalogPath = Join-Path $PSScriptRoot 'PSCompletionsCatalog.json'
+        if (-not (Test-Path $catalogPath)) {
+            Set-ItResult -Skipped -Because "PSCompletionsCatalog.json snapshot missing; run .github/scripts/Update-PSCompletionsCatalog.ps1"
+            return
+        }
+        $catalog = @((Get-Content -Raw -Path $catalogPath | ConvertFrom-Json).Completions)
+        foreach ($cli in @($Pkg.CliCommands)) {
+            $catalog | Should -Contain $cli -Because "Completion='pscompletions' requires '$cli' to exist in https://github.com/abgox/PSCompletions/tree/main/completions; otherwise switch to Completion='auto' with a NativeCommandScript"
+        }
+    }
+
     It '<Pkg.Name> (<Bundle>) declares plausible short CLI names' -ForEach $script:pkgCases {
         foreach ($cli in @($Pkg.CliCommands)) {
             $cli | Should -Match '^[A-Za-z0-9._\-]+$' -Because "CliCommands must be bare command names (no paths/quotes)"

--- a/bucket/ClientBasePackages.json
+++ b/bucket/ClientBasePackages.json
@@ -1,6 +1,6 @@
 {
     "$schema": "https://raw.githubusercontent.com/lukesampson/scoop/master/schema.json",
-    "version": "1.11.000",
+    "version": "1.12.000",
     "url": [
         "https://raw.githubusercontent.com/MarkMichaelis/ScoopBucket/master/bucket/ClientBasePackages.ps1"
     ],

--- a/bucket/ClientBasePackages.ps1
+++ b/bucket/ClientBasePackages.ps1
@@ -7,7 +7,7 @@ if (Test-Path $scoopBucketPsd1) { Import-Module $scoopBucketPsd1 -Force } else {
 #   #9/#11            Snagit / Todoist via Microsoft Store (winget --source msstore)
 #   #13/#46           DbxCli delisted from choco; install via local bucket manifest
 #   #27               foxitreader choco package times out; use winget
-#   #73               bw completion only supports zsh -> PSCompletions fallback
+#   #73               bw / gcloud have no PSCompletions catalog entry — ship our own native completer
 
 $Packages = [Package[]]@(
     [Package]@{ Name = 'exiftool';         Installer = 'choco';  Id = 'exiftool';                                CliCommands = @('exiftool') }
@@ -31,9 +31,25 @@ $Packages = [Package[]]@(
         Installer   = 'winget'
         Id          = 'Bitwarden.CLI'
         CliCommands = @('bw')
-        Completion  = 'pscompletions'
+        Completion  = 'auto'
         DependsOn   = @('Bitwarden')
-        Notes       = '`bw completion` only supports zsh; no native PS completion. PSCompletions fallback (#73).'
+        Notes       = '`bw completion` only supports zsh and PSCompletions has no `bw` entry; ship a hand-curated top-level subcommand completer (#73).'
+        ExpectedCompletions = @{ bw = @('login','logout','sync','list','unlock','status') }
+        NativeCommandScript = {
+            @"
+Register-ArgumentCompleter -Native -CommandName bw -ScriptBlock {
+    param(`$wordToComplete, `$commandAst, `$cursorPosition)
+    `$cmds = @(
+        'completion','config','create','delete','device-approval','edit','encode',
+        'export','generate','get','help','import','list','lock','login','logout',
+        'restore','send','serve','share','status','sync','unlock','update'
+    )
+    `$cmds | Where-Object { `$_ -like "`$wordToComplete*" } | ForEach-Object {
+        [System.Management.Automation.CompletionResult]::new(`$_, `$_, 'ParameterValue', `$_)
+    }
+}
+"@
+        }
     }
     [Package]@{ Name = 'calibre';          Installer = 'winget'; Id = 'calibre.calibre' }
     [Package]@{ Name = 'SoX';              Installer = 'winget'; Id = 'ChrisBagwell.SoX';      CliCommands = @('sox') }

--- a/bucket/CompletionEndToEnd.Tests.ps1
+++ b/bucket/CompletionEndToEnd.Tests.ps1
@@ -1,0 +1,86 @@
+#requires -Version 7.0
+#requires -Modules @{ ModuleName = 'Pester'; ModuleVersion = '5.0.0' }
+
+<#
+.SYNOPSIS
+    End-to-end (no mocks) tab-completion tests: for every Package
+    declaring Completion != 'none', press Tab after `<cli> ` in a fresh
+    pwsh runspace and verify the manifest-declared ExpectedCompletions
+    actually appear.
+
+.DESCRIPTION
+    Heavy-tag suite. Assumes the CLI under test is already installed on
+    PATH (i.e. validate-installs.yml has run Install-Package first) and
+    the AllUsersAllHosts profile contains the sentinel block written by
+    Register-PackageCompletion. Each row spawns `pwsh -NoProfile`, dot-
+    sources the profile, then calls [CommandCompletion]::CompleteInput
+    so PowerShell's real completion engine produces the candidate list.
+    No mocks of psc, Register-ArgumentCompleter, or anything else —
+    this is the spec for "Tab actually works."
+#>
+
+BeforeAll {
+    $script:moduleManifest = Resolve-Path (Join-Path (Split-Path -Parent $PSScriptRoot) 'module\MarkMichaelis.ScoopBucket\MarkMichaelis.ScoopBucket.psd1')
+    Import-Module $script:moduleManifest -Force
+
+    $script:allPkgs = @(Get-Package -BucketPath $PSScriptRoot)
+    $script:completionCases = @(
+        foreach ($p in $script:allPkgs) {
+            if ($p.Completion -eq 'none') { continue }
+            foreach ($cli in @($p.CliCommands)) {
+                @{
+                    Bundle   = $p.Bundle
+                    Package  = $p.Name
+                    Cli      = $cli
+                    Expected = @($p.ExpectedCompletions[$cli])
+                }
+            }
+        }
+    )
+
+    $script:profilePath = $PROFILE.AllUsersAllHosts
+    $script:profileExists = $script:profilePath -and (Test-Path $script:profilePath)
+}
+
+Describe 'Completion end-to-end (real Tab, no mocks)' -Tag 'Heavy','Completion' {
+
+    It '<Package>/<Cli> sentinel block is present in AllUsersAllHosts profile' -ForEach $script:completionCases {
+        if (-not $script:profileExists) {
+            Set-ItResult -Skipped -Because "AllUsersAllHosts profile missing at $script:profilePath; run Install-Package first."
+            return
+        }
+        $raw = Get-Content -Raw -Path $script:profilePath
+        $raw | Should -Match "ScoopBucket:CliCompletion:$([regex]::Escape($Cli)):BEGIN"
+    }
+
+    It '<Package>/<Cli> TabExpansion2 returns expected subcommands' -ForEach $script:completionCases {
+        if (-not $script:profileExists) {
+            Set-ItResult -Skipped -Because "AllUsersAllHosts profile missing; nothing to load."
+            return
+        }
+        if (-not (Get-Command $Cli -ErrorAction SilentlyContinue)) {
+            Set-ItResult -Skipped -Because "CLI '$Cli' not on PATH on this host; Install-Package may have been skipped."
+            return
+        }
+
+        $script = @"
+`$ErrorActionPreference = 'Stop'
+. '$($script:profilePath -replace "'","''")'
+`$line = '$Cli '
+`$result = [System.Management.Automation.CommandCompletion]::CompleteInput(`$line, `$line.Length, `$null)
+`$result.CompletionMatches | ForEach-Object { `$_.CompletionText }
+"@
+        $tmp = New-TemporaryFile
+        try {
+            Set-Content -Path $tmp -Value $script -Encoding UTF8
+            $out = & pwsh -NoProfile -NoLogo -File $tmp 2>$null
+        } finally {
+            Remove-Item -Path $tmp -ErrorAction Ignore
+        }
+        $completions = @($out | Where-Object { $_ })
+
+        foreach ($e in $Expected) {
+            $completions | Should -Contain $e -Because "TabExpansion2 for '$Cli ' must return '$e' per the ExpectedCompletions contract; got: $($completions -join ', ')"
+        }
+    }
+}

--- a/bucket/DeveloperBasePackages.json
+++ b/bucket/DeveloperBasePackages.json
@@ -1,6 +1,6 @@
 {
     "$schema": "https://raw.githubusercontent.com/lukesampson/scoop/master/schema.json",
-    "version": "1.19.001",
+    "version": "1.20.000",
     "url": [
         "https://raw.githubusercontent.com/MarkMichaelis/ScoopBucket/master/bucket/DeveloperBasePackages.ps1"
     ],

--- a/bucket/DeveloperBasePackages.ps1
+++ b/bucket/DeveloperBasePackages.ps1
@@ -38,8 +38,7 @@ $Packages = [Package[]]@(
         Installer   = 'winget'
         Id          = 'GitHub.Copilot'
         CliCommands = @('copilot')
-        Completion  = 'pscompletions'
-        Notes       = '`copilot completion` only supports bash/zsh/fish; no native PowerShell completion command. Fall back to PSCompletions. See #73.'
+        Notes       = '`copilot completion` only supports bash/zsh/fish; not in PSCompletions catalog. No PS completion shipped — track upstream (#73).'
     }
     [Package]@{ Name = 'Python';                        Installer = 'winget'; Id = 'Python.Python.3.14';                                    CliCommands = @('python') }
 

--- a/bucket/OSBasePackages.json
+++ b/bucket/OSBasePackages.json
@@ -1,6 +1,6 @@
 {
     "$schema": "https://raw.githubusercontent.com/lukesampson/scoop/master/schema.json",
-    "version": "1.20.000",
+    "version": "1.21.000",
     "url": [
         "https://raw.githubusercontent.com/MarkMichaelis/ScoopBucket/master/bucket/OSBasePackages.ps1"
     ],

--- a/bucket/OSBasePackages.ps1
+++ b/bucket/OSBasePackages.ps1
@@ -17,7 +17,31 @@ $Packages = [Package[]]@(
     [Package]@{ Name = 'UniversalSilentSwitchFinder';   Installer = 'winget'; Id = 'WindowsPostInstallWizard.UniversalSilentSwitchFinder' }
     [Package]@{ Name = 'bat';                           Installer = 'winget'; Id = 'sharkdp.bat';                                        CliCommands = @('bat') }
     [Package]@{ Name = 'fzf';                           Installer = 'winget'; Id = 'junegunn.fzf';                                       CliCommands = @('fzf') }
-    [Package]@{ Name = 'Google Cloud SDK';              Installer = 'winget'; Id = 'Google.CloudSDK';                                    CliCommands = @('gcloud'); Completion = 'pscompletions' }
+    [Package]@{
+        Name        = 'Google Cloud SDK'
+        Installer   = 'winget'
+        Id          = 'Google.CloudSDK'
+        CliCommands = @('gcloud')
+        Completion  = 'auto'
+        Notes       = '`gcloud` has no PowerShell completion command and is not in PSCompletions catalog; ship a hand-curated top-level command-group completer (#73).'
+        ExpectedCompletions = @{ gcloud = @('auth','config','version') }
+        NativeCommandScript = {
+            @"
+Register-ArgumentCompleter -Native -CommandName gcloud -ScriptBlock {
+    param(`$wordToComplete, `$commandAst, `$cursorPosition)
+    `$cmds = @(
+        'auth','components','config','compute','container','dataflow','dataproc',
+        'deployment-manager','dns','functions','iam','init','kms','logging','ml',
+        'organizations','projects','pubsub','run','services','source','spanner',
+        'sql','storage','topic','version','help'
+    )
+    `$cmds | Where-Object { `$_ -like "`$wordToComplete*" } | ForEach-Object {
+        [System.Management.Automation.CompletionResult]::new(`$_, `$_, 'ParameterValue', `$_)
+    }
+}
+"@
+        }
+    }
 
     # Editor included in the OS baseline so a freshly imaged box has a
     # text editor available before DeveloperBasePackages runs. The winget
@@ -35,6 +59,7 @@ $Packages = [Package[]]@(
         Completion  = 'native'
         NativeCommandScript = { rg --generate complete-powershell }
         Notes       = 'scoop main/ripgrep gives v14+, required for --generate complete-powershell. See #73.'
+        ExpectedCompletions = @{ rg = @('--help','--version','--color') }
     }
     [Package]@{
         Name        = 'Sysinternals Suite'

--- a/bucket/PSCompletionsCatalog.json
+++ b/bucket/PSCompletionsCatalog.json
@@ -1,0 +1,17 @@
+{
+    "Source": "https://api.github.com/repos/abgox/PSCompletions/contents/completions",
+    "RefreshScript": ".github/scripts/Update-PSCompletionsCatalog.ps1",
+    "Completions": [
+        "7z", "adb", "arch", "b2sum", "b3sum", "base32", "base64", "basename",
+        "basenc", "bun", "cargo", "chfs", "choco", "cksum", "comm", "conda",
+        "csplit", "cut", "date", "dd", "deno", "df", "dircolors", "dirname",
+        "docker", "dotnet", "du", "env", "factor", "ffmpeg", "fmt", "fnm",
+        "fold", "gh", "git", "go", "hashsum", "head", "jj", "jjui", "join",
+        "jq", "kubectl", "link", "ln", "md5sum", "mise", "mktemp", "mysql",
+        "ngrok", "nl", "node", "npm", "nproc", "nrm", "numfmt", "nvm", "od",
+        "oh-my-posh", "ollama", "paste", "pdm", "pip", "pnpm", "powershell",
+        "psc", "pwsh", "python", "scoop", "scoop-checkver", "scoop-install",
+        "scoop-update", "sfsu", "uv", "volta", "winget", "wsh", "wsl", "wt",
+        "ya", "yarn", "yazi", "zoxide"
+    ]
+}

--- a/bucket/Package.Tests.ps1
+++ b/bucket/Package.Tests.ps1
@@ -175,8 +175,34 @@ Describe 'Package.Validate() — happy paths' -Tag 'Light', 'Module' {
             CliCommands         = @('gh')
             Completion          = 'native'
             NativeCommandScript = { 'gh completion -s powershell' }
+            ExpectedCompletions = @{ gh = @('auth','repo','pr') }
         }
         { $p.Validate() } | Should -Not -Throw
+    }
+
+    It 'requires ExpectedCompletions when Completion != none' {
+        $p = [Package]@{
+            Name                = 'gh'
+            Installer           = 'winget'
+            Id                  = 'GitHub.cli'
+            CliCommands         = @('gh')
+            Completion          = 'native'
+            NativeCommandScript = { 'noop' }
+        }
+        { $p.Validate() } | Should -Throw -ExpectedMessage '*ExpectedCompletions*'
+    }
+
+    It 'requires an ExpectedCompletions entry for every CliCommands name' {
+        $p = [Package]@{
+            Name                = 'gh'
+            Installer           = 'winget'
+            Id                  = 'GitHub.cli'
+            CliCommands         = @('gh','gh2')
+            Completion          = 'native'
+            NativeCommandScript = { 'noop' }
+            ExpectedCompletions = @{ gh = @('auth') }
+        }
+        { $p.Validate() } | Should -Throw -ExpectedMessage "*missing a key for CLI 'gh2'*"
     }
 }
 

--- a/bucket/PackageInstall.Tests.ps1
+++ b/bucket/PackageInstall.Tests.ps1
@@ -321,24 +321,24 @@ Describe 'Completion registration' -Tag 'Light','Module' {
         (Get-Content $script:profilePath -Raw) | Should -Match 'ScoopBucket:CliCompletion:mycli:BEGIN'
     }
 
-    It 'is idempotent: rerunning preserves existing block' {
+    It 'is idempotent: rerunning always replaces with the current native output' {
         $null = & $script:RegisterFn -Cli 'idem' `
             -NativeCommand { 'first' } -Mode 'native' -ProfilePath $script:profilePath -Confirm:$false
         $r = & $script:RegisterFn -Cli 'idem' `
             -NativeCommand { 'second' } -Mode 'native' -ProfilePath $script:profilePath -Confirm:$false
-        $r.Action | Should -Be 'Preserved'
-        (Get-Content $script:profilePath -Raw) | Should -Match 'first'
-        (Get-Content $script:profilePath -Raw) | Should -Not -Match 'second'
-    }
-
-    It 'replaces existing block when -Force is passed' {
-        $null = & $script:RegisterFn -Cli 'idem2' `
-            -NativeCommand { 'first' } -Mode 'native' -ProfilePath $script:profilePath -Confirm:$false
-        $r = & $script:RegisterFn -Cli 'idem2' `
-            -NativeCommand { 'second' } -Mode 'native' -ProfilePath $script:profilePath -Force -Confirm:$false
         $r.Action | Should -Be 'Replaced'
         (Get-Content $script:profilePath -Raw) | Should -Match 'second'
         (Get-Content $script:profilePath -Raw) | Should -Not -Match 'first'
+    }
+
+    It 'rerunning with identical native output produces a byte-identical block' {
+        $null = & $script:RegisterFn -Cli 'idem3' `
+            -NativeCommand { 'same' } -Mode 'native' -ProfilePath $script:profilePath -Confirm:$false
+        $first = Get-Content $script:profilePath -Raw
+        $null = & $script:RegisterFn -Cli 'idem3' `
+            -NativeCommand { 'same' } -Mode 'native' -ProfilePath $script:profilePath -Confirm:$false
+        $second = Get-Content $script:profilePath -Raw
+        $first | Should -Be $second
     }
 
     It 'returns Skipped (Mode=native) when native command emits nothing' {

--- a/module/MarkMichaelis.ScoopBucket/Classes/Package.ps1
+++ b/module/MarkMichaelis.ScoopBucket/Classes/Package.ps1
@@ -32,6 +32,13 @@ class Package {
     [ValidateSet('none', 'native', 'pscompletions', 'auto')]
     [string]   $Completion = 'none'
 
+    # Per-CLI expected-completion hashtable: CliName -> string[] of
+    # subcommands the manifest promises TabExpansion2 will return for
+    # that CLI after registration. Tested end-to-end by
+    # CompletionEndToEnd.Tests.ps1 and statically by
+    # CompletionContract.Tests.ps1. Required whenever Completion != 'none'.
+    [hashtable] $ExpectedCompletions = @{}
+
     [scriptblock] $NativeCommandScript
     [scriptblock] $CustomInstallScript
     [scriptblock] $PostInstallScript
@@ -77,6 +84,24 @@ class Package {
 
         if ($this.Completion -in @('native', 'auto') -and -not $this.NativeCommandScript) {
             throw "Package '$($this.Name)': NativeCommandScript is required when Completion='$($this.Completion)'."
+        }
+
+        if ($this.Completion -ne 'none') {
+            if ($this.CliCommands.Count -eq 0) {
+                throw "Package '$($this.Name)': CliCommands must be non-empty when Completion='$($this.Completion)'."
+            }
+            if (-not $this.ExpectedCompletions -or $this.ExpectedCompletions.Count -eq 0) {
+                throw "Package '$($this.Name)': ExpectedCompletions hashtable is required when Completion='$($this.Completion)' so completion can be verified end-to-end (no mocks)."
+            }
+            foreach ($cli in $this.CliCommands) {
+                if (-not $this.ExpectedCompletions.ContainsKey($cli)) {
+                    throw "Package '$($this.Name)': ExpectedCompletions is missing a key for CLI '$cli'."
+                }
+                $items = @($this.ExpectedCompletions[$cli])
+                if ($items.Count -eq 0) {
+                    throw "Package '$($this.Name)': ExpectedCompletions['$cli'] is empty; supply at least one subcommand TabExpansion2 must produce."
+                }
+            }
         }
 
         if ($this.DependsOn -contains $this.Name) {

--- a/module/MarkMichaelis.ScoopBucket/Private/Get-BundlePackages.ps1
+++ b/module/MarkMichaelis.ScoopBucket/Private/Get-BundlePackages.ps1
@@ -88,6 +88,7 @@ function global:Invoke-PackageInstall {
             Scope       = `$p.Scope
             CliCommands = @(`$p.CliCommands)
             Completion  = `$p.Completion
+            ExpectedCompletions = `$p.ExpectedCompletions
             DependsOn   = @(`$p.DependsOn)
             CISkip      = `$p.CISkip
             Notes       = `$p.Notes

--- a/module/MarkMichaelis.ScoopBucket/Private/Invoke-BundleScript.ps1
+++ b/module/MarkMichaelis.ScoopBucket/Private/Invoke-BundleScript.ps1
@@ -30,7 +30,7 @@ function Invoke-BundleScript {
     .PARAMETER Names
         Optional -Name filter. When omitted the whole bundle installs.
 
-    .PARAMETER DryRun, SkipCompletion, ForceCompletion
+    .PARAMETER DryRun, SkipCompletion
         Passed through to `Invoke-PackageInstall`.
     #>
     [CmdletBinding()]
@@ -39,8 +39,7 @@ function Invoke-BundleScript {
         [Parameter(Mandatory)][string]$Bundle,
         [string[]]$Names,
         [switch]$DryRun,
-        [switch]$SkipCompletion,
-        [switch]$ForceCompletion
+        [switch]$SkipCompletion
     )
 
     if ($Names -and $Names.Count -gt 0) {
@@ -55,7 +54,6 @@ function Invoke-BundleScript {
     $flags = @()
     if ($DryRun)          { $flags += '-DryRun' }
     if ($SkipCompletion)  { $flags += '-SkipCompletion' }
-    if ($ForceCompletion) { $flags += '-ForceCompletion' }
     $flagsStr = $flags -join ' '
 
     $nameFilterLiteral = ''

--- a/module/MarkMichaelis.ScoopBucket/Private/Register-PackageCompletion.ps1
+++ b/module/MarkMichaelis.ScoopBucket/Private/Register-PackageCompletion.ps1
@@ -98,8 +98,7 @@ function Set-PackageCompletionProfileBlock {
     param(
         [Parameter(Mandatory)][AllowEmptyString()][string]$Content,
         [Parameter(Mandatory)][string]$Cli,
-        [Parameter(Mandatory)][string]$Block,
-        [switch]$Force
+        [Parameter(Mandatory)][string]$Block
     )
     $ver = $script:CompletionSentinelVersion
     $begin = "# ScoopBucket:CliCompletion:$Cli`:BEGIN $ver"
@@ -108,7 +107,6 @@ function Set-PackageCompletionProfileBlock {
     $newBlock = "$begin`r`n$Block`r`n$end`r`n"
     $match = [regex]::Match($Content, $pattern)
     if ($match.Success) {
-        if (-not $Force) { return $Content }
         $before = $Content.Substring(0, $match.Index)
         $after  = $Content.Substring($match.Index + $match.Length)
         return $before + $newBlock + $after
@@ -140,8 +138,6 @@ function Register-PackageCompletion {
         'pscompletions' — skip native, go straight to PSCompletions probe.
         'auto'          — native first, fall back to PSCompletions.
         Defaults to 'auto'.
-    .PARAMETER Force
-        Overwrite an existing block for the same CLI.
     .PARAMETER ProfilePath
         Test hook: write to this file instead of AllUsersAllHosts.
         Bypasses the elevation check.
@@ -152,7 +148,6 @@ function Register-PackageCompletion {
         [Parameter(Mandatory)][string]$Cli,
         [scriptblock]$NativeCommand,
         [ValidateSet('native','pscompletions','auto')][string]$Mode = 'auto',
-        [switch]$Force,
         [string]$ProfilePath
     )
 
@@ -166,12 +161,6 @@ function Register-PackageCompletion {
 
     $content  = Read-PackageCompletionProfileContent -Path $target
     $existed  = [regex]::IsMatch($content, "(?ms)^\# ScoopBucket:CliCompletion:$([regex]::Escape($Cli))`:BEGIN \w+")
-    if ($existed -and -not $Force) {
-        return [pscustomobject]@{
-            Cli = $Cli; Source = 'Preserved'; Action = 'Preserved'
-            ProfilePath = $target; Reason = 'Existing block preserved; pass -Force to overwrite.'
-        }
-    }
 
     $resolveSplat = @{ Cli = $Cli }
     if ($NativeCommand -and $Mode -ne 'pscompletions') {
@@ -205,8 +194,7 @@ function Register-PackageCompletion {
     }
 
     if ($resolved.Source -eq 'PSCompletions') {
-        $pscAction = "psc add $Cli" + ($(if ($Force) { ' (re-add)' } else { '' }))
-        if ($PSCmdlet.ShouldProcess($Cli, $pscAction)) {
+        if ($PSCmdlet.ShouldProcess($Cli, "psc add $Cli")) {
             try {
                 Import-Module PSCompletions -ErrorAction Stop
                 & psc add $Cli 2>$null | Out-Null
@@ -225,7 +213,7 @@ function Register-PackageCompletion {
         }
     }
 
-    $newContent = Set-PackageCompletionProfileBlock -Content $content -Cli $Cli -Block $resolved.Code -Force:$true
+    $newContent = Set-PackageCompletionProfileBlock -Content $content -Cli $Cli -Block $resolved.Code
     $tmp = "$target.tmp"
     [System.IO.File]::WriteAllText($tmp, $newContent, [System.Text.UTF8Encoding]::new($false))
     Move-Item -Path $tmp -Destination $target -Force

--- a/module/MarkMichaelis.ScoopBucket/Public/Get-Package.ps1
+++ b/module/MarkMichaelis.ScoopBucket/Public/Get-Package.ps1
@@ -74,6 +74,7 @@ function Get-Package {
                 Scope       = $p.Scope
                 CliCommands = @($p.CliCommands)
                 Completion  = $p.Completion
+                ExpectedCompletions = $p.ExpectedCompletions
                 DependsOn   = @($p.DependsOn)
                 CISkip      = $p.CISkip
                 Notes       = $p.Notes

--- a/module/MarkMichaelis.ScoopBucket/Public/Install-Package.ps1
+++ b/module/MarkMichaelis.ScoopBucket/Public/Install-Package.ps1
@@ -35,13 +35,6 @@ function Install-Package {
     .PARAMETER SkipCompletion
         Don't attempt completion registration.
 
-    .PARAMETER ForceCompletion
-        Re-register every CLI's tab-completion block even when a
-        sentinel block already exists in the AllUsersAllHosts profile.
-        Use this to repair completion for a CLI that was installed
-        before PSCompletions was available (the classic `bw <Tab>`
-        repair scenario).
-
     .PARAMETER BucketPath
         Override the auto-detected bucket directory.
 
@@ -56,7 +49,6 @@ function Install-Package {
         [Parameter(Mandatory, Position = 0)][string[]]$Name,
         [switch]$DryRun,
         [switch]$SkipCompletion,
-        [switch]$ForceCompletion,
         [string]$BucketPath
     )
 
@@ -147,8 +139,7 @@ function Install-Package {
     # --- Dispatch (a): Package.Name flow with -Name filter -----------------
     foreach ($entry in $byBundle.Values) {
         Invoke-BundleScript -BundlePath $entry.BundlePath -Bundle $entry.Bundle `
-            -Names $entry.Names -DryRun:$DryRun -SkipCompletion:$SkipCompletion `
-            -ForceCompletion:$ForceCompletion
+            -Names $entry.Names -DryRun:$DryRun -SkipCompletion:$SkipCompletion
     }
 
     # --- Dispatch (b): full-bundle install (no -Name filter) ---------------
@@ -156,8 +147,7 @@ function Install-Package {
         Write-Host ""
         Write-Host "Install-Package: dispatching bundle '$($b.Bundle)' (all packages)..."
         Invoke-BundleScript -BundlePath $b.BundlePath -Bundle $b.Bundle `
-            -DryRun:$DryRun -SkipCompletion:$SkipCompletion `
-            -ForceCompletion:$ForceCompletion
+            -DryRun:$DryRun -SkipCompletion:$SkipCompletion
     }
 
     # --- Dispatch (c): scoop install fallback for bare manifests -----------

--- a/module/MarkMichaelis.ScoopBucket/Public/Invoke-PackageInstall.ps1
+++ b/module/MarkMichaelis.ScoopBucket/Public/Invoke-PackageInstall.ps1
@@ -59,10 +59,6 @@ function Invoke-PackageInstall {
     .PARAMETER SkipCompletion
         Don't attempt completion registration (used by tests / CI when
         the AllUsersAllHosts profile isn't writable).
-
-    .PARAMETER ForceCompletion
-        Pass -Force through to Register-PackageCompletion so existing
-        sentinel blocks are replaced rather than preserved.
     #>
     [CmdletBinding(SupportsShouldProcess, ConfirmImpact = 'Medium')]
     [OutputType([object[]])]
@@ -72,8 +68,7 @@ function Invoke-PackageInstall {
         [string[]]$Name,
         [string[]]$Skip,
         [switch]$DryRun,
-        [switch]$SkipCompletion,
-        [switch]$ForceCompletion
+        [switch]$SkipCompletion
     )
 
     foreach ($pkg in $Packages) {
@@ -200,7 +195,7 @@ function Invoke-PackageInstall {
             $pkg.Completion -ne 'none' -and $pkg.CliCommands.Count -gt 0) {
             $completionResults = New-Object System.Collections.Generic.List[object]
             foreach ($cli in $pkg.CliCommands) {
-                $registerArgs = @{ Cli = $cli; Mode = $pkg.Completion; Force = $ForceCompletion }
+                $registerArgs = @{ Cli = $cli; Mode = $pkg.Completion }
                 if ($pkg.NativeCommandScript) { $registerArgs['NativeCommand'] = $pkg.NativeCommandScript }
                 try {
                     $r = Register-PackageCompletion @registerArgs

--- a/module/MarkMichaelis.ScoopBucket/Public/Update-PackageCompletion.ps1
+++ b/module/MarkMichaelis.ScoopBucket/Public/Update-PackageCompletion.ps1
@@ -90,7 +90,7 @@ function Update-PackageCompletion {
                         $results.Add([pscustomobject]@{
                             Cli = $cli; Package = $p.Name; Bundle = $b.Bundle
                             Mode = $mode; Action = 'Skipped'; Source = 'Skipped'
-                            Reason = "Package declares Completion='auto' with a native scriptblock; re-run Install-Package -ForceCompletion to refresh native completion."
+                            Reason = "Package declares Completion='auto' with a native scriptblock; re-run Install-Package to refresh native completion."
                         })
                     }
                     continue
@@ -132,7 +132,6 @@ function Update-PackageCompletion {
                 $registerArgs = @{
                     Cli   = $cli
                     Mode  = $effectiveMode
-                    Force = $true   # Always overwrite during repair.
                 }
                 if ($ProfilePath) { $registerArgs['ProfilePath'] = $ProfilePath }
 


### PR DESCRIPTION
Closes the long-standing `bw <Tab>` gap and adds an end-to-end (no-mocks) completion contract for every CLI we register.

## Root cause

Bitwarden CLI was declared with `Completion='pscompletions'`, but PSCompletions ships **no `bw` catalog entry**. Same gap exists for `gcloud` and `copilot`. The existing tests mocked `psc list` and `Register-ArgumentCompleter` so they never asserted that pressing Tab actually returns subcommands.

## What this PR does

### Manifest contract
- `[Package]` gains an `ExpectedCompletions` hashtable. `Validate()` enforces one entry per `CliCommands` name whenever `Completion != 'none'`.

### Real fixes
- **`bw`**: ship a hand-rolled native completer (top-level subcommands) and flip `Completion='auto'`.
- **`gcloud`**: same treatment.
- **`rg`**: declare `ExpectedCompletions` (already had a working native completer via `rg --generate complete-powershell`).
- **`copilot`**: stop claiming PSCompletions support  no upstream catalog entry and no PS completion command.

### -ForceCompletion removed
- The sentinel markers (`# ScoopBucket:CliCompletion:<cli>:BEGIN/END v1`) are deterministic and ours. `Register-PackageCompletion` now always replaces its own block. `Install-Package`, `Invoke-PackageInstall`, `Invoke-BundleScript` lose the flag. `Update-PackageCompletion` keeps its own `-Force` (different semantic: skip-if-block-exists vs. always-replace).

### Tests
- **Light** (`Bundles.Tests.ps1`): for every `Completion='pscompletions'` Package, cross-reference each CLI against `bucket/PSCompletionsCatalog.json`  a cached snapshot of [abgox/PSCompletions/completions/](https://github.com/abgox/PSCompletions/tree/main/completions), refreshable via `.github/scripts/Update-PSCompletionsCatalog.ps1`. **This single assertion would have caught `bw`.**
- **Heavy** (new `bucket/CompletionEndToEnd.Tests.ps1`): for every `Completion != 'none'` Package, spawn a fresh `pwsh -NoProfile`, dot-source `\C:\Users\Mark\OneDrive - IntelliTect\Documents\PowerShell\Microsoft.PowerShell_profile.ps1.AllUsersAllHosts`, then call `[CommandCompletion]::CompleteInput('<cli> ', )` and assert every `ExpectedCompletions` entry appears. No mocks.

### Doc / housekeeping
- Manifest versions bumped on every touched bundle.

## Repair flow for users

\\\powershell
git pull
Install-Package 'Bitwarden CLI'
# open a fresh pwsh
bw <Tab>     # login / logout / sync / list / ...
\\\

Refs #73.