### PR TITLE
Fix Install-Package Add throw + Import-PackageCompletion PSCustomObject path

### DIFF
--- a/module/MarkMichaelis.ScoopBucket/Public/Import-PackageCompletion.ps1
+++ b/module/MarkMichaelis.ScoopBucket/Public/Import-PackageCompletion.ps1
@@ -43,13 +43,19 @@ function Import-PackageCompletion {
         [Parameter(ParameterSetName = 'ByCli', Position = 0)]
         [string[]]$Cli,
 
+        # `object[]` (not `Package[]`) because Install-Package's post-install
+        # path feeds in JSON-deserialized PSCustomObjects from
+        # Get-BundlePackages — PowerShell can't coerce PSCustomObject ->
+        # Package and parameter binding throws. The end-block only reads
+        # property names (Completion, CliCommands, NativeCommandScript,
+        # NativeCommandOutputs), which works uniformly on both.
         [Parameter(ParameterSetName = 'ByPackage', ValueFromPipeline)]
-        [Package[]]$Package
+        [object[]]$Package
     )
 
     begin {
         $results = New-Object System.Collections.Generic.List[object]
-        $packagesToProcess = New-Object System.Collections.Generic.List[Package]
+        $packagesToProcess = New-Object System.Collections.Generic.List[object]
     }
 
     process {
@@ -100,15 +106,38 @@ function Import-PackageCompletion {
             foreach ($cliName in @($p.CliCommands)) {
                 if (-not $seen.Add($cliName)) { continue }
 
-                $resolveSplat = @{ Cli = $cliName }
-                if ($p.NativeCommandScript -and $p.Completion -ne 'pscompletions') {
-                    $resolveSplat['NativeCommand'] = $p.NativeCommandScript
-                }
-                if ($p.Completion -eq 'pscompletions') {
-                    $resolveSplat['PreferPSCompletions'] = $true
+                # Prefer the bundle-loader's pre-captured native output
+                # (NativeCommandOutputs[$cliName]) when the package object
+                # is a PSCustomObject from Get-BundlePackages — the live
+                # NativeCommandScript scriptblock can't round-trip JSON,
+                # so it's $null on that path. For real in-memory [Package]
+                # callers, the script is intact and Resolve-... invokes
+                # it directly.
+                $preComputedNative = $null
+                if ($p.PSObject.Properties.Name -contains 'NativeCommandOutputs' -and $p.NativeCommandOutputs) {
+                    $no = $p.NativeCommandOutputs
+                    if ($no -is [hashtable] -and $no.ContainsKey($cliName)) {
+                        $preComputedNative = [string]$no[$cliName]
+                    } elseif ($no.PSObject -and ($no.PSObject.Properties.Name -contains $cliName)) {
+                        $preComputedNative = [string]$no.$cliName
+                    }
                 }
 
-                $resolved = Resolve-PackageCompletionSource @resolveSplat
+                $resolved = $null
+                if ($preComputedNative -and $preComputedNative.Trim() -and $p.Completion -ne 'pscompletions') {
+                    $guarded = "if (Get-Command $cliName -ErrorAction SilentlyContinue) {`r`n$preComputedNative}"
+                    $resolved = @{ Source = 'Native'; Code = $guarded; PSCompletionsName = $null }
+                } else {
+                    $resolveSplat = @{ Cli = $cliName }
+                    if ($p.NativeCommandScript -and $p.Completion -ne 'pscompletions') {
+                        $resolveSplat['NativeCommand'] = $p.NativeCommandScript
+                    }
+                    if ($p.Completion -eq 'pscompletions') {
+                        $resolveSplat['PreferPSCompletions'] = $true
+                    }
+                    $resolved = Resolve-PackageCompletionSource @resolveSplat
+                }
+
                 if ($p.Completion -eq 'native' -and $resolved.Source -eq 'PSCompletions') {
                     $resolved = @{ Source = 'Skipped'; Code = $null; PSCompletionsName = $null }
                 }

--- a/module/MarkMichaelis.ScoopBucket/Public/Install-Package.ps1
+++ b/module/MarkMichaelis.ScoopBucket/Public/Install-Package.ps1
@@ -175,7 +175,14 @@ function Install-Package {
     # Register-ArgumentCompleter -Native is process-global so this works
     # regardless of module scope.
     if (-not $SkipCompletion -and -not $DryRun) {
-        $packagesToImport = New-Object System.Collections.Generic.List[Package]
+        # NOTE: List[object] (not List[Package]) because $b.Packages items
+        # are JSON-deserialized PSCustomObjects from Get-BundlePackages'
+        # child runspace, not real [Package] instances. PowerShell can't
+        # coerce PSCustomObject -> Package, so List[Package].Add throws
+        # "Cannot find an overload for 'Add' and the argument count: '1'".
+        # Import-PackageCompletion only reads property names off the
+        # objects, so PSCustomObject works fine downstream.
+        $packagesToImport = New-Object System.Collections.Generic.List[object]
         foreach ($entry in $byBundle.Values) {
             foreach ($b in $bundles) {
                 if ($b.BundlePath -ne $entry.BundlePath) { continue }


### PR DESCRIPTION
## Symptom

After #133 merged, re-running `Install-Package 'Sysinternals Suite'` printed all 9 CLIs as `Action=Added` and then threw at the very end:

```
Install-Package: Cannot find an overload for "Add" and the argument count: "1".
```

## Root cause (latent since the post-install activation block was added)

`Install-Package`'s "activate completers in the current session" block typed its accumulator as `List[Package]` and called `.Add($p)`. But `$p` comes from `Get-BundlePackages`, which round-trips bundle output through JSON in a child runspace — scriptblocks can't serialize, so the receiver always gets a `PSCustomObject`, not a `[Package]`. `List[Package].Add(PSCustomObject)` can't coerce → throw.

The same shape mismatch silently broke `Import-PackageCompletion`'s resolution path: it read `$p.NativeCommandScript` (a scriptblock, stripped during JSON serialization), so every PSCustomObject-fed CLI resolved to `Skipped`/`NotFound`. PR #133 introduced `NativeCommandOutputs` (per-CLI pre-captured text) for exactly this case — this PR wires it up.

Why this only surfaced now: Sysinternals previously had `Completion = 'none'` (default), so the post-install loop was a no-op for it. #133 set `Completion = 'native'` → first PSCustomObject reached `List[Package].Add` → boom.

## Fix

- `Install-Package.ps1`: `List[Package]` → `List[object]` for `$packagesToImport` (duck-typed; only reads `.Completion`, `.CliCommands`, `.NativeCommandOutputs`).
- `Import-PackageCompletion.ps1`:
  - Param `[Package[]]$Package` → `[object[]]$Package`.
  - Internal `List[Package]` → `List[object]`.
  - Before resolution, if `$p.NativeCommandOutputs[$cliName]` is non-empty (and not pscompletions mode), build the guarded `Register-ArgumentCompleter` block directly from that pre-captured text and mark `Source='Native'`. Falls back to `Resolve-PackageCompletionSource` for in-memory `[Package]` callers whose scriptblock is intact.
  - Handles both `Hashtable` and `PSCustomObject` shapes of `NativeCommandOutputs`.

## Tests

Local Light suite: **836 passed, 0 failed, 4 skipped** — same baseline as #133.

Smoke test confirmed `Get-BundlePackages` → Sysinternals PSCustomObject exposes `NativeCommandOutputs.handle64` with the expected `Register-ArgumentCompleter` text, and the new resolution branch picks it up without throwing.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>