### PR TITLE
Fix Sysinternals tab-completion + close test gap that hid it

### DIFF
--- a/bucket/Bundles.Tests.ps1
+++ b/bucket/Bundles.Tests.ps1
@@ -36,12 +36,21 @@ BeforeAll {
         }
         $script:byName[$p.Name] += $p
     }
-    # Generic-test consumers: one row per package, given to It -ForEach.
-    # Pester's -ForEach iterates over each hashtable's key/value pairs
-    # and exposes them as named variables ($Bundle, $Pkg) inside the It.
-    $script:pkgCases = foreach ($p in $script:allPkgs) {
-        @{ Bundle = $p.Bundle; Pkg = $p }
-    }
+}
+
+# DISCOVERY-TIME data collection. The per-package `It -ForEach $script:pkgCases`
+# cases below need $script:pkgCases populated at Pester DISCOVERY time, not at
+# Run time (BeforeAll runs after discovery). Previously this lived in
+# BeforeAll, which silently produced ZERO iterations for every -ForEach test
+# — i.e. all per-package validation was inert. This block runs during the
+# discovery pass so the cases fan out properly.
+$scoopBucketPsd1Discovery = Join-Path $PSScriptRoot '..\module\MarkMichaelis.ScoopBucket\MarkMichaelis.ScoopBucket.psd1'
+if (Test-Path $scoopBucketPsd1Discovery) { Import-Module $scoopBucketPsd1Discovery -Force } else { Import-Module MarkMichaelis.ScoopBucket -Force }
+# Generic-test consumers: one row per package, given to It -ForEach.
+# Pester's -ForEach iterates over each hashtable's key/value pairs
+# and exposes them as named variables ($Bundle, $Pkg) inside the It.
+$script:pkgCases = foreach ($p in @(Get-Package -BucketPath $PSScriptRoot)) {
+    @{ Bundle = $p.Bundle; Pkg = $p }
 }
 
 Describe 'Declarative bundles (data-driven)' -Tag 'Light','Bundle' {
@@ -143,6 +152,59 @@ Describe 'Declarative bundles (data-driven)' -Tag 'Light','Bundle' {
         $catalog = @((Get-Content -Raw -Path $catalogPath | ConvertFrom-Json).Completions)
         foreach ($cli in @($Pkg.CliCommands)) {
             $catalog | Should -Contain $cli -Because "Completion='pscompletions' requires '$cli' to exist in https://github.com/abgox/PSCompletions/tree/main/completions; otherwise switch to Completion='auto' with a NativeCommandScript"
+        }
+    }
+
+    It "<Pkg.Name> (<Bundle>) NativeCommandScript emits Register-ArgumentCompleter for every declared CLI" -ForEach $script:pkgCases {
+        # Regression guard for the Sysinternals gap: a Package can declare
+        # Completion='native'/'auto' with a NativeCommandScript that runs
+        # without error but emits nothing for one or more of its CliCommands
+        # entries. Resolve-PackageCompletionSource then silently returns
+        # Source='Skipped' and the CLI ships with no tab-completion.
+        #
+        # Get-Package's NativeCommandOutputs is pre-computed by the bundle
+        # loader (Get-BundlePackages): it invokes $p.NativeCommandScript
+        # against each $cli the same way Resolve-PackageCompletionSource
+        # does at install time and captures the resulting text. We assert
+        # on that captured text here so the failure mode is caught at PR
+        # time without needing the package installed.
+        if ($Pkg.Completion -notin @('native','auto')) { return }
+        $Pkg.HasNativeCommandScript | Should -BeTrue -Because "Completion='$($Pkg.Completion)' requires a NativeCommandScript"
+        foreach ($cli in @($Pkg.CliCommands)) {
+            $Pkg.NativeCommandOutputs.ContainsKey($cli) | Should -BeTrue -Because "Get-Package should expose NativeCommandOutputs for every declared CLI"
+            $out = [string]$Pkg.NativeCommandOutputs[$cli]
+            $trimmed = $out.Trim()
+            if (-not $trimmed) {
+                # The bundle loader (Get-BundlePackages) invoked the
+                # NativeCommandScript but it emitted nothing. Two
+                # legitimate reasons:
+                #   1. The script delegates to the CLI binary
+                #      (e.g. `rg --generate complete-powershell`)
+                #      which isn't installed (or is too old) in the
+                #      Light/PR runner. Heavy validate-installs reruns
+                #      this same probe AFTER install and will catch
+                #      genuine breakage there.
+                #   2. The script is a static here-string but mis-uses
+                #      its $Cli arg so it emits text for one CLI only,
+                #      leaving others blank. Sysinternals-class bug.
+                # We can't distinguish (1) from (2) statically, so we
+                # only flag (2)-style breakage when at least ONE CLI on
+                # the same package DID emit. That catches uneven
+                # multi-CLI scripts without false-positive'ing on
+                # single-CLI binary-delegating scripts.
+                $anyEmitted = $false
+                foreach ($otherCli in @($Pkg.CliCommands)) {
+                    if ($otherCli -eq $cli) { continue }
+                    $otherOut = [string]$Pkg.NativeCommandOutputs[$otherCli]
+                    if ($otherOut.Trim()) { $anyEmitted = $true; break }
+                }
+                if ($anyEmitted) {
+                    throw "NativeCommandScript emitted output for some CLIs in '$($Pkg.Name)' but NOT for '$cli'. The shared script likely doesn't honor its `$Cli arg for every declared CLI -- Resolve-PackageCompletionSource will silently skip '$cli' at install time."
+                }
+                Set-ItResult -Skipped -Because "NativeCommandScript for '$cli' produced no output (likely binary-dependent and not on PATH in this runner). Heavy validate-installs covers this end-to-end."
+                continue
+            }
+            $trimmed | Should -Match 'Register-ArgumentCompleter' -Because "NativeCommandScript output for CLI '$cli' must contain a Register-ArgumentCompleter call so the profile block actually wires tab-completion"
         }
     }
 

--- a/bucket/OSBasePackages.json
+++ b/bucket/OSBasePackages.json
@@ -1,6 +1,6 @@
 {
     "$schema": "https://raw.githubusercontent.com/lukesampson/scoop/master/schema.json",
-    "version": "1.21.000",
+    "version": "1.22.000",
     "url": [
         "https://raw.githubusercontent.com/MarkMichaelis/ScoopBucket/master/bucket/OSBasePackages.ps1"
     ],

--- a/bucket/OSBasePackages.ps1
+++ b/bucket/OSBasePackages.ps1
@@ -65,7 +65,44 @@ Register-ArgumentCompleter -Native -CommandName gcloud -ScriptBlock {
         Name        = 'Sysinternals Suite'
         Installer   = 'scoop'
         Id          = 'extras/sysinternals'
-        Notes       = 'extras/sysinternals declares every tool in its manifest "bin" list, so scoop creates a shim per tool (procexp, autoruns, accesschk, ...) automatically. No PATH update required. See #44.'
+        # Curated subset of the 70+ shims extras/sysinternals creates. We
+        # only enumerate the tools most commonly used interactively so
+        # tab-completion is registered for them. The full set is still on
+        # PATH via scoop's shims; users who want completion for additional
+        # tools can extend this list.
+        CliCommands = @('handle64','procexp64','autoruns','accesschk','psexec','pslist','sigcheck','procdump','tcpview')
+        Completion  = 'native'
+        # Sysinternals tools share a small, stable set of universal flags
+        # (Win32 conventions: both slash- and dash-prefixed). No upstream
+        # PowerShell completer ships for any of them; PSCompletions has
+        # no entries either. Emit a per-CLI Register-ArgumentCompleter
+        # from this single shared script (Resolve-PackageCompletionSource
+        # passes $Cli so the same script generates each tool's block).
+        NativeCommandScript = {
+            param($Cli)
+@"
+Register-ArgumentCompleter -Native -CommandName $Cli -ScriptBlock {
+    param(`$wordToComplete, `$commandAst, `$cursorPosition)
+    @('/?','-?','/accepteula','-accepteula','/nobanner','-nobanner','/h','-h') |
+        Where-Object { `$_ -like "`$wordToComplete*" } |
+        ForEach-Object {
+            [System.Management.Automation.CompletionResult]::new(`$_, `$_, 'ParameterValue', `$_)
+        }
+}
+"@
+        }
+        ExpectedCompletions = @{
+            handle64   = @('/?','/accepteula','/nobanner')
+            procexp64  = @('/?','/accepteula','/nobanner')
+            autoruns   = @('/?','/accepteula','/nobanner')
+            accesschk  = @('/?','/accepteula','/nobanner')
+            psexec     = @('/?','/accepteula','/nobanner')
+            pslist     = @('/?','/accepteula','/nobanner')
+            sigcheck   = @('/?','/accepteula','/nobanner')
+            procdump   = @('/?','/accepteula','/nobanner')
+            tcpview    = @('/?','/accepteula','/nobanner')
+        }
+        Notes       = 'extras/sysinternals declares every tool in its manifest "bin" list, so scoop creates a shim per tool (procexp, autoruns, accesschk, ...) automatically. No PATH update required. CliCommands enumerates the curated subset that gets tab-completion via a shared per-CLI flag completer (universal Sysinternals flags: /?, /accepteula, /nobanner). See #44.'
     }
 )
 

--- a/module/MarkMichaelis.ScoopBucket/Private/Get-BundlePackages.ps1
+++ b/module/MarkMichaelis.ScoopBucket/Private/Get-BundlePackages.ps1
@@ -80,6 +80,18 @@ function Get-ScoopBucketModulePath { return '$packageClass' }
 function global:Invoke-PackageInstall {
     param([Parameter(Mandatory)][object[]]`$Packages, [Parameter(Mandatory)][string]`$Bundle, [Parameter(ValueFromRemainingArguments)]`$Remaining)
     `$exported = foreach (`$p in `$Packages) {
+        # Pre-invoke the NativeCommandScript per declared CLI inside this
+        # child runspace so the parent process can assert on what the
+        # completion machinery would actually emit at install time, without
+        # round-tripping scriptblocks through JSON (which would strip them).
+        `$nativeOutputs = @{}
+        if (`$p.NativeCommandScript) {
+            foreach (`$cli in @(`$p.CliCommands)) {
+                `$out = ''
+                try { `$out = & `$p.NativeCommandScript `$cli 2>`$null | Out-String } catch { `$out = '' }
+                `$nativeOutputs[`$cli] = `$out
+            }
+        }
         @{
             Name        = `$p.Name
             Installer   = `$p.Installer
@@ -89,6 +101,7 @@ function global:Invoke-PackageInstall {
             CliCommands = @(`$p.CliCommands)
             Completion  = `$p.Completion
             ExpectedCompletions = `$p.ExpectedCompletions
+            NativeCommandOutputs = `$nativeOutputs
             DependsOn   = @(`$p.DependsOn)
             CISkip      = `$p.CISkip
             Notes       = `$p.Notes

--- a/module/MarkMichaelis.ScoopBucket/Private/Register-PackageCompletion.ps1
+++ b/module/MarkMichaelis.ScoopBucket/Private/Register-PackageCompletion.ps1
@@ -55,7 +55,11 @@ function Resolve-PackageCompletionSource {
 
     if ($NativeCommand -and -not $PreferPSCompletions) {
         $native = $null
-        try { $native = & $NativeCommand 2>$null | Out-String } catch { }
+        # Pass $Cli so multi-CLI packages (e.g. Sysinternals Suite) can emit
+        # a per-CLI Register-ArgumentCompleter from a single shared
+        # NativeCommandScript. Existing paramless scriptblocks (gh, rg, bw,
+        # gcloud) simply ignore the extra argument.
+        try { $native = & $NativeCommand $Cli 2>$null | Out-String } catch { }
         if ($native -and $native.Trim()) {
             $guarded = "if (Get-Command $Cli -ErrorAction SilentlyContinue) {`r`n$native}"
             return @{ Source = 'Native'; Code = $guarded; PSCompletionsName = $null }

--- a/module/MarkMichaelis.ScoopBucket/Public/Get-Package.ps1
+++ b/module/MarkMichaelis.ScoopBucket/Public/Get-Package.ps1
@@ -65,6 +65,30 @@ function Get-Package {
     foreach ($b in $bundles) {
         if ($Bundle -and ($b.Bundle -notin $Bundle)) { continue }
         foreach ($p in $b.Packages) {
+            # Get-BundlePackages round-trips through JSON, so hashtables
+            # arrive as PSCustomObjects. Restore them to real Hashtables
+            # here so callers (tests, sweep loops) can use .ContainsKey()
+            # and indexer syntax uniformly.
+            $expected = @{}
+            if ($p.ExpectedCompletions) {
+                if ($p.ExpectedCompletions -is [hashtable]) {
+                    $expected = $p.ExpectedCompletions
+                } else {
+                    foreach ($prop in $p.ExpectedCompletions.PSObject.Properties) {
+                        $expected[$prop.Name] = @($prop.Value)
+                    }
+                }
+            }
+            $nativeOutputs = @{}
+            if ($p.PSObject.Properties.Name -contains 'NativeCommandOutputs' -and $p.NativeCommandOutputs) {
+                if ($p.NativeCommandOutputs -is [hashtable]) {
+                    $nativeOutputs = $p.NativeCommandOutputs
+                } else {
+                    foreach ($prop in $p.NativeCommandOutputs.PSObject.Properties) {
+                        $nativeOutputs[$prop.Name] = [string]$prop.Value
+                    }
+                }
+            }
             $obj = [pscustomobject]@{
                 Bundle      = $b.Bundle
                 Name        = $p.Name
@@ -74,7 +98,8 @@ function Get-Package {
                 Scope       = $p.Scope
                 CliCommands = @($p.CliCommands)
                 Completion  = $p.Completion
-                ExpectedCompletions = $p.ExpectedCompletions
+                ExpectedCompletions = $expected
+                NativeCommandOutputs = $nativeOutputs
                 DependsOn   = @($p.DependsOn)
                 CISkip      = $p.CISkip
                 Notes       = $p.Notes


### PR DESCRIPTION
## Why

`handle64`, `procexp64`, `autoruns`, and every other Sysinternals tool shipped with no tab-completion. Sysinternals was the only `[Package]` across all bundles that declared no `CliCommands`, so `Invoke-PackageInstall`'s `if (CliCommands.Count -gt 0)` guard silently skipped completion registration for all 70+ shimmed tools.

## The Sysinternals fix

Curated `CliCommands` list (most-used tools) + a shared `NativeCommandScript` that emits a per-CLI `Register-ArgumentCompleter` for the universal Sysinternals flags (`/?`, `-?`, `/accepteula`, `-accepteula`, `/nobanner`, `/h`).

To make one script serve N CLIs, `Resolve-PackageCompletionSource` now passes `$Cli` to the scriptblock. Existing paramless scripts (gh, rg, bw, gcloud) ignore the extra arg — backward compatible.

## Why tests didn't catch this — the real story

Two compounding bugs:

### 1. The per-package tests in `Bundles.Tests.ps1` were silently inert

The data feeding `It '...' -ForEach $script:pkgCases` was assigned in `BeforeAll`, which runs **after** Pester discovery. So `-ForEach` saw `$null` at discovery and produced **zero iterations** for every per-package case. **12 of 20 `It` blocks in this file never ran.** Moved the data collection out of `BeforeAll` into discovery scope.

Test count after fix:
- `Bundles.Tests.ps1` alone: **9 → 691**
- Full Light suite: **155 → 836**

### 2. There was no test that actually *invoked* `NativeCommandScript` per CLI

A shared multi-CLI script could mishandle its `$Cli` arg and emit text for some CLIs while leaving others blank — exactly the failure mode introduced by replacing Sysinternals' missing wiring with a shared completer. Added a new per-CLI test that consumes `NativeCommandOutputs`, which the bundle loader now pre-computes the same way `Resolve-PackageCompletionSource` does at install time.

Heuristic for binary-dependent scripts (`rg --generate complete-powershell`): static Light testing can't tell "broken script" from "binary not yet installed / wrong version on PATH." Those CLIs get a documented `Set-ItResult -Skipped`. The heuristic still catches uneven-multi-CLI bugs: **if any sibling CLI in the same package did emit, an empty one is treated as broken.** This is what locks in the Sysinternals-class regression guard going forward. Heavy `validate-installs` covers binary-dependent CLIs post-install.

## Supporting changes

- `Get-BundlePackages` pre-invokes each `NativeCommandScript` per declared CLI in its child runspace and ships the captured output back via a new `NativeCommandOutputs` field (scriptblocks can't round-trip JSON).
- `Get-Package` surfaces `NativeCommandOutputs` and restores `ExpectedCompletions` to a real `Hashtable` (JSON serialization turns hashtables into `PSCustomObject` and breaks `.ContainsKey()`).
- Bump `bucket/OSBasePackages.json` 1.21.000 → 1.22.000.

## Verification

- Light suite: **836 passed, 0 failed, 4 skipped** (3 pre-existing + 1 new for `rg` no-binary-on-PATH).
- Manual: `Get-Package | ? Name -eq 'Sysinternals Suite'` → 9 CLIs, each with `NativeCommandOutputs[$cli]` containing a working `Register-ArgumentCompleter` block for that exact CLI name.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>