### PR TITLE
Reset winget source before install validation; drop no-scope retry

### DIFF
--- a/.github/scripts/Test-Installs.ps1
+++ b/.github/scripts/Test-Installs.ps1
@@ -187,17 +187,6 @@ function Install-WingetPackage {
             }
             break
         }
-        # If the chosen --scope has no applicable installer (0x8A150014) or the
-        # value is rejected as invalid (0x8A150002), the manifest only ships an
-        # installer for the *other* scope. Retry once without --scope and let
-        # winget pick whatever the package actually supports.
-        if (-not $result.TimedOut -and ($code -eq -1978335212 -or $code -eq -1978335230)) {
-            $fallbackCmd = "winget install --id $PackageId --accept-package-agreements --accept-source-agreements --disable-interactivity --silent"
-            Write-Host "  [winget] ${Name}: --scope $effectiveScope rejected (exit $code); retrying without --scope..."
-            $result = Invoke-WithTimeout -Command $fallbackCmd -TimeoutSeconds $script:DefaultTimeoutSec
-            $code = $result.ExitCode
-            $cmd = $fallbackCmd
-        }
         if ($result.TimedOut) {
             Add-Result -Name $Name -PackageId $PackageId -InstallerType 'winget' `
                 -SourceScript $SourceScript -Command $cmd -Status 'fail' `

--- a/.github/workflows/validate-installs.yml
+++ b/.github/workflows/validate-installs.yml
@@ -73,7 +73,14 @@ jobs:
       - name: Accept winget source agreements
         shell: pwsh
         run: |
-          winget source update --accept-source-agreements
+          # winget sources occasionally land in a corrupted/stale state on
+          # fresh runners (exit 0x8A15000F "Data required by the source is
+          # missing" on subsequent installs). Reset + re-add + update gives
+          # us a clean baseline before any install attempt.
+          Write-Host "winget source reset --force"
+          winget source reset --force --disable-interactivity 2>&1 | ForEach-Object { Write-Host $_ }
+          Write-Host "winget source update --accept-source-agreements"
+          winget source update --accept-source-agreements --disable-interactivity 2>&1 | ForEach-Object { Write-Host $_ }
           winget source list
 
       - name: Bootstrap Chocolatey


### PR DESCRIPTION
Reset winget source before install validation + drop no-scope retry.

## Why

After #135 merged, the Heavy run cleanly surfaced two issues that the
"invalid scope value" bug had been masking:

1. **Every winget install was failing with exit `-1978335217`
   (0x8A15000F)**  `Failed in attempting to update the source:
   winget` / `Data required by the source is missing`. The
   "Accept winget source agreements" step runs at the top of the job
   (after Resolve artifact paths, before Bootstrap Chocolatey/Scoop),
   so by the time `Run install validation` starts the winget source
   has gone stale on the windows-2025 runner. `winget install` then
   tries to auto-update the source mid-install and trips on the missing
   metadata.

2. The no-scope-retry fallback I added to `Install-WingetPackage`
   in #135 (retry on NO_APPLICABLE_INSTALLER without `--scope`) is
   now redundant. With the declarative schema's per-package `Scope`
   override flowing through correctly (#135), the right place to
   declare "this package is user-scope only" is the manifest, not a
   blanket retry that costs us extra real installs on the runner.

## What

- `.github/workflows/validate-installs.yml`  replace the bare
  `winget source update` with `winget source reset --force` +
  `winget source update`. Reset + re-add gives every subsequent
  `winget install` a clean source baseline. `--disable-interactivity`
  on both calls.
- `.github/scripts/Test-Installs.ps1`  drop the no-scope-retry
  block from `Install-WingetPackage`.

## Expected impact on Heavy

Pre-fix (run 25954369045): 107 pkgs, 70 pass, 27 fail, 10 untested.
26 of the 27 failures were exit -1978335217 caused by the source
issue. After this PR I expect those 26 to flip to pass (or to whatever
real installer-level error they have, which is what we actually want
to see and triage).

## Verification

- Light: Pester install-helper tests (7/7) still pass  the removed
  retry block wasn't covered by an assertion.
- Heavy will only run on push to `main` per workflow trigger, so the
  real validation happens after merge.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
