### PR TITLE
feat(ClientBasePackages): add Handy (local speech-to-text)

### DIFF
--- a/bucket/ClientBasePackages.json
+++ b/bucket/ClientBasePackages.json
@@ -1,6 +1,6 @@
 {
     "$schema": "https://raw.githubusercontent.com/lukesampson/scoop/master/schema.json",
-    "version": "1.12.000",
+    "version": "1.13.000",
     "url": [
         "https://raw.githubusercontent.com/MarkMichaelis/ScoopBucket/master/bucket/ClientBasePackages.ps1"
     ],

--- a/bucket/ClientBasePackages.ps1
+++ b/bucket/ClientBasePackages.ps1
@@ -19,6 +19,9 @@ $Packages = [Package[]]@(
     [Package]@{ Name = 'AIAgents bundle';  Installer = 'scoop';  Id = 'MarkMichaelis/AIAgents'
                 Notes = 'Pulls every AI agent + Claude Desktop and configures MCP servers; see AIAgents.ps1.' }
 
+    [Package]@{ Name = 'Handy';            Installer = 'winget'; Id = 'cjpais.Handy'
+                Notes = 'Free open-source local speech-to-text (https://handy.computer). Runs Whisper/Parakeet locally; no cloud.' }
+
     [Package]@{ Name = 'eSpeak NG';        Installer = 'scoop';  Id = 'main/espeak-ng';    CliCommands = @('espeak-ng') }
     [Package]@{ Name = 'Notion';           Installer = 'scoop';  Id = 'extras/notion' }
     [Package]@{ Name = 'Spotify';          Installer = 'scoop';  Id = 'extras/spotify' }


### PR DESCRIPTION
Adds [Handy](https://handy.computer) (winget id `cjpais.Handy`) to ClientBasePackages, positioned immediately after the AIAgents bundle.

Handy is a free, open-source, privacy-focused, offline speech-to-text app that runs Whisper / Parakeet locally  no cloud round-trip.

Bumps `ClientBasePackages.json` 1.12.000  1.13.000 per the manifest-versioning rule (any edit to a referenced file bumps the manifest).

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>