### PR TITLE
fix: Handy needs user scope; color-code Invoke-PackageInstall summary

### DIFF
--- a/bucket/ClientBasePackages.json
+++ b/bucket/ClientBasePackages.json
@@ -1,6 +1,6 @@
 {
     "$schema": "https://raw.githubusercontent.com/lukesampson/scoop/master/schema.json",
-    "version": "1.13.000",
+    "version": "1.14.000",
     "url": [
         "https://raw.githubusercontent.com/MarkMichaelis/ScoopBucket/master/bucket/ClientBasePackages.ps1"
     ],

--- a/bucket/ClientBasePackages.ps1
+++ b/bucket/ClientBasePackages.ps1
@@ -19,8 +19,8 @@ $Packages = [Package[]]@(
     [Package]@{ Name = 'AIAgents bundle';  Installer = 'scoop';  Id = 'MarkMichaelis/AIAgents'
                 Notes = 'Pulls every AI agent + Claude Desktop and configures MCP servers; see AIAgents.ps1.' }
 
-    [Package]@{ Name = 'Handy';            Installer = 'winget'; Id = 'cjpais.Handy'
-                Notes = 'Free open-source local speech-to-text (https://handy.computer). Runs Whisper/Parakeet locally; no cloud.' }
+    [Package]@{ Name = 'Handy';            Installer = 'winget'; Id = 'cjpais.Handy'; Scope = 'user'
+                Notes = 'Free open-source local speech-to-text (https://handy.computer). Runs Whisper/Parakeet locally; no cloud. User-scope only (no machine-scope installer).' }
 
     [Package]@{ Name = 'eSpeak NG';        Installer = 'scoop';  Id = 'main/espeak-ng';    CliCommands = @('espeak-ng') }
     [Package]@{ Name = 'Notion';           Installer = 'scoop';  Id = 'extras/notion' }

--- a/bucket/InvokePackageInstallSummary.Tests.ps1
+++ b/bucket/InvokePackageInstallSummary.Tests.ps1
@@ -1,0 +1,54 @@
+#requires -Version 7.0
+#requires -Modules @{ ModuleName = 'Pester'; ModuleVersion = '5.0.0' }
+
+<#
+.SYNOPSIS
+    Light test for Invoke-PackageInstall's summary output: each row must
+    be color-coded by State so Failed rows can't be mistaken for success.
+#>
+
+BeforeAll {
+    $script:moduleManifest = Resolve-Path (Join-Path (Split-Path -Parent $PSScriptRoot) 'module\MarkMichaelis.ScoopBucket\MarkMichaelis.ScoopBucket.psd1')
+    Import-Module $script:moduleManifest -Force
+}
+
+Describe 'Invoke-PackageInstall summary coloring' -Tag 'Light','Module' {
+
+    It 'writes Failed rows in Red and Installed rows in Green' {
+        InModuleScope MarkMichaelis.ScoopBucket {
+            $captured = New-Object System.Collections.Generic.List[object]
+            Mock Write-Host -MockWith {
+                $captured.Add([pscustomobject]@{
+                    Message = $Object
+                    Color   = $ForegroundColor
+                })
+            }
+
+            # Two packages: one that succeeds (custom installer returns
+            # success), one that fails (custom installer throws).
+            $pkgs = @(
+                [Package]@{ Name = 'GoodPkg'; Installer = 'custom'
+                            CustomInstallScript = { @{ State = 'Installed'; Reason = $null } } }
+                [Package]@{ Name = 'BadPkg';  Installer = 'custom'
+                            CustomInstallScript = { throw 'simulated failure' } }
+            )
+
+            $null = Invoke-PackageInstall -Bundle 'Test' -Packages $pkgs
+
+            $summaryLines = @($captured | Where-Object { $_.Message -match '^\s{2}\S' -and $_.Color })
+            $goodLine = $summaryLines | Where-Object Message -match 'GoodPkg' | Select-Object -Last 1
+            $badLine  = $summaryLines | Where-Object Message -match 'BadPkg'  | Select-Object -Last 1
+
+            $goodLine | Should -Not -BeNullOrEmpty
+            $badLine  | Should -Not -BeNullOrEmpty
+            $goodLine.Color | Should -Be 'Green'
+            $badLine.Color  | Should -Be 'Red'
+
+            # The post-summary red banner — must appear and must be red.
+            $banner = $captured | Where-Object { $_.Message -match '^!! .*failed' } | Select-Object -Last 1
+            $banner          | Should -Not -BeNullOrEmpty
+            $banner.Color    | Should -Be 'Red'
+            $banner.Message  | Should -Match '1 package failed'
+        }
+    }
+}

--- a/module/MarkMichaelis.ScoopBucket/Private/Install-WingetPackage.ps1
+++ b/module/MarkMichaelis.ScoopBucket/Private/Install-WingetPackage.ps1
@@ -69,6 +69,7 @@ function Install-WingetPackage {
     $permanentFailureCodes = @(
         -1978335212  # APPINSTALLER_CLI_ERROR_NO_APPLICABLE_INSTALLER (user-scope only)
         -1978334969  # APPINSTALLER_CLI_ERROR_INSTALL_BLOCKED_BY_POLICY
+        -1978334972  # APPINSTALLER_CLI_ERROR_INVALID_INSTALLER_TYPE_FOR_SCOPE (nullsoft/EXE installers that don't support --scope machine)
     )
     for ($attempt = 1; $attempt -le $maxAttempts; $attempt++) {
         if ($attempt -gt 1) {

--- a/module/MarkMichaelis.ScoopBucket/Public/Invoke-PackageInstall.ps1
+++ b/module/MarkMichaelis.ScoopBucket/Public/Invoke-PackageInstall.ps1
@@ -222,9 +222,31 @@ function Invoke-PackageInstall {
     $arr | ForEach-Object {
         $line = "  {0,-18} {1,-12} {2}" -f $_.State, $_.Installer, $_.Name
         if ($_.Reason) { $line += "  -- $($_.Reason)" }
-        Write-Host $line
+        # Colorize by state so a glance at the summary tells the story.
+        # Without this, every line — Installed, Failed, Skipped — rendered
+        # in the default foreground and "Failed" was easy to overlook.
+        $color = switch ($_.State) {
+            'Installed'        { 'Green' }
+            'AlreadyInstalled' { 'DarkGreen' }
+            'Failed'           { 'Red' }
+            'Skipped'          { 'Yellow' }
+            default            { $Host.UI.RawUI.ForegroundColor }
+        }
+        Write-Host $line -ForegroundColor $color
     }
     Write-Host ""
+
+    # PowerShell auto-renders the returned PSCustomObject array as
+    # Format-List with green property names; on a failed install, that
+    # green can mislead a quick eye into thinking the operation
+    # succeeded. Emit a final, unambiguous red banner so failures can't
+    # be skimmed past.
+    $failedCount = @($arr | Where-Object State -eq 'Failed').Count
+    if ($failedCount -gt 0) {
+        $noun = if ($failedCount -eq 1) { 'package' } else { 'packages' }
+        Write-Host "!! $failedCount $noun failed in '$Bundle' — see [Reason] above." -ForegroundColor Red
+        Write-Host ""
+    }
 
     return ,$arr
 }


### PR DESCRIPTION
Three related fixes uncovered by `Install-Package Handy` failing silently:

## 1. Handy: user-scope only

cjpais.Handy's nullsoft installer doesn't support `--scope machine`, so it failed three times with winget exit `-1978334972`. Set `Scope = 'user'` on the Package.

## 2. Summary lines now color-coded

`Invoke-PackageInstall`'s summary lines used plain `Write-Host` with no color. `Failed` rows rendered in the default foreground  same as `Installed`. Worse, PowerShell auto-formats the returned `PSCustomObject[]` as Format-List with **green property names**, which reads like success at a glance ([screenshot in original report](https://github.com/MarkMichaelis/ScoopBucket/issues)).

Now:
- Summary rows colorized by State (`Installed`=Green, `AlreadyInstalled`=DarkGreen, `Failed`=Red, `Skipped`=Yellow).
- If any package failed, a final red banner `!! N package(s) failed in '<Bundle>'` is printed  survives downstream auto-formatting.

## 3. Don't retry exit `-1978334972`

Added to `Install-WingetPackage.ps1`'s `permanentFailureCodes` list (`APPINSTALLER_CLI_ERROR_INVALID_INSTALLER_TYPE_FOR_SCOPE`). Saves ~30s of pointless retries when a nullsoft/EXE installer can't honor `--scope machine`.

## Tests

New `bucket/InvokePackageInstallSummary.Tests.ps1` asserts `Failed` rows are Red, `Installed` rows are Green, and the failure banner is emitted in Red. Full Light suite: **153/0/3** (was 152/0/3).

Bumps `ClientBasePackages.json` 1.13.000  1.14.000.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>