### PR TITLE
Fix Install-Package Handy: pass --skip-dependencies via WingetExtraArgs

### DIFF
--- a/bucket/ClientBasePackages.json
+++ b/bucket/ClientBasePackages.json
@@ -1,6 +1,6 @@
 {
     "$schema": "https://raw.githubusercontent.com/lukesampson/scoop/master/schema.json",
-    "version": "1.14.000",
+    "version": "1.15.000",
     "url": [
         "https://raw.githubusercontent.com/MarkMichaelis/ScoopBucket/master/bucket/ClientBasePackages.ps1"
     ],

--- a/bucket/ClientBasePackages.ps1
+++ b/bucket/ClientBasePackages.ps1
@@ -20,7 +20,8 @@ $Packages = [Package[]]@(
                 Notes = 'Pulls every AI agent + Claude Desktop and configures MCP servers; see AIAgents.ps1.' }
 
     [Package]@{ Name = 'Handy';            Installer = 'winget'; Id = 'cjpais.Handy'; Scope = 'user'
-                Notes = 'Free open-source local speech-to-text (https://handy.computer). Runs Whisper/Parakeet locally; no cloud. User-scope only (no machine-scope installer).' }
+                WingetExtraArgs = @('--skip-dependencies')
+                Notes = 'Free open-source local speech-to-text (https://handy.computer). Runs Whisper/Parakeet locally; no cloud. User-scope only. Declares a KhronosGroup.VulkanRT dependency winget cannot resolve on most machines (already present via GPU drivers), so we skip dependency processing.' }
 
     [Package]@{ Name = 'eSpeak NG';        Installer = 'scoop';  Id = 'main/espeak-ng';    CliCommands = @('espeak-ng') }
     [Package]@{ Name = 'Notion';           Installer = 'scoop';  Id = 'extras/notion' }

--- a/bucket/PackageInstall.Tests.ps1
+++ b/bucket/PackageInstall.Tests.ps1
@@ -92,6 +92,39 @@ Describe 'Engine dispatchers' -Tag 'Light','Module' {
             $r.State | Should -Be 'Failed'
             $r.Reason | Should -Match '5'
         }
+
+        It 'appends WingetExtraArgs to the install command' {
+            $script:installArgs = $null
+            Mock -ModuleName MarkMichaelis.ScoopBucket winget {
+                if ($args[0] -eq 'list') { $global:LASTEXITCODE = 1; return '' }
+                $script:installArgs = $args
+                $global:LASTEXITCODE = 0
+                return 'Installed.'
+            }
+
+            $pkg = [Package]@{ Name='Test'; Installer='winget'; Id='Test.Id'
+                               WingetExtraArgs = @('--skip-dependencies', '--force') }
+            $null = & $script:Engine -Package $pkg
+            $script:installArgs | Should -Contain '--skip-dependencies'
+            $script:installArgs | Should -Contain '--force'
+        }
+
+        It 'does not stop retries as permanent for exit -1978334972 (missing dependency)' {
+            # -1978334972 = APPINSTALLER_CLI_ERROR_INSTALL_MISSING_DEPENDENCY.
+            # Retrying won't recover, so we treat it as permanent (no retry loop).
+            $script:installCount = 0
+            Mock -ModuleName MarkMichaelis.ScoopBucket winget {
+                if ($args[0] -eq 'list') { $global:LASTEXITCODE = 1; return '' }
+                $script:installCount++
+                $global:LASTEXITCODE = -1978334972
+                return 'missing dependency'
+            }
+
+            $pkg = [Package]@{ Name='Test'; Installer='winget'; Id='Test.Id' }
+            $r = & $script:Engine -Package $pkg
+            $r.State | Should -Be 'Failed'
+            $script:installCount | Should -Be 1
+        }
     }
 
     Context 'Install-ChocoPackage' {

--- a/module/MarkMichaelis.ScoopBucket/Classes/Package.ps1
+++ b/module/MarkMichaelis.ScoopBucket/Classes/Package.ps1
@@ -45,6 +45,13 @@ class Package {
     [scriptblock] $PostInstallScript
     [scriptblock] $VerifyScript
 
+    # Engine-specific extra arguments appended to the install command.
+    # Currently only consumed by Install-WingetPackage. Use for cases
+    # where winget needs a flag beyond the standard ones (e.g.
+    # --skip-dependencies for packages with broken or already-satisfied
+    # dependency manifests).
+    [string[]] $WingetExtraArgs = @()
+
     [string[]] $DependsOn = @()
 
     [string]   $CISkip = ''

--- a/module/MarkMichaelis.ScoopBucket/Private/Install-WingetPackage.ps1
+++ b/module/MarkMichaelis.ScoopBucket/Private/Install-WingetPackage.ps1
@@ -50,6 +50,9 @@ function Install-WingetPackage {
         $scope = if ($Package.Scope -eq 'user') { 'user' } else { 'machine' }
         $installArgs += @('--scope', $scope)
     }
+    if ($Package.WingetExtraArgs -and $Package.WingetExtraArgs.Count -gt 0) {
+        $installArgs += @($Package.WingetExtraArgs)
+    }
 
     if ($WhatIf) {
         Write-Host "  [WhatIf] winget $($installArgs -join ' ')"
@@ -69,7 +72,7 @@ function Install-WingetPackage {
     $permanentFailureCodes = @(
         -1978335212  # APPINSTALLER_CLI_ERROR_NO_APPLICABLE_INSTALLER (user-scope only)
         -1978334969  # APPINSTALLER_CLI_ERROR_INSTALL_BLOCKED_BY_POLICY
-        -1978334972  # APPINSTALLER_CLI_ERROR_INVALID_INSTALLER_TYPE_FOR_SCOPE (nullsoft/EXE installers that don't support --scope machine)
+        -1978334972  # APPINSTALLER_CLI_ERROR_INSTALL_MISSING_DEPENDENCY (declared dependency package has no applicable installer)
     )
     for ($attempt = 1; $attempt -le $maxAttempts; $attempt++) {
         if ($attempt -gt 1) {


### PR DESCRIPTION
Handy's winget manifest declares a `KhronosGroup.VulkanRT 1.4.350.0` dependency that winget cannot resolve on most machines, so `winget install cjpais.Handy` returns exit `-1978334972` (`APPINSTALLER_CLI_ERROR_INSTALL_MISSING_DEPENDENCY` -- not a scope error as PR #130 mislabeled it). The Vulkan runtime is in practice already supplied by GPU drivers, so `--skip-dependencies` makes the install succeed end-to-end (verified manually against the real package).

## Changes

- `[Package]` gains an optional `[string[]] $WingetExtraArgs` field.
- `Install-WingetPackage` appends those args after the scope branch.
- Comment on `-1978334972` in `permanentFailureCodes` corrected to `APPINSTALLER_CLI_ERROR_INSTALL_MISSING_DEPENDENCY`.
- `ClientBasePackages.ps1` sets `WingetExtraArgs=@('--skip-dependencies')` and updates Notes on the Handy entry.
- `ClientBasePackages.json` version 1.14.000 -> 1.15.000.
- Two new Light tests: `WingetExtraArgs` reaches the winget command line; exit `-1978334972` is permanent (no retry).

## Testing

Full Light suite passes locally: 155/0/3.

## After merge

`Install-Package Handy` will invoke `winget install --id cjpais.Handy --accept-package-agreements --accept-source-agreements --scope user --skip-dependencies` and succeed.