### PR TITLE
Fix Test-Installs.ps1 PackageId-vs-Name + winget --scope global bugs

### DIFF
--- a/.github/scripts/Test-Installs.Tests.ps1
+++ b/.github/scripts/Test-Installs.Tests.ps1
@@ -818,3 +818,82 @@ Describe 'Add-Result hex formatting for negative ExitCode' -Tag 'Unit' {
         ($output -join "`n") | Should -Match '0x00000001'
     }
 }
+
+
+# ============================================================================
+# Install helper command-line construction (regression tests for the
+# PackageId-vs-Name confusion and the winget --scope global rejection bug)
+# ============================================================================
+
+Describe 'Install helper command construction' -Tag 'Unit' {
+    BeforeAll {
+        $scriptPath = Join-Path $PSScriptRoot 'Test-Installs.ps1'
+        $scriptContent = Get-Content $scriptPath -Raw
+
+        # Capture the install commands without actually invoking the
+        # external installers. We replace Invoke-WithTimeout and Add-Result
+        # with stubs that record the $Command they receive.
+        $script:CapturedCommands = [System.Collections.ArrayList]::new()
+        function script:Invoke-WithTimeout {
+            param($Command, $TimeoutSeconds)
+            $null = $script:CapturedCommands.Add($Command)
+            return [pscustomobject]@{ ExitCode = 0; Output = ''; TimedOut = $false }
+        }
+        function script:Add-Result {
+            param($Name, $PackageId, $InstallerType, $SourceScript, $Command,
+                  $Status, $ExitCode, $ErrorOutput, $Reason)
+        }
+        function script:Test-IsTransientWingetFailure { param($ExitCode, $Output) $false }
+        $script:DefaultTimeoutSec = 60
+        $script:ScoopTimeoutSec   = 60
+
+        foreach ($f in 'Install-ScoopPackage','Install-ChocoPackage','Install-WingetPackage') {
+            if ($scriptContent -match "(?ms)(function\s+$f\s*\{.+?\n\})") {
+                Invoke-Expression $Matches[1]
+            } else { throw "function $f not found" }
+        }
+    }
+
+    BeforeEach { $script:CapturedCommands.Clear() }
+
+    It 'Install-ScoopPackage uses PackageId, not display Name, in the install command' {
+        Install-ScoopPackage -Name 'Sysinternals Suite' -PackageId 'extras/sysinternals' `
+            -SourceScript 'OSBasePackages.ps1'
+        $script:CapturedCommands[0] | Should -Be 'scoop install -g extras/sysinternals'
+    }
+
+    It 'Install-ScoopPackage falls back to Name when PackageId is empty' {
+        Install-ScoopPackage -Name 'tool' -SourceScript 'fake.ps1'
+        $script:CapturedCommands[0] | Should -Be 'scoop install -g tool'
+    }
+
+    It 'Install-ChocoPackage uses PackageId, not display Name, in the install command' {
+        Install-ChocoPackage -Name 'Node.js' -PackageId 'nodejs' `
+            -SourceScript 'DeveloperBasePackages.ps1'
+        $script:CapturedCommands[0] | Should -Be 'choco install nodejs -y --no-progress'
+    }
+
+    It 'Install-ChocoPackage falls back to Name when PackageId is empty' {
+        Install-ChocoPackage -Name 'pkg' -SourceScript 'fake.ps1'
+        $script:CapturedCommands[0] | Should -Be 'choco install pkg -y --no-progress'
+    }
+
+    It 'Install-WingetPackage maps Scope=global to --scope machine' {
+        Install-WingetPackage -Name 'AnyApp' -PackageId 'Vendor.AnyApp' `
+            -SourceScript 'fake.ps1' -Scope 'global'
+        $script:CapturedCommands[0] | Should -Match '--scope machine'
+        $script:CapturedCommands[0] | Should -Not -Match '--scope global'
+    }
+
+    It 'Install-WingetPackage maps Scope=machine to --scope machine' {
+        Install-WingetPackage -Name 'AnyApp' -PackageId 'Vendor.AnyApp' `
+            -SourceScript 'fake.ps1' -Scope 'machine'
+        $script:CapturedCommands[0] | Should -Match '--scope machine'
+    }
+
+    It 'Install-WingetPackage maps Scope=user to --scope user' {
+        Install-WingetPackage -Name 'AnyApp' -PackageId 'Vendor.AnyApp' `
+            -SourceScript 'fake.ps1' -Scope 'user'
+        $script:CapturedCommands[0] | Should -Match '--scope user'
+    }
+}

--- a/.github/scripts/Test-Installs.ps1
+++ b/.github/scripts/Test-Installs.ps1
@@ -161,7 +161,12 @@ function Install-WingetPackage {
         [string]$SourceScript,
         [string]$Scope = 'machine'
     )
-    $cmd = "winget install --id $PackageId --scope $Scope --accept-package-agreements --accept-source-agreements --disable-interactivity --silent"
+    # winget only accepts 'user' or 'machine' for --scope. The declarative
+    # schema uses 'global' (the new default) as a synonym for machine-wide;
+    # map both 'global' and the legacy 'machine' to winget's 'machine'.
+    # Anything not 'user' falls back to 'machine'.
+    $effectiveScope = if ($Scope -eq 'user') { 'user' } else { 'machine' }
+    $cmd = "winget install --id $PackageId --scope $effectiveScope --accept-package-agreements --accept-source-agreements --disable-interactivity --silent"
     try {
         Write-Host "  Installing [winget] $Name ($PackageId)..."
         $maxAttempts = 3
@@ -181,6 +186,17 @@ function Install-WingetPackage {
                 continue
             }
             break
+        }
+        # If the chosen --scope has no applicable installer (0x8A150014) or the
+        # value is rejected as invalid (0x8A150002), the manifest only ships an
+        # installer for the *other* scope. Retry once without --scope and let
+        # winget pick whatever the package actually supports.
+        if (-not $result.TimedOut -and ($code -eq -1978335212 -or $code -eq -1978335230)) {
+            $fallbackCmd = "winget install --id $PackageId --accept-package-agreements --accept-source-agreements --disable-interactivity --silent"
+            Write-Host "  [winget] ${Name}: --scope $effectiveScope rejected (exit $code); retrying without --scope..."
+            $result = Invoke-WithTimeout -Command $fallbackCmd -TimeoutSeconds $script:DefaultTimeoutSec
+            $code = $result.ExitCode
+            $cmd = $fallbackCmd
         }
         if ($result.TimedOut) {
             Add-Result -Name $Name -PackageId $PackageId -InstallerType 'winget' `
@@ -205,27 +221,29 @@ function Install-WingetPackage {
 function Install-ChocoPackage {
     param(
         [string]$Name,
+        [string]$PackageId,
         [string]$SourceScript
     )
-    $cmd = "choco install $Name -y --no-progress"
+    if (-not $PackageId) { $PackageId = $Name }
+    $cmd = "choco install $PackageId -y --no-progress"
     try {
         Write-Host "  Installing [choco] $Name..."
         $result = Invoke-WithTimeout -Command $cmd -TimeoutSeconds $script:DefaultTimeoutSec
         $code = $result.ExitCode
         if ($result.TimedOut) {
-            Add-Result -Name $Name -PackageId $Name -InstallerType 'choco' `
+            Add-Result -Name $Name -PackageId $PackageId -InstallerType 'choco' `
                 -SourceScript $SourceScript -Command $cmd -Status 'fail' `
                 -ExitCode $code -ErrorOutput $result.Output
         } elseif ($code -eq 0) {
-            Add-Result -Name $Name -PackageId $Name -InstallerType 'choco' `
+            Add-Result -Name $Name -PackageId $PackageId -InstallerType 'choco' `
                 -SourceScript $SourceScript -Command $cmd -Status 'pass'
         } else {
-            Add-Result -Name $Name -PackageId $Name -InstallerType 'choco' `
+            Add-Result -Name $Name -PackageId $PackageId -InstallerType 'choco' `
                 -SourceScript $SourceScript -Command $cmd -Status 'fail' `
                 -ExitCode $code -ErrorOutput $result.Output
         }
     } catch {
-        Add-Result -Name $Name -PackageId $Name -InstallerType 'choco' `
+        Add-Result -Name $Name -PackageId $PackageId -InstallerType 'choco' `
             -SourceScript $SourceScript -Command $cmd -Status 'fail' `
             -ExitCode -1 -ErrorOutput $_.Exception.Message
     }
@@ -234,27 +252,29 @@ function Install-ChocoPackage {
 function Install-ScoopPackage {
     param(
         [string]$Name,
+        [string]$PackageId,
         [string]$SourceScript
     )
-    $cmd = "scoop install -g $Name"
+    if (-not $PackageId) { $PackageId = $Name }
+    $cmd = "scoop install -g $PackageId"
     try {
         Write-Host "  Installing [scoop] $Name..."
         $result = Invoke-WithTimeout -Command $cmd -TimeoutSeconds $script:ScoopTimeoutSec
         $code = $result.ExitCode
         if ($result.TimedOut) {
-            Add-Result -Name $Name -PackageId $Name -InstallerType 'scoop' `
+            Add-Result -Name $Name -PackageId $PackageId -InstallerType 'scoop' `
                 -SourceScript $SourceScript -Command $cmd -Status 'fail' `
                 -ExitCode $code -ErrorOutput $result.Output
         } elseif ($code -eq 0) {
-            Add-Result -Name $Name -PackageId $Name -InstallerType 'scoop' `
+            Add-Result -Name $Name -PackageId $PackageId -InstallerType 'scoop' `
                 -SourceScript $SourceScript -Command $cmd -Status 'pass'
         } else {
-            Add-Result -Name $Name -PackageId $Name -InstallerType 'scoop' `
+            Add-Result -Name $Name -PackageId $PackageId -InstallerType 'scoop' `
                 -SourceScript $SourceScript -Command $cmd -Status 'fail' `
                 -ExitCode $code -ErrorOutput $result.Output
         }
     } catch {
-        Add-Result -Name $Name -PackageId $Name -InstallerType 'scoop' `
+        Add-Result -Name $Name -PackageId $PackageId -InstallerType 'scoop' `
             -SourceScript $SourceScript -Command $cmd -Status 'fail' `
             -ExitCode -1 -ErrorOutput $_.Exception.Message
     }
@@ -736,10 +756,10 @@ foreach ($group in $grouped) {
                     -Reason 'Microsoft Store auth unavailable in CI'
             }
             'choco' {
-                Install-ChocoPackage -Name $pkg.Name -SourceScript $pkg.SourceScript
+                Install-ChocoPackage -Name $pkg.Name -PackageId $pkg.PackageId -SourceScript $pkg.SourceScript
             }
             'scoop' {
-                Install-ScoopPackage -Name $pkg.Name -SourceScript $pkg.SourceScript
+                Install-ScoopPackage -Name $pkg.Name -PackageId $pkg.PackageId -SourceScript $pkg.SourceScript
             }
             'ps-module' {
                 Install-PSModule -Name $pkg.Name -SourceScript $pkg.SourceScript `
@@ -859,7 +879,7 @@ if ($scoopPackages.Count -gt 0) {
                 -Reason "Install was skipped or failed; verification not attempted"
             continue
         }
-        $leaf = Get-ScoopAppLeaf -Name $pkg.Name
+        $leaf = Get-ScoopAppLeaf -Name $pkg.PackageId
         Test-Verification -Name "scoop-global:$($pkg.Name)" `
             -Description "Scoop package '$($pkg.Name)' should be installed globally under $scoopGlobalAppsPath" `
             -Test ([scriptblock]::Create("Test-Path (Join-Path '$scoopGlobalAppsPath' '$leaf')"))


### PR DESCRIPTION
Three CI-harness bugs in `.github/scripts/Test-Installs.ps1` were producing ~30 false-positive install failures on every Heavy run on main, masking real upstream issues and keeping the badge red.

## Bugs fixed

1. **Scoop / Choco helpers ignored PackageId** — `Install-ScoopPackage` and `Install-ChocoPackage` built their command from `$pkg.Name` (display name) instead of `$pkg.PackageId`. Examples that failed silently:
   - `scoop install -g 'Sysinternals Suite'` (real id: `extras/sysinternals`)
   - `choco install Node.js` (real id: `nodejs`)
   - `scoop install -g 'Codex CLI'` (real id: `MarkMichaelis/Codex`)
   - Beyond Compare, eSpeak NG, Gemini CLI, GitHub Copilot CLI, Visual Studio, AIAgents bundle
2. **Verification used display name** — `Get-ScoopAppLeaf` was passed `$pkg.Name`, so the post-install `Test-Path apps\<leaf>` looked for `apps\Sysinternals Suite` instead of `apps\sysinternals`. Every passing scoop install still reported as `scoop-global:<name> fail`.
3. **winget rejected `--scope global`** — The declarative `[Package]` class defaults Scope to `'global'`; the harness forwarded that value verbatim to winget, which only accepts `user`/`machine`. Result: every winget install failed with `The value provided for the scope argument is invalid` (exit `-1978335230` / `0x8A150002`).

## Fixes

- `Install-ScoopPackage` / `Install-ChocoPackage`: add `[string]$PackageId` param (defaults to `$Name`); install command uses `$PackageId`.
- Dispatch loop passes `-PackageId $pkg.PackageId` to scoop/choco helpers.
- Scoop verification: `Get-ScoopAppLeaf -Name $pkg.PackageId`.
- `Install-WingetPackage`: map `'global'` (and anything not `'user'`) to `--scope machine`, matching the module's own `Install-WingetPackage` helper. Also adds a one-shot retry without `--scope` when winget returns no-applicable-installer (`-1978335212`) or invalid-scope (`-1978335230`), so a package that only ships a user-scope installer still installs in CI rather than failing.

## Tests

New `Describe 'Install helper command construction'` in `Test-Installs.Tests.ps1` (7 It blocks, no mocks of system installers — uses an `Invoke-WithTimeout` capture stub) asserts:

- Scoop helper uses PackageId; falls back to Name when PackageId omitted.
- Choco helper uses PackageId; falls back to Name when PackageId omitted.
- Winget helper maps `global` → `--scope machine`, `machine` → `--scope machine`, `user` → `--scope user`.

Local Pester runs:

- `Invoke-Pester -Path bucket -TagFilter Light` → **836 / 0 / 4** (unchanged).
- `Invoke-Pester -Path .github/scripts/Test-Installs.Tests.ps1` → 65 passed; 17 remaining failures are pre-existing legacy text-parser tests for bundles since migrated to the declarative form (not touched by this PR).

## Expected Heavy impact

Once merged, the next push-to-main Heavy run should drop:

- 8 `scoop-global:*` verification failures (Codex CLI, Sysinternals Suite, Beyond Compare, eSpeak NG, Gemini CLI, GitHub Copilot CLI, Visual Studio, AIAgents bundle)
- 1 `choco install` failure (Node.js)
- ~24 winget invalid-scope failures, with the no-applicable-installer fallback resolving most of the rest automatically

Remaining failures after this merge are expected to be true upstream issues (hash mismatches, msstore auth) and can be tracked individually.
