### PR TITLE
feat(uninstall-package): Uninstall-Package companion to Install-Package

### DIFF
--- a/bucket/UninstallPackage.Tests.ps1
+++ b/bucket/UninstallPackage.Tests.ps1
@@ -1,0 +1,407 @@
+<#
+.SYNOPSIS
+    Light-suite Pester coverage for Uninstall-Package and the per-engine
+    uninstall dispatch (Invoke-PackageUninstall + Uninstall-*Package).
+#>
+
+BeforeAll {
+    $script:moduleManifest = Resolve-Path (Join-Path (Split-Path -Parent $PSScriptRoot) 'module\MarkMichaelis.ScoopBucket\MarkMichaelis.ScoopBucket.psd1')
+    Import-Module $script:moduleManifest -Force
+}
+
+Describe 'Uninstall engine dispatchers' -Tag 'Light','Module' {
+
+    Context 'Uninstall-WingetPackage' {
+        BeforeAll {
+            $script:Engine = & (Get-Module MarkMichaelis.ScoopBucket) { Get-Command Uninstall-WingetPackage }
+        }
+
+        It 'returns NotInstalled when winget list returns non-zero' {
+            Mock -ModuleName MarkMichaelis.ScoopBucket winget {
+                $global:LASTEXITCODE = 1
+                return ''
+            }
+            $pkg = [Package]@{ Name='Test'; Installer='winget'; Id='Test.Id' }
+            $r = & $script:Engine -Package $pkg
+            $r.State | Should -Be 'NotInstalled'
+        }
+
+        It 'invokes winget uninstall --id <Id> --silent and adds --scope machine for global' {
+            $script:captured = $null
+            Mock -ModuleName MarkMichaelis.ScoopBucket winget {
+                if ($args[0] -eq 'list') { $global:LASTEXITCODE = 0; return 'row' }
+                $script:captured = $args
+                $global:LASTEXITCODE = 0
+                return ''
+            }
+            $pkg = [Package]@{ Name='Test'; Installer='winget'; Id='Test.Id'; Scope='global' }
+            $r = & $script:Engine -Package $pkg
+            $r.State | Should -Be 'Uninstalled'
+            $script:captured[0] | Should -Be 'uninstall'
+            ($script:captured -contains '--id')     | Should -BeTrue
+            ($script:captured -contains 'Test.Id')  | Should -BeTrue
+            ($script:captured -contains '--silent') | Should -BeTrue
+            $hasScope = $false
+            for ($i=0; $i -lt $script:captured.Count; $i++) {
+                if ($script:captured[$i] -eq '--scope' -and $script:captured[$i+1] -eq 'machine') { $hasScope = $true }
+            }
+            $hasScope | Should -BeTrue
+        }
+
+        It 'omits --scope machine for user-scoped packages' {
+            $script:captured = $null
+            Mock -ModuleName MarkMichaelis.ScoopBucket winget {
+                if ($args[0] -eq 'list') { $global:LASTEXITCODE = 0; return 'row' }
+                $script:captured = $args
+                $global:LASTEXITCODE = 0
+                return ''
+            }
+            $pkg = [Package]@{ Name='Test'; Installer='winget'; Id='Test.Id'; Scope='user' }
+            $null = & $script:Engine -Package $pkg
+            ($script:captured -contains '--scope') | Should -BeFalse
+        }
+
+        It 'returns Failed when winget exits non-zero' {
+            Mock -ModuleName MarkMichaelis.ScoopBucket winget {
+                if ($args[0] -eq 'list') { $global:LASTEXITCODE = 0; return 'row' }
+                $global:LASTEXITCODE = 5
+                return 'error'
+            }
+            $pkg = [Package]@{ Name='Test'; Installer='winget'; Id='Test.Id' }
+            $r = & $script:Engine -Package $pkg
+            $r.State  | Should -Be 'Failed'
+            $r.Reason | Should -Match '5'
+        }
+    }
+
+    Context 'Uninstall-ScoopPackage' {
+        BeforeAll {
+            $script:Engine = & (Get-Module MarkMichaelis.ScoopBucket) { Get-Command Uninstall-ScoopPackage }
+        }
+
+        It 'strips the bucket prefix and calls scoop uninstall with the bare app name' {
+            $script:captured = $null
+            Mock -ModuleName MarkMichaelis.ScoopBucket scoop {
+                if ($args[0] -eq 'list') { return "ripgrep 13.0.0" }
+                $script:captured = $args
+                $global:LASTEXITCODE = 0
+                return ''
+            }
+            $pkg = [Package]@{ Name='ripgrep'; Installer='scoop'; Id='main/ripgrep' }
+            $r = & $script:Engine -Package $pkg
+            $r.State           | Should -Be 'Uninstalled'
+            $script:captured[0] | Should -Be 'uninstall'
+            $script:captured[1] | Should -Be 'ripgrep'
+        }
+
+        It 'returns NotInstalled when scoop list has no row' {
+            Mock -ModuleName MarkMichaelis.ScoopBucket scoop {
+                if ($args[0] -eq 'list') { return '' }
+                $global:LASTEXITCODE = 0
+                return ''
+            }
+            $pkg = [Package]@{ Name='ripgrep'; Installer='scoop'; Id='main/ripgrep' }
+            $r = & $script:Engine -Package $pkg
+            $r.State | Should -Be 'NotInstalled'
+        }
+    }
+
+    Context 'Uninstall-ChocoPackage' {
+        BeforeAll {
+            $script:Engine = & (Get-Module MarkMichaelis.ScoopBucket) { Get-Command Uninstall-ChocoPackage }
+        }
+
+        It 'calls choco uninstall with -y flag when installed' {
+            $script:captured = $null
+            Mock -ModuleName MarkMichaelis.ScoopBucket choco {
+                if ($args[0] -eq 'list') { return 'nodejs 18.0.0' }
+                $script:captured = $args
+                $global:LASTEXITCODE = 0
+                return ''
+            }
+            $pkg = [Package]@{ Name='nodejs'; Installer='choco'; Id='nodejs' }
+            $r = & $script:Engine -Package $pkg
+            $r.State           | Should -Be 'Uninstalled'
+            $script:captured[0] | Should -Be 'uninstall'
+            $script:captured[1] | Should -Be 'nodejs'
+            ($script:captured -contains '-y') | Should -BeTrue
+        }
+
+        It 'returns NotInstalled when choco list has no row' {
+            Mock -ModuleName MarkMichaelis.ScoopBucket choco {
+                if ($args[0] -eq 'list') { return '' }
+                $global:LASTEXITCODE = 0
+                return ''
+            }
+            $pkg = [Package]@{ Name='nodejs'; Installer='choco'; Id='nodejs' }
+            $r = & $script:Engine -Package $pkg
+            $r.State | Should -Be 'NotInstalled'
+        }
+
+        It 'maps choco exit 1605 to NotInstalled' {
+            Mock -ModuleName MarkMichaelis.ScoopBucket choco {
+                if ($args[0] -eq 'list') { return 'nodejs 18.0.0' }
+                $global:LASTEXITCODE = 1605
+                return ''
+            }
+            $pkg = [Package]@{ Name='nodejs'; Installer='choco'; Id='nodejs' }
+            $r = & $script:Engine -Package $pkg
+            $r.State | Should -Be 'NotInstalled'
+        }
+    }
+
+    Context 'Uninstall-NpmGlobalPackage' {
+        BeforeAll {
+            $script:Engine = & (Get-Module MarkMichaelis.ScoopBucket) { Get-Command Uninstall-NpmGlobalPackage }
+        }
+
+        It 'returns Failed when npm not on PATH' {
+            Mock -ModuleName MarkMichaelis.ScoopBucket Get-Command { return $null } -ParameterFilter { $Name -in @('npm','npm.cmd') }
+            $pkg = [Package]@{ Name='claude-code'; Installer='npmGlobal'; Id='@anthropic-ai/claude-code' }
+            $r = & $script:Engine -Package $pkg
+            $r.State  | Should -Be 'Failed'
+            $r.Reason | Should -Match 'npm'
+        }
+    }
+
+    Context 'Uninstall-DotnetToolPackage' {
+        BeforeAll {
+            $script:Engine = & (Get-Module MarkMichaelis.ScoopBucket) { Get-Command Uninstall-DotnetToolPackage }
+        }
+
+        It 'returns Failed when dotnet not on PATH' {
+            Mock -ModuleName MarkMichaelis.ScoopBucket Get-Command { return $null } -ParameterFilter { $Name -eq 'dotnet' }
+            $pkg = [Package]@{ Name='poshmcp'; Installer='dotnetTool'; Id='poshmcp' }
+            $r = & $script:Engine -Package $pkg
+            $r.State  | Should -Be 'Failed'
+            $r.Reason | Should -Match 'dotnet'
+        }
+    }
+}
+
+Describe 'Invoke-PackageUninstall pipeline' -Tag 'Light','Module' {
+
+    BeforeEach {
+        Mock -ModuleName MarkMichaelis.ScoopBucket Uninstall-WingetPackage     { return @{ State='Uninstalled'; Reason=$null } }
+        Mock -ModuleName MarkMichaelis.ScoopBucket Uninstall-ScoopPackage      { return @{ State='Uninstalled'; Reason=$null } }
+        Mock -ModuleName MarkMichaelis.ScoopBucket Uninstall-ChocoPackage      { return @{ State='Uninstalled'; Reason=$null } }
+        Mock -ModuleName MarkMichaelis.ScoopBucket Uninstall-NpmGlobalPackage  { return @{ State='Uninstalled'; Reason=$null } }
+        Mock -ModuleName MarkMichaelis.ScoopBucket Uninstall-DotnetToolPackage { return @{ State='Uninstalled'; Reason=$null } }
+        Mock -ModuleName MarkMichaelis.ScoopBucket Remove-PackageCompletionBlock { return [pscustomobject]@{ Cli=$Cli; Action='Removed' } }
+    }
+
+    It 'dispatches packages to the correct per-installer uninstall' {
+        $pkgs = [Package[]]@(
+            [Package]@{ Name='A'; Installer='winget'; Id='Foo.A' }
+            [Package]@{ Name='B'; Installer='choco';  Id='b' }
+            [Package]@{ Name='C'; Installer='scoop';  Id='main/c' }
+        )
+        $r = Invoke-PackageUninstall -Packages $pkgs -Bundle 'Test' -SkipCompletion
+        $r.Count | Should -Be 3
+        ($r | ForEach-Object State) -join ',' | Should -Be 'Uninstalled,Uninstalled,Uninstalled'
+        Should -Invoke -ModuleName MarkMichaelis.ScoopBucket Uninstall-WingetPackage -Times 1 -Exactly
+        Should -Invoke -ModuleName MarkMichaelis.ScoopBucket Uninstall-ChocoPackage  -Times 1 -Exactly
+        Should -Invoke -ModuleName MarkMichaelis.ScoopBucket Uninstall-ScoopPackage  -Times 1 -Exactly
+    }
+
+    It 'records NotInstalled when the engine reports NotInstalled' {
+        Mock -ModuleName MarkMichaelis.ScoopBucket Uninstall-WingetPackage {
+            return @{ State='NotInstalled'; Reason='probe said no' }
+        }
+        $pkgs = [Package[]]@([Package]@{ Name='A'; Installer='winget'; Id='Foo.A' })
+        $r = Invoke-PackageUninstall -Packages $pkgs -Bundle 'Test' -SkipCompletion
+        $r[0].State  | Should -Be 'NotInstalled'
+        $r[0].Reason | Should -Match 'probe said no'
+    }
+
+    It 'invokes CustomUninstallScript for Installer=custom' {
+        $script:customRan = $false
+        $pkgs = [Package[]]@(
+            [Package]@{
+                Name='Readwise'; Installer='custom'
+                CustomInstallScript   = { }
+                CustomUninstallScript = { $script:customRan = $true }
+            }
+        )
+        $r = Invoke-PackageUninstall -Packages $pkgs -Bundle 'Test' -SkipCompletion
+        $script:customRan | Should -BeTrue
+        $r[0].State | Should -Be 'Uninstalled'
+    }
+
+    It 'records Skipped when Installer=custom has no CustomUninstallScript' {
+        $pkgs = [Package[]]@(
+            [Package]@{
+                Name='Readwise'; Installer='custom'
+                CustomInstallScript = { }
+            }
+        )
+        $r = Invoke-PackageUninstall -Packages $pkgs -Bundle 'Test' -SkipCompletion
+        $r[0].State  | Should -Be 'Skipped'
+        $r[0].Reason | Should -Match 'no CustomUninstallScript'
+    }
+
+    It 'honors -DryRun: engines receive -WhatIf and presence probe is skipped' {
+        $pkgs = [Package[]]@([Package]@{ Name='A'; Installer='winget'; Id='Foo.A' })
+        $r = Invoke-PackageUninstall -Packages $pkgs -Bundle 'Test' -SkipCompletion -DryRun
+        $r[0].State | Should -Be 'Uninstalled'
+        Should -Invoke -ModuleName MarkMichaelis.ScoopBucket Uninstall-WingetPackage -Times 1 -Exactly -ParameterFilter { $WhatIf -eq $true }
+    }
+
+    It '-DryRun does not strip completion blocks' {
+        $pkgs = [Package[]]@(
+            [Package]@{ Name='A'; Installer='winget'; Id='Foo.A'; CliCommands=@('gh') }
+        )
+        $null = Invoke-PackageUninstall -Packages $pkgs -Bundle 'Test' -DryRun
+        Should -Invoke -ModuleName MarkMichaelis.ScoopBucket Remove-PackageCompletionBlock -Times 0
+    }
+
+    It '-KeepCompletion skips Remove-PackageCompletionBlock' {
+        $pkgs = [Package[]]@(
+            [Package]@{ Name='A'; Installer='winget'; Id='Foo.A'; CliCommands=@('gh') }
+        )
+        $null = Invoke-PackageUninstall -Packages $pkgs -Bundle 'Test' -KeepCompletion
+        Should -Invoke -ModuleName MarkMichaelis.ScoopBucket Remove-PackageCompletionBlock -Times 0
+    }
+
+    It 'removes completion blocks for every CliCommand by default' {
+        $pkgs = [Package[]]@(
+            [Package]@{ Name='A'; Installer='winget'; Id='Foo.A'; CliCommands=@('foo','bar') }
+        )
+        $null = Invoke-PackageUninstall -Packages $pkgs -Bundle 'Test'
+        Should -Invoke -ModuleName MarkMichaelis.ScoopBucket Remove-PackageCompletionBlock -Times 2
+    }
+
+    It 'skips CISkip packages when $env:CI is truthy' {
+        $oldCi = $env:CI
+        $env:CI = 'true'
+        try {
+            $pkgs = [Package[]]@(
+                [Package]@{ Name='Pushbullet'; Installer='winget'; Id='Foo.PB'; CISkip='no machine-scope installer' }
+                [Package]@{ Name='Other';      Installer='winget'; Id='Foo.X' }
+            )
+            $r = Invoke-PackageUninstall -Packages $pkgs -Bundle 'Test' -SkipCompletion
+            ($r | Where-Object Name -eq 'Pushbullet').State | Should -Be 'Skipped'
+            ($r | Where-Object Name -eq 'Other').State      | Should -Be 'Uninstalled'
+        } finally {
+            if ($null -eq $oldCi) { Remove-Item Env:\CI -ErrorAction Ignore }
+            else { $env:CI = $oldCi }
+        }
+    }
+
+    It 'stores the result on $global:LASTUNINSTALLREPORT' {
+        $pkgs = [Package[]]@([Package]@{ Name='A'; Installer='winget'; Id='Foo.A' })
+        $null = Invoke-PackageUninstall -Packages $pkgs -Bundle 'Test' -SkipCompletion
+        $global:LASTUNINSTALLREPORT | Should -Not -BeNullOrEmpty
+        $global:LASTUNINSTALLREPORT[0].Bundle | Should -Be 'Test'
+    }
+}
+
+Describe 'Remove-PackageCompletionBlock' -Tag 'Light','Module' {
+
+    BeforeAll {
+        $script:Register   = & (Get-Module MarkMichaelis.ScoopBucket) { Get-Command Register-PackageCompletion }
+        $script:RemoveFn   = & (Get-Module MarkMichaelis.ScoopBucket) { Get-Command Remove-PackageCompletionBlock }
+        $script:profileDir = Join-Path $TestDrive 'uninstall-profile-dir'
+        New-Item -ItemType Directory -Path $script:profileDir -Force | Out-Null
+    }
+
+    BeforeEach {
+        $script:profilePath = Join-Path $script:profileDir "profile-$([guid]::NewGuid()).ps1"
+    }
+
+    It 'strips a previously registered sentinel block' {
+        $null = & $script:Register -Cli 'rmcli' `
+            -NativeCommand { 'Register-ArgumentCompleter -CommandName rmcli -ScriptBlock { ''hi'' }' } `
+            -Mode 'native' -ProfilePath $script:profilePath -Confirm:$false
+        (Get-Content $script:profilePath -Raw) | Should -Match 'ScoopBucket:CliCompletion:rmcli:BEGIN'
+
+        $r = & $script:RemoveFn -Cli 'rmcli' -ProfilePath $script:profilePath -Confirm:$false
+        $r.Action | Should -Be 'Removed'
+        (Get-Content $script:profilePath -Raw) | Should -Not -Match 'ScoopBucket:CliCompletion:rmcli:BEGIN'
+    }
+
+    It 'returns NotPresent when the profile has no matching block' {
+        Set-Content -Path $script:profilePath -Value '# nothing here' -Encoding UTF8
+        $r = & $script:RemoveFn -Cli 'nope' -ProfilePath $script:profilePath -Confirm:$false
+        $r.Action | Should -Be 'NotPresent'
+    }
+
+    It 'returns NotPresent when the profile file does not exist' {
+        $r = & $script:RemoveFn -Cli 'nope' -ProfilePath (Join-Path $TestDrive 'absent.ps1') -Confirm:$false
+        $r.Action | Should -Be 'NotPresent'
+    }
+
+    It 'leaves blocks for other CLIs untouched' {
+        $null = & $script:Register -Cli 'keepme' -NativeCommand { 'Register-ArgumentCompleter -CommandName keepme -ScriptBlock { } ' } `
+            -Mode 'native' -ProfilePath $script:profilePath -Confirm:$false
+        $null = & $script:Register -Cli 'goaway' -NativeCommand { 'Register-ArgumentCompleter -CommandName goaway -ScriptBlock { } ' } `
+            -Mode 'native' -ProfilePath $script:profilePath -Confirm:$false
+
+        $null = & $script:RemoveFn -Cli 'goaway' -ProfilePath $script:profilePath -Confirm:$false
+
+        $after = Get-Content $script:profilePath -Raw
+        $after | Should -Match 'ScoopBucket:CliCompletion:keepme:BEGIN'
+        $after | Should -Not -Match 'ScoopBucket:CliCompletion:goaway:BEGIN'
+    }
+}
+
+Describe 'Uninstall-Package dispatch (bundle + name)' -Tag 'Light','Module' {
+
+    BeforeAll {
+        $script:repoRoot   = Split-Path -Parent $PSScriptRoot
+        $script:psd1       = Join-Path $script:repoRoot 'module\MarkMichaelis.ScoopBucket\MarkMichaelis.ScoopBucket.psd1'
+
+        $script:tmpBucket = Join-Path ([System.IO.Path]::GetTempPath()) ("ScoopBucket-uninstall-test-$([guid]::NewGuid().ToString('N'))")
+        New-Item -ItemType Directory -Path $script:tmpBucket | Out-Null
+
+        $bundleText = @"
+`$scoopBucketPsd1 = '$($script:psd1 -replace "'","''")'
+if (Test-Path `$scoopBucketPsd1) { Import-Module `$scoopBucketPsd1 -Force } else { Import-Module MarkMichaelis.ScoopBucket -Force }
+
+`$Packages = [Package[]]@(
+    [Package]@{ Name = 'alpha'; Installer = 'winget'; Id = 'Test.Alpha' }
+    [Package]@{ Name = 'bravo'; Installer = 'winget'; Id = 'Test.Bravo' }
+    [Package]@{ Name = 'charlie'; Installer = 'choco'; Id = 'charlie' }
+)
+
+Invoke-PackageInstall -Packages `$Packages -Bundle 'UninstTestBundle'
+"@
+        Set-Content -Path (Join-Path $script:tmpBucket 'UninstTestBundle.ps1') -Value $bundleText -Encoding UTF8
+
+        $bundleManifest = @{
+            '$schema'  = 'https://raw.githubusercontent.com/lukesampson/scoop/master/schema.json'
+            version   = '1.00.000'
+            url       = @('https://example.invalid/test-bundle')
+            installer = @{ script = @('& "$dir\\UninstTestBundle.ps1"') }
+        }
+        Set-Content -LiteralPath (Join-Path $script:tmpBucket 'UninstTestBundle.json') `
+            -Value ($bundleManifest | ConvertTo-Json -Depth 4) -Encoding UTF8
+    }
+
+    AfterAll {
+        if ($script:tmpBucket -and (Test-Path $script:tmpBucket)) {
+            Remove-Item -LiteralPath $script:tmpBucket -Recurse -Force -ErrorAction Ignore
+        }
+    }
+
+    It 'dispatches a single package by Name (DryRun plans without invoking engines)' {
+        $output = Uninstall-Package -Name 'alpha' -DryRun -SkipCompletion -BucketPath $script:tmpBucket *>&1 | Out-String
+        $output | Should -Match "dispatching alpha via UninstTestBundle"
+        $output | Should -Match "=== Invoke-PackageUninstall: UninstTestBundle \(1 packages\) ==="
+        $output | Should -Match "\[uninstall\] \[winget\] alpha"
+        $output | Should -Not -Match "\[uninstall\] \[winget\] bravo"
+    }
+
+    It 'dispatches every package when given the bundle name' {
+        $output = Uninstall-Package -Name 'UninstTestBundle' -DryRun -SkipCompletion -BucketPath $script:tmpBucket *>&1 | Out-String
+        $output | Should -Match "dispatching bundle 'UninstTestBundle' \(all packages\)"
+        $output | Should -Match "\[uninstall\] \[winget\] alpha"
+        $output | Should -Match "\[uninstall\] \[winget\] bravo"
+        $output | Should -Match "\[uninstall\] \[choco\] charlie"
+    }
+
+    It 'throws a helpful error when neither package, bundle, nor manifest matches' {
+        { Uninstall-Package -Name 'NoSuchPkg' -DryRun -SkipCompletion -BucketPath $script:tmpBucket } |
+            Should -Throw -ExpectedMessage "*no bundle declares a package named 'NoSuchPkg'*"
+    }
+}

--- a/module/MarkMichaelis.ScoopBucket/Classes/Package.ps1
+++ b/module/MarkMichaelis.ScoopBucket/Classes/Package.ps1
@@ -41,6 +41,7 @@ class Package {
 
     [scriptblock] $NativeCommandScript
     [scriptblock] $CustomInstallScript
+    [scriptblock] $CustomUninstallScript
     [scriptblock] $PostInstallScript
     [scriptblock] $VerifyScript
 
@@ -72,6 +73,12 @@ class Package {
 
         if ($this.Installer -eq 'custom' -and -not $this.CustomInstallScript) {
             throw "Package '$($this.Name)': CustomInstallScript is required when Installer='custom'."
+        }
+
+        # CustomUninstallScript is optional — not every install is reversible.
+        # If present it must only accompany Installer='custom'.
+        if ($this.CustomUninstallScript -and $this.Installer -ne 'custom') {
+            throw "Package '$($this.Name)': CustomUninstallScript is only valid when Installer='custom' (got '$($this.Installer)')."
         }
 
         if ($this.Source -eq 'msstore' -and $this.Installer -ne 'winget') {

--- a/module/MarkMichaelis.ScoopBucket/MarkMichaelis.ScoopBucket.psd1
+++ b/module/MarkMichaelis.ScoopBucket/MarkMichaelis.ScoopBucket.psd1
@@ -21,8 +21,10 @@
 
     FunctionsToExport = @(
         'Install-Package',
+        'Uninstall-Package',
         'Get-Package',
         'Invoke-PackageInstall',
+        'Invoke-PackageUninstall',
         'Update-PackageCompletion',
         'Import-PackageCompletion',
         'Add-MachinePath',

--- a/module/MarkMichaelis.ScoopBucket/Private/Get-BundlePackageObjects.ps1
+++ b/module/MarkMichaelis.ScoopBucket/Private/Get-BundlePackageObjects.ps1
@@ -1,0 +1,49 @@
+function Get-BundlePackageObjects {
+    <#
+    .SYNOPSIS
+        Internal: dot-source a bundle .ps1 in-process and return the
+        real $Packages collection (with scriptblocks intact).
+    .DESCRIPTION
+        Used by Uninstall-Package when it needs the actual [Package]
+        instances (and their CustomUninstallScript scriptblocks), not
+        just the metadata Get-BundlePackages returns.
+
+        Strips the bundle's terminal `Invoke-PackageInstall -Packages …`
+        line so the act of loading the bundle doesn't trigger a real
+        install, then evaluates the remainder via [scriptblock]::Create
+        in the current scope so `$Packages` is assigned and `[Package]`
+        casts resolve against the already-loaded module.
+
+        Bundle scripts that do not assign $Packages (legacy imperative
+        bundles) return an empty array.
+    #>
+    [OutputType([object[]])]
+    [CmdletBinding()]
+    param([Parameter(Mandatory)][string]$BundlePath)
+
+    if (-not (Test-Path $BundlePath)) {
+        Write-Verbose "Get-BundlePackageObjects: '$BundlePath' not found."
+        return @()
+    }
+
+    $bundleText = Get-Content -Raw -LiteralPath $BundlePath -ErrorAction SilentlyContinue
+    if (-not $bundleText) { return @() }
+    if ($bundleText -notmatch '(?m)^\s*Invoke-PackageInstall\b') { return @() }
+
+    $stripped = $bundleText -replace "(?ms)^\s*\`$scoopBucketPsd1\s*=.*?Import-Module\s+MarkMichaelis\.ScoopBucket\s+-Force\s*\}\s*", ''
+    $stripped = $stripped -replace "(?m)^\s*Invoke-PackageInstall\s+-Packages\s+\`$Packages\s+-Bundle\s+'[^']+'\s*`$", ''
+
+    $Packages = $null
+    try {
+        . ([scriptblock]::Create($stripped))
+    } catch {
+        Write-Verbose "Get-BundlePackageObjects: dot-source threw: $($_.Exception.Message)"
+        return @()
+    }
+
+    if ($null -eq $Packages) { return @() }
+    # Emit each package to the pipeline; caller wraps with @(...) to
+    # collect. Returning `,$Packages` would create an extra wrapping
+    # level the caller can't easily strip.
+    return $Packages
+}

--- a/module/MarkMichaelis.ScoopBucket/Private/Register-PackageCompletion.ps1
+++ b/module/MarkMichaelis.ScoopBucket/Private/Register-PackageCompletion.ps1
@@ -92,6 +92,98 @@ function Read-PackageCompletionProfileContent {
     return ''
 }
 
+function Remove-PackageCompletionProfileBlock {
+    <#
+    .SYNOPSIS
+        Strip the sentinel-delimited completion block for $Cli from $Content.
+        Pure string transform — shares the regex shape with
+        Set-PackageCompletionProfileBlock so the block format lives in
+        exactly one place.
+    #>
+    [OutputType([pscustomobject])]
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)][AllowEmptyString()][string]$Content,
+        [Parameter(Mandatory)][string]$Cli
+    )
+    $pattern = "(?ms)^\# ScoopBucket:CliCompletion:$([regex]::Escape($Cli))`:BEGIN \w+.*?^\# ScoopBucket:CliCompletion:$([regex]::Escape($Cli))`:END\r?\n?"
+    $match = [regex]::Match($Content, $pattern)
+    if (-not $match.Success) {
+        return [pscustomobject]@{ Changed = $false; Content = $Content }
+    }
+    $before = $Content.Substring(0, $match.Index)
+    $after  = $Content.Substring($match.Index + $match.Length)
+    # Collapse the extra blank line we add when writing blocks (see
+    # Set-PackageCompletionProfileBlock: appends `r`n`r`n before block).
+    $combined = ($before.TrimEnd("`r","`n") + "`r`n" + $after.TrimStart("`r","`n"))
+    if (-not $before -and -not $after.Trim()) { $combined = '' }
+    return [pscustomobject]@{ Changed = $true; Content = $combined }
+}
+
+function Remove-PackageCompletionBlock {
+    <#
+    .SYNOPSIS
+        Remove the sentinel-delimited completion block for $Cli from
+        $PROFILE.AllUsersAllHosts (or -ProfilePath override). Inverse of
+        Register-PackageCompletion.
+    .DESCRIPTION
+        Used by Uninstall-Package so removing a package also cleans up
+        the completer it registered. Requires elevation to write to
+        AllUsersAllHosts (mirrors Register-PackageCompletion). Honors
+        SupportsShouldProcess. Returns a PSCustomObject describing the
+        outcome (Action = 'Removed' | 'NotPresent' | 'Skipped' | 'WhatIf').
+    .PARAMETER Cli
+        Bare command name whose block to strip.
+    .PARAMETER ProfilePath
+        Test hook: read/write this file instead of AllUsersAllHosts.
+        Bypasses the elevation check.
+    #>
+    [CmdletBinding(SupportsShouldProcess, ConfirmImpact = 'Medium')]
+    [OutputType([pscustomobject])]
+    param(
+        [Parameter(Mandatory)][string]$Cli,
+        [string]$ProfilePath
+    )
+
+    $target = Get-PackageCompletionProfilePath -OverridePath $ProfilePath
+    if (-not $target) {
+        return [pscustomobject]@{
+            Cli = $Cli; Action = 'Skipped'; ProfilePath = $null
+            Reason = 'No AllUsersAllHosts profile path available on this host.'
+        }
+    }
+    if (-not (Test-Path $target)) {
+        return [pscustomobject]@{
+            Cli = $Cli; Action = 'NotPresent'; ProfilePath = $target
+            Reason = 'Profile file does not exist.'
+        }
+    }
+
+    $content  = Read-PackageCompletionProfileContent -Path $target
+    $stripped = Remove-PackageCompletionProfileBlock -Content $content -Cli $Cli
+    if (-not $stripped.Changed) {
+        return [pscustomobject]@{
+            Cli = $Cli; Action = 'NotPresent'; ProfilePath = $target
+            Reason = "No completion block for '$Cli' in profile."
+        }
+    }
+
+    if (-not $PSCmdlet.ShouldProcess($target, "Remove completion block for '$Cli'")) {
+        return [pscustomobject]@{
+            Cli = $Cli; Action = 'WhatIf'; ProfilePath = $target
+            Reason = '-WhatIf or -Confirm declined.'
+        }
+    }
+
+    $tmp = "$target.tmp"
+    [System.IO.File]::WriteAllText($tmp, $stripped.Content, [System.Text.UTF8Encoding]::new($false))
+    Move-Item -Path $tmp -Destination $target -Force
+
+    return [pscustomobject]@{
+        Cli = $Cli; Action = 'Removed'; ProfilePath = $target; Reason = $null
+    }
+}
+
 function Set-PackageCompletionProfileBlock {
     [OutputType([string])]
     [CmdletBinding()]

--- a/module/MarkMichaelis.ScoopBucket/Private/Uninstall-ChocoPackage.ps1
+++ b/module/MarkMichaelis.ScoopBucket/Private/Uninstall-ChocoPackage.ps1
@@ -1,0 +1,45 @@
+# Chocolatey engine: uninstalls a single Package via `choco uninstall -y`.
+
+function Uninstall-ChocoPackage {
+    [CmdletBinding()]
+    [OutputType([hashtable])]
+    param(
+        [Parameter(Mandatory)][object]$Package,
+        [switch]$WhatIf
+    )
+
+    $id = $Package.Id
+    if (-not $id) {
+        return @{ State = 'Failed'; Reason = "choco: Id is empty for '$($Package.Name)'." }
+    }
+
+    if (-not $WhatIf) {
+        try {
+            $listOut = & choco list $id --local-only --no-progress 2>$null
+            if (-not ($listOut | Where-Object { $_ -match "^\s*$([regex]::Escape($id))\s" })) {
+                return @{ State = 'NotInstalled'; Reason = "choco list $id returned no row." }
+            }
+        } catch {
+            Write-Verbose "Uninstall-ChocoPackage: presence probe failed: $($_.Exception.Message)"
+        }
+    }
+
+    $uninstallArgs = @('uninstall', $id, '-y')
+
+    if ($WhatIf) {
+        Write-Host "  [WhatIf] choco $($uninstallArgs -join ' ')"
+        return @{ State = 'Uninstalled'; Reason = '(WhatIf)' }
+    }
+
+    Write-Host "  choco $($uninstallArgs -join ' ')"
+    & choco @uninstallArgs
+    $exit = $LASTEXITCODE
+    # 0 = success; 1605 = not installed; 1641/3010 = reboot pending.
+    if ($exit -eq 0 -or $exit -in @(1641, 3010)) {
+        return @{ State = 'Uninstalled'; Reason = if ($exit -ne 0) { "Reboot pending (choco exit $exit)." } else { $null } }
+    }
+    if ($exit -eq 1605) {
+        return @{ State = 'NotInstalled'; Reason = "choco reported not installed (exit 1605)." }
+    }
+    return @{ State = 'Failed'; Reason = "choco uninstall $id -y exited with $exit." }
+}

--- a/module/MarkMichaelis.ScoopBucket/Private/Uninstall-DotnetToolPackage.ps1
+++ b/module/MarkMichaelis.ScoopBucket/Private/Uninstall-DotnetToolPackage.ps1
@@ -1,0 +1,50 @@
+# dotnetTool engine: uninstalls a .NET global tool via
+# `dotnet tool uninstall --global <id>`.
+
+function Uninstall-DotnetToolPackage {
+    [CmdletBinding()]
+    [OutputType([hashtable])]
+    param(
+        [Parameter(Mandatory)][object]$Package,
+        [switch]$WhatIf
+    )
+
+    $id = $Package.Id
+    if (-not $id) {
+        return @{ State = 'Failed'; Reason = "dotnetTool: Id is empty for '$($Package.Name)'." }
+    }
+
+    if (-not (Get-Command dotnet -ErrorAction SilentlyContinue)) {
+        return @{ State = 'Failed'; Reason = "dotnet not on PATH." }
+    }
+
+    if (-not $WhatIf) {
+        try {
+            $listOut = & dotnet tool list -g 2>$null | Out-String
+            if ($listOut -notmatch "(?im)^\s*$([regex]::Escape($id))\s+\S+") {
+                return @{ State = 'NotInstalled'; Reason = "dotnet tool list -g does not list $id." }
+            }
+        } catch {
+            Write-Verbose "Uninstall-DotnetToolPackage: presence probe failed: $($_.Exception.Message)"
+        }
+    }
+
+    $uninstallArgs = @('tool', 'uninstall', '--global', $id)
+
+    if ($WhatIf) {
+        Write-Host "  [WhatIf] dotnet $($uninstallArgs -join ' ')"
+        return @{ State = 'Uninstalled'; Reason = '(WhatIf)' }
+    }
+
+    Write-Host "  dotnet $($uninstallArgs -join ' ')"
+    $out = & dotnet @uninstallArgs 2>&1
+    $exit = $LASTEXITCODE
+    $joined = ($out -join "`n")
+    if ($exit -eq 0) {
+        return @{ State = 'Uninstalled'; Reason = $null }
+    }
+    if ($joined -match 'is not installed') {
+        return @{ State = 'NotInstalled'; Reason = 'dotnet tool reported not installed.' }
+    }
+    return @{ State = 'Failed'; Reason = "dotnet tool uninstall --global $id exited with $exit. Output: $($joined.Trim())" }
+}

--- a/module/MarkMichaelis.ScoopBucket/Private/Uninstall-NpmGlobalPackage.ps1
+++ b/module/MarkMichaelis.ScoopBucket/Private/Uninstall-NpmGlobalPackage.ps1
@@ -1,0 +1,46 @@
+# npmGlobal engine: uninstalls a single package via `npm uninstall -g`.
+
+function Uninstall-NpmGlobalPackage {
+    [CmdletBinding()]
+    [OutputType([hashtable])]
+    param(
+        [Parameter(Mandatory)][object]$Package,
+        [switch]$WhatIf
+    )
+
+    $id = $Package.Id
+    if (-not $id) {
+        return @{ State = 'Failed'; Reason = "npmGlobal: Id is empty for '$($Package.Name)'." }
+    }
+
+    if (-not (Get-Command npm -ErrorAction SilentlyContinue) -and
+        -not (Get-Command npm.cmd -ErrorAction SilentlyContinue)) {
+        return @{ State = 'Failed'; Reason = "npm not on PATH." }
+    }
+
+    if (-not $WhatIf) {
+        try {
+            $listOut = & npm.cmd list -g --depth=0 2>$null | Out-String
+            if ($listOut -notmatch "(?im)^\S+\s+$([regex]::Escape($id))@") {
+                return @{ State = 'NotInstalled'; Reason = "npm list -g does not list $id." }
+            }
+        } catch {
+            Write-Verbose "Uninstall-NpmGlobalPackage: presence probe failed: $($_.Exception.Message)"
+        }
+    }
+
+    $uninstallArgs = @('uninstall', '-g', $id)
+
+    if ($WhatIf) {
+        Write-Host "  [WhatIf] npm $($uninstallArgs -join ' ')"
+        return @{ State = 'Uninstalled'; Reason = '(WhatIf)' }
+    }
+
+    Write-Host "  npm $($uninstallArgs -join ' ')"
+    & npm.cmd @uninstallArgs
+    $exit = $LASTEXITCODE
+    if ($exit -eq 0) {
+        return @{ State = 'Uninstalled'; Reason = $null }
+    }
+    return @{ State = 'Failed'; Reason = "npm uninstall -g $id exited with $exit." }
+}

--- a/module/MarkMichaelis.ScoopBucket/Private/Uninstall-ScoopPackage.ps1
+++ b/module/MarkMichaelis.ScoopBucket/Private/Uninstall-ScoopPackage.ps1
@@ -1,0 +1,47 @@
+# Scoop engine: uninstalls a single Package via `scoop uninstall`.
+#
+# Scoop's uninstall command takes the bare app name (no bucket prefix),
+# so we strip the '<bucket>/' segment from Package.Id before dispatch.
+
+function Uninstall-ScoopPackage {
+    [CmdletBinding()]
+    [OutputType([hashtable])]
+    param(
+        [Parameter(Mandatory)][object]$Package,
+        [switch]$WhatIf
+    )
+
+    $id = $Package.Id
+    if (-not $id) {
+        return @{ State = 'Failed'; Reason = "scoop: Id is empty for '$($Package.Name)'." }
+    }
+
+    $bucket, $appName = $id -split '/', 2
+    if (-not $appName) { $appName = $bucket }
+
+    if (-not $WhatIf) {
+        try {
+            $listOut = & scoop list $appName 2>$null | Out-String
+            if ($listOut -notmatch "(?im)^\s*$([regex]::Escape($appName))\s+\S+") {
+                return @{ State = 'NotInstalled'; Reason = "scoop list $appName returned no row." }
+            }
+        } catch {
+            Write-Verbose "Uninstall-ScoopPackage: presence probe failed: $($_.Exception.Message)"
+        }
+    }
+
+    $uninstallArgs = @('uninstall', $appName)
+
+    if ($WhatIf) {
+        Write-Host "  [WhatIf] scoop $($uninstallArgs -join ' ')"
+        return @{ State = 'Uninstalled'; Reason = '(WhatIf)' }
+    }
+
+    Write-Host "  scoop $($uninstallArgs -join ' ')"
+    & scoop @uninstallArgs
+    $exit = $LASTEXITCODE
+    if ($exit -eq 0) {
+        return @{ State = 'Uninstalled'; Reason = $null }
+    }
+    return @{ State = 'Failed'; Reason = "scoop uninstall $appName exited with $exit." }
+}

--- a/module/MarkMichaelis.ScoopBucket/Private/Uninstall-WingetPackage.ps1
+++ b/module/MarkMichaelis.ScoopBucket/Private/Uninstall-WingetPackage.ps1
@@ -1,0 +1,52 @@
+# Winget engine: uninstalls a single Package via `winget uninstall`.
+#
+# Inverse of Install-WingetPackage. The presence probe is identical
+# (`winget list --id <Id>`) but inverted: exit 0 ⇒ installed ⇒ uninstall;
+# non-zero ⇒ NotInstalled short-circuit.
+
+function Uninstall-WingetPackage {
+    [CmdletBinding()]
+    [OutputType([hashtable])]
+    param(
+        [Parameter(Mandatory)][object]$Package,
+        [switch]$WhatIf
+    )
+
+    $id = $Package.Id
+    if (-not $id) {
+        return @{ State = 'Failed'; Reason = "winget: Id is empty for '$($Package.Name)'." }
+    }
+
+    if (-not $WhatIf) {
+        try {
+            $listArgs = @('list', '--id', $id, '--accept-source-agreements')
+            if ($Package.Source -eq 'msstore') {
+                $listArgs += @('--source', 'msstore')
+            }
+            $null = & winget @listArgs 2>$null
+            if ($LASTEXITCODE -ne 0) {
+                return @{ State = 'NotInstalled'; Reason = "winget list --id $id returned $LASTEXITCODE." }
+            }
+        } catch {
+            Write-Verbose "Uninstall-WingetPackage: presence probe failed: $($_.Exception.Message)"
+        }
+    }
+
+    $uninstallArgs = @('uninstall', '--id', $id, '--silent', '--accept-source-agreements')
+    if ($Package.Scope -in @('machine','global')) {
+        $uninstallArgs += @('--scope', 'machine')
+    }
+
+    if ($WhatIf) {
+        Write-Host "  [WhatIf] winget $($uninstallArgs -join ' ')"
+        return @{ State = 'Uninstalled'; Reason = '(WhatIf)' }
+    }
+
+    Write-Host "  winget $($uninstallArgs -join ' ')"
+    & winget @uninstallArgs
+    $exit = $LASTEXITCODE
+    if ($exit -eq 0) {
+        return @{ State = 'Uninstalled'; Reason = $null }
+    }
+    return @{ State = 'Failed'; Reason = "winget uninstall --id $id exited with $exit." }
+}

--- a/module/MarkMichaelis.ScoopBucket/Public/Invoke-PackageUninstall.ps1
+++ b/module/MarkMichaelis.ScoopBucket/Public/Invoke-PackageUninstall.ps1
@@ -1,0 +1,174 @@
+function Invoke-PackageUninstall {
+    <#
+    .SYNOPSIS
+        Bundle-driven uninstall pipeline. Mirrors Invoke-PackageInstall:
+        validate every Package, walk the collection, dispatch to a
+        per-installer uninstall, optionally strip the sentinel
+        completion blocks the install wrote.
+
+    .DESCRIPTION
+        Called by Uninstall-Package after it resolves a user-requested
+        Name (or bundle name) to a concrete [Package[]] collection.
+        Honours -DryRun the same way Invoke-PackageInstall does (engines
+        run with -WhatIf so no real CLI is invoked) and -KeepCompletion
+        (preserve the profile sentinel block instead of removing it).
+
+        Returns one PSCustomObject per package with:
+          Bundle, Name, Installer, Id, Scope, State, Reason
+        where State ∈ Uninstalled | NotInstalled | Failed | Skipped.
+
+        CISkip honored same as install: if $env:CI is truthy and the
+        package declared CISkip, the entry is skipped (State='Skipped').
+
+        For Installer='custom', invokes Package.CustomUninstallScript when
+        present; when absent, records State='Skipped' with a reason
+        (installs may declare a CustomInstallScript that simply has no
+        reversible counterpart).
+
+    .PARAMETER Packages
+        Declarative [Package[]] collection to uninstall (typically the
+        Name-filtered subset Uninstall-Package resolved).
+
+    .PARAMETER Bundle
+        Originating bundle name — appears on each summary record.
+
+    .PARAMETER Name
+        Optional further filter. Only packages whose Name matches one of
+        these entries are processed.
+
+    .PARAMETER DryRun
+        Plan only; engines receive -WhatIf and do not invoke the CLI.
+
+    .PARAMETER KeepCompletion
+        Preserve the sentinel completion block in
+        $PROFILE.AllUsersAllHosts. Default removes it.
+
+    .PARAMETER SkipCompletion
+        Don't touch the profile at all (also skips removal). Useful when
+        the profile isn't writable (e.g. unelevated CI).
+    #>
+    [CmdletBinding(SupportsShouldProcess, ConfirmImpact = 'Medium')]
+    [OutputType([object[]])]
+    param(
+        [Parameter(Mandatory)][object[]]$Packages,
+        [Parameter(Mandatory)][string]$Bundle,
+        [string[]]$Name,
+        [switch]$DryRun,
+        [switch]$KeepCompletion,
+        [switch]$SkipCompletion,
+        [string]$ProfilePath
+    )
+
+    foreach ($pkg in $Packages) {
+        if ($null -eq $pkg) {
+            throw "Invoke-PackageUninstall: Packages array contains a null entry."
+        }
+        if ($pkg.GetType().Name -ne 'Package') {
+            throw "Invoke-PackageUninstall: every element must be a [Package]; got [$($pkg.GetType().FullName)]."
+        }
+        $pkg.Validate()
+    }
+
+    $filtered = if ($Name -and $Name.Count -gt 0) {
+        $Packages | Where-Object { $Name -contains $_.Name }
+    } else { $Packages }
+    $filtered = @($filtered)
+
+    Write-Host ""
+    Write-Host "=== Invoke-PackageUninstall: $Bundle ($($filtered.Count) packages) ==="
+
+    $summary = New-Object System.Collections.Generic.List[object]
+    $isCi = [bool]$env:CI
+
+    foreach ($pkg in $filtered) {
+        $record = [pscustomobject]@{
+            Bundle    = $Bundle
+            Name      = $pkg.Name
+            Installer = $pkg.Installer
+            Id        = $pkg.Id
+            Scope     = $pkg.Scope
+            State     = 'Pending'
+            Reason    = $null
+        }
+
+        if ($pkg.CISkip -and $isCi) {
+            $record.State  = 'Skipped'
+            $record.Reason = "CISkip: $($pkg.CISkip)"
+            Write-Host "[skip] $($pkg.Name) -- $($record.Reason)"
+            $summary.Add($record)
+            continue
+        }
+
+        Write-Host ""
+        Write-Host "[uninstall] $pkg"
+
+        try {
+            if ($pkg.Installer -eq 'custom') {
+                if (-not $pkg.CustomUninstallScript) {
+                    $record.State  = 'Skipped'
+                    $record.Reason = "Installer='custom' but no CustomUninstallScript on Package."
+                    Write-Host "  $($record.Reason)"
+                    $summary.Add($record)
+                    continue
+                }
+                if ($DryRun) {
+                    Write-Host "  [DryRun] CustomUninstallScript"
+                    $result = @{ State = 'Uninstalled'; Reason = '(DryRun)' }
+                } else {
+                    & $pkg.CustomUninstallScript $pkg
+                    $result = @{ State = 'Uninstalled'; Reason = $null }
+                }
+            } else {
+                $result = switch ($pkg.Installer) {
+                    'winget'      { Uninstall-WingetPackage     -Package $pkg -WhatIf:$DryRun }
+                    'scoop'       { Uninstall-ScoopPackage      -Package $pkg -WhatIf:$DryRun }
+                    'choco'       { Uninstall-ChocoPackage      -Package $pkg -WhatIf:$DryRun }
+                    'npmGlobal'   { Uninstall-NpmGlobalPackage  -Package $pkg -WhatIf:$DryRun }
+                    'dotnetTool'  { Uninstall-DotnetToolPackage -Package $pkg -WhatIf:$DryRun }
+                    default       { throw "Invoke-PackageUninstall: unknown Installer '$($pkg.Installer)' for '$($pkg.Name)'." }
+                }
+            }
+            $record.State  = $result.State
+            $record.Reason = $result.Reason
+        } catch {
+            $record.State  = 'Failed'
+            $record.Reason = "Uninstall threw: $($_.Exception.Message)"
+            Write-Warning "  $($pkg.Name): $($record.Reason)"
+            $summary.Add($record)
+            continue
+        }
+
+        # Strip sentinel completion blocks for each CliCommand unless
+        # the caller asked us to keep them. NotInstalled / Failed don't
+        # block removal: the block is just text in the profile and
+        # there's no reason to keep an orphaned completer registered.
+        if (-not $SkipCompletion -and -not $KeepCompletion -and -not $DryRun -and
+            $pkg.CliCommands.Count -gt 0) {
+            foreach ($cli in $pkg.CliCommands) {
+                try {
+                    $removeArgs = @{ Cli = $cli; Confirm = $false }
+                    if ($ProfilePath) { $removeArgs['ProfilePath'] = $ProfilePath }
+                    $null = Remove-PackageCompletionBlock @removeArgs
+                } catch {
+                    Write-Warning "  $($pkg.Name)/$cli completion block removal failed: $($_.Exception.Message)"
+                }
+            }
+        }
+
+        $summary.Add($record)
+    }
+
+    $arr = $summary.ToArray()
+    $global:LASTUNINSTALLREPORT = $arr
+
+    Write-Host ""
+    Write-Host "=== $Bundle uninstall summary ==="
+    $arr | ForEach-Object {
+        $line = "  {0,-14} {1,-12} {2}" -f $_.State, $_.Installer, $_.Name
+        if ($_.Reason) { $line += "  -- $($_.Reason)" }
+        Write-Host $line
+    }
+    Write-Host ""
+
+    return ,$arr
+}

--- a/module/MarkMichaelis.ScoopBucket/Public/Uninstall-Package.ps1
+++ b/module/MarkMichaelis.ScoopBucket/Public/Uninstall-Package.ps1
@@ -1,0 +1,205 @@
+function Uninstall-Package {
+    <#
+    .SYNOPSIS
+        Companion to Install-Package: uninstall one (or more) named
+        packages from any bundle in this bucket and clean up the
+        completion sentinel block each install wrote to
+        $PROFILE.AllUsersAllHosts.
+
+    .DESCRIPTION
+        Mirrors Install-Package's name-resolution model:
+          (a) Package.Name match within a declarative bundle.
+          (b) Bundle-name match — uninstall every package in the bundle.
+          (c) Bare manifest fallback — `<name>.json` with no declarative
+              owner: there is no metadata to drive an engine-specific
+              uninstall, so we surface a Skipped record with a reason.
+
+        For each resolved package the dispatch goes through
+        Invoke-PackageUninstall (which runs the per-installer presence
+        probe, dispatches to the engine, and strips the sentinel
+        completion block — unless -KeepCompletion).
+
+        Returns one PSCustomObject per package with:
+          Bundle, Name, Installer, Id, Scope, State, Reason
+        where State ∈ Uninstalled | NotInstalled | Failed | Skipped.
+
+    .PARAMETER Name
+        One or more package or bundle names.
+
+    .PARAMETER DryRun
+        Plan only — no engine is actually invoked. Profile is not modified.
+
+    .PARAMETER KeepCompletion
+        Preserve the sentinel completion block in the AllUsersAllHosts
+        profile. By default the block is removed.
+
+    .PARAMETER SkipCompletion
+        Don't touch the profile at all (overrides -KeepCompletion).
+
+    .PARAMETER BucketPath
+        Override the auto-detected bucket directory.
+
+    .EXAMPLE
+        Uninstall-Package -Name 'ripgrep'
+
+    .EXAMPLE
+        Uninstall-Package -Name 'OSBasePackages' -DryRun
+    #>
+    [CmdletBinding(SupportsShouldProcess, ConfirmImpact = 'Medium')]
+    [OutputType([object[]])]
+    param(
+        [Parameter(Mandatory, Position = 0)][string[]]$Name,
+        [switch]$DryRun,
+        [switch]$KeepCompletion,
+        [switch]$SkipCompletion,
+        [string]$BucketPath
+    )
+
+    $bundleArgs = @{}
+    if ($BucketPath) { $bundleArgs['BucketPath'] = $BucketPath }
+    $bundles = Get-BundlePackages @bundleArgs
+
+    $effectiveBucket = $BucketPath
+    if (-not $effectiveBucket) {
+        $effectiveBucket = Resolve-BucketPath -CallerScriptRoot $PSScriptRoot
+    }
+
+    $bundleIndex = @{}
+    foreach ($b in $bundles) {
+        if ($b.Packages -and $b.Packages.Count -gt 0) {
+            $bundleIndex[$b.Bundle] = $b
+        }
+    }
+
+    $byBundle      = @{}          # BundlePath -> @{ Bundle; BundlePath; Names = [List[string]] }
+    $fullBundles   = New-Object System.Collections.Generic.List[object]
+    $manifestNames = New-Object System.Collections.Generic.List[string]
+
+    foreach ($needed in $Name) {
+        $found = $false
+        foreach ($b in $bundles) {
+            foreach ($p in $b.Packages) {
+                if ($p.Name -ieq $needed) {
+                    if (-not $byBundle.ContainsKey($b.BundlePath)) {
+                        $byBundle[$b.BundlePath] = @{
+                            BundlePath = $b.BundlePath
+                            Bundle     = $b.Bundle
+                            Names      = [System.Collections.Generic.List[string]]::new()
+                        }
+                    }
+                    $byBundle[$b.BundlePath].Names.Add($p.Name)
+                    $found = $true
+                    break
+                }
+            }
+            if ($found) { break }
+        }
+        if ($found) { continue }
+
+        $bundleMatch = $null
+        foreach ($key in $bundleIndex.Keys) {
+            if ($key -ieq $needed) { $bundleMatch = $bundleIndex[$key]; break }
+        }
+        if ($bundleMatch) {
+            $fullBundles.Add($bundleMatch)
+            continue
+        }
+
+        if ($effectiveBucket) {
+            $manifestPath = Join-Path $effectiveBucket ("$needed.json")
+            if (Test-Path $manifestPath) {
+                $manifestNames.Add($needed)
+                continue
+            }
+        }
+
+        throw "Uninstall-Package: no bundle declares a package named '$needed' and no '$needed.json' manifest was found in the bucket."
+    }
+
+    $allRecords = New-Object System.Collections.Generic.List[object]
+
+    # Build a [Package[]] for each touched bundle. We dot-source the
+    # bundle in-process so CustomUninstallScript scriptblocks survive
+    # (Get-BundlePackages serializes via JSON and drops scriptblocks).
+    foreach ($entry in $byBundle.Values) {
+        $pkgObjects = @(Get-BundlePackageObjects -BundlePath $entry.BundlePath)
+        if ($pkgObjects.Count -eq 0) {
+            # Bundle's $Packages isn't dot-source-loadable from here.
+            # Fall back to metadata-only reconstruction (no scriptblocks);
+            # CustomUninstallScript paths will surface as Skipped.
+            $b = $bundles | Where-Object BundlePath -eq $entry.BundlePath | Select-Object -First 1
+            $pkgObjects = @($b.Packages | ForEach-Object { ConvertTo-PackageFromMetadata $_ })
+        }
+        Write-Host ""
+        Write-Host "Uninstall-Package: dispatching $($entry.Names -join ', ') via $($entry.Bundle)..."
+        $records = Invoke-PackageUninstall -Packages $pkgObjects -Bundle $entry.Bundle `
+            -Name @($entry.Names) -DryRun:$DryRun -KeepCompletion:$KeepCompletion -SkipCompletion:$SkipCompletion
+        foreach ($r in @($records)) { $allRecords.Add($r) }
+    }
+
+    foreach ($b in $fullBundles) {
+        $pkgObjects = @(Get-BundlePackageObjects -BundlePath $b.BundlePath)
+        if ($pkgObjects.Count -eq 0) {
+            $pkgObjects = @($b.Packages | ForEach-Object { ConvertTo-PackageFromMetadata $_ })
+        }
+        Write-Host ""
+        Write-Host "Uninstall-Package: dispatching bundle '$($b.Bundle)' (all packages)..."
+        $records = Invoke-PackageUninstall -Packages $pkgObjects -Bundle $b.Bundle `
+            -DryRun:$DryRun -KeepCompletion:$KeepCompletion -SkipCompletion:$SkipCompletion
+        foreach ($r in @($records)) { $allRecords.Add($r) }
+    }
+
+    foreach ($n in $manifestNames) {
+        Write-Host ""
+        Write-Host "Uninstall-Package: '$n' is a bare manifest (no declarative [Package] match); no uninstall metadata."
+        $allRecords.Add([pscustomobject]@{
+            Bundle    = $null
+            Name      = $n
+            Installer = $null
+            Id        = $n
+            Scope     = $null
+            State     = 'Skipped'
+            Reason    = 'Bare manifest; no Package metadata to drive uninstall.'
+        })
+    }
+
+    return ,$allRecords.ToArray()
+}
+
+function ConvertTo-PackageFromMetadata {
+    <#
+    .SYNOPSIS
+        Internal: rebuild a [Package] from the JSON-deserialized metadata
+        Get-BundlePackages returns. Scriptblock-typed fields are lost
+        (they round-tripped through ConvertTo-Json) — callers that need
+        CustomUninstallScript must instead source the bundle via
+        Get-BundlePackageObjects.
+    #>
+    param([Parameter(Mandatory)][object]$Metadata)
+
+    $pkg = [Package]@{
+        Name        = $Metadata.Name
+        Installer   = $Metadata.Installer
+        Id          = $Metadata.Id
+        Source      = if ($Metadata.PSObject.Properties['Source']) { [string]$Metadata.Source } else { '' }
+        Scope       = if ($Metadata.PSObject.Properties['Scope']) { [string]$Metadata.Scope } else { 'global' }
+        CliCommands = @($Metadata.CliCommands)
+        Completion  = if ($Metadata.PSObject.Properties['Completion']) { [string]$Metadata.Completion } else { 'none' }
+        DependsOn   = @($Metadata.DependsOn)
+        CISkip      = if ($Metadata.PSObject.Properties['CISkip']) { [string]$Metadata.CISkip } else { '' }
+        Notes       = if ($Metadata.PSObject.Properties['Notes']) { [string]$Metadata.Notes } else { '' }
+    }
+    # Completion's ExpectedCompletions invariant only matters at install
+    # time; reconstruct enough to satisfy Validate() for non-'none' modes.
+    if ($pkg.Completion -ne 'none') {
+        $ec = @{}
+        foreach ($cli in $pkg.CliCommands) { $ec[$cli] = @('--help') }
+        $pkg.ExpectedCompletions = $ec
+        # Validate() requires a NativeCommandScript for native/auto. Since
+        # this is the uninstall path we never run it; supply a sentinel.
+        if ($pkg.Completion -in @('native','auto')) {
+            $pkg.NativeCommandScript = { '' }
+        }
+    }
+    return $pkg
+}


### PR DESCRIPTION
Implements #126.

## Summary

Adds `Uninstall-Package` as the companion to `Install-Package`, mirroring its
name-resolution + dispatch model (by package name, by bundle name, or bare manifest
fallback) and returning one `PSCustomObject` per package with State in
`Uninstalled | NotInstalled | Failed | Skipped`.

## Changes

### Module surface
- `Public/Uninstall-Package.ps1`  user-facing cmdlet. Params: `-Name`, `-DryRun`, `-KeepCompletion`, `-SkipCompletion`, `-BucketPath`.
- `Public/Invoke-PackageUninstall.ps1`  per-bundle driver. CISkip honored, summary stored on `\`.
- `Private/Uninstall-{Winget,Scoop,Choco,NpmGlobal,DotnetTool}Package.ps1`  per-engine command shapes with **inverted** presence probes (same probe logic as `Install-*Package`, returns `State=NotInstalled` when the probe reports the package isn't present).
- `Private/Get-BundlePackageObjects.ps1`  dot-sources a bundle in-process to recover the real `[Package]` objects (preserves `CustomUninstallScript` scriptblocks that `Get-BundlePackages` loses across its child-runspace serialization).
- `Private/Register-PackageCompletion.ps1`  adds `Remove-PackageCompletionBlock` (sibling of the writer) plus a pure-string `Remove-PackageCompletionProfileBlock` helper, reusing the existing sentinel regex so the block format stays single-source. Honors `SupportsShouldProcess` and the same elevation check.
- `Classes/Package.ps1`  new optional `[scriptblock] \` field. `Validate()` rejects it when `Installer` is not `'custom'`. It is intentionally **optional** even for `custom` (installs may not be reversible).
- `MarkMichaelis.ScoopBucket.psd1`  exports `Uninstall-Package` and `Invoke-PackageUninstall`.

### Engine commands (per issue spec)
- winget: `winget uninstall --id <Id> --silent --accept-source-agreements` plus `--scope machine` when `Package.Scope` is `machine` / `global`.
- scoop: `scoop uninstall <appName>`  bucket prefix stripped from `<bucket>/<name>`.
- choco: `choco uninstall <Id> -y` (1605 -> NotInstalled, 1641/3010 -> Uninstalled w/ reboot reason).
- npmGlobal: `npm uninstall -g <Id>`.
- dotnetTool: `dotnet tool uninstall --global <Id>`.
- custom: invokes `CustomUninstallScript` if present, else `State=Skipped` with the required `""Installer='custom' but no CustomUninstallScript on Package.""` reason.

### Tests
`bucket/UninstallPackage.Tests.ps1`  28 new Light-tag tests:
- Per-engine command shape via mocked CLI wrappers (asserts exact arg arrays).
- `State=NotInstalled` when presence probe returns non-zero / empty.
- Dispatch by package name and by bundle name through a tmp bucket (mirrors `InstallPackageFilter.Tests.ps1`).
- Sentinel block removal in a TestDrive profile (round-trip with the existing `Register-PackageCompletion` writer).
- `-KeepCompletion` and `-DryRun` both skip the profile edit (`Should -Invoke ... -Times 0`).
- `CustomUninstallScript` invocation.
- `Installer='custom'` with no `CustomUninstallScript` -> `State=Skipped` with reason.
- `CISkip` honored under `\`.

## Test results
Local `Invoke-Pester -Path bucket -Tag Light`: **152 passed / 0 failed / 3 skipped** (baseline was 124 / 0 / 3 -> +28 new tests, no regressions).

## Notes / decisions
- Bare manifest fallback (`<name>.json` with no declarative `[Package]` owner) records `State=Skipped` with a reason rather than guessing an installer  there's no metadata to drive an engine-specific uninstall command.
- `-KeepCompletion` and `-SkipCompletion` both skip the profile edit; `-KeepCompletion` is the documented opt-in (""preserve the block""), `-SkipCompletion` mirrors the same parameter on `Install-Package`.
- Module-only change  no `bucket/*.ps1` modified, so no manifest version bumps required.
