### PR TITLE
Require completion for every Package with CliCommands (wire all 25 violators)

### DIFF
--- a/bucket/AIAgents.json
+++ b/bucket/AIAgents.json
@@ -1,6 +1,6 @@
 {
     "$schema": "https://raw.githubusercontent.com/lukesampson/scoop/master/schema.json",
-    "version": "1.15.000",
+    "version": "1.16.000",
     "url": [
         "https://raw.githubusercontent.com/MarkMichaelis/ScoopBucket/master/bucket/AIAgents.ps1"
     ],

--- a/bucket/AIAgents.ps1
+++ b/bucket/AIAgents.ps1
@@ -33,7 +33,46 @@ $Packages = [Package[]]@(
         Installer   = 'choco'
         Id          = 'nodejs'
         CliCommands = @('node','npm','npx')
-        Notes       = 'Required for every npx-based MCP server (context7, playwright, filesystem, github).'
+        Completion  = 'auto'
+        Notes       = 'Required for every npx-based MCP server (context7, playwright, filesystem, github). node/npm have PSCompletions entries but npx does not, so ship a shared hand-curated NativeCommandScript that registers all three uniformly here.'
+        ExpectedCompletions = @{
+            node = @('--help','--version','--eval')
+            npm  = @('install','run','version')
+            npx  = @('--help','--version','--package')
+        }
+        NativeCommandScript = {
+            @"
+Register-ArgumentCompleter -Native -CommandName node -ScriptBlock {
+    param(`$wordToComplete, `$commandAst, `$cursorPosition)
+    @(
+        '--help','--version','--eval','--print','--check','--interactive','--require','--inspect',
+        '--inspect-brk','--enable-source-maps','--experimental-modules','--experimental-vm-modules',
+        '--unhandled-rejections','--use-openssl-ca','--no-warnings','--trace-warnings'
+    ) | Where-Object { `$_ -like "`$wordToComplete*" } | ForEach-Object {
+        [System.Management.Automation.CompletionResult]::new(`$_, `$_, 'ParameterValue', `$_)
+    }
+}
+Register-ArgumentCompleter -Native -CommandName npm -ScriptBlock {
+    param(`$wordToComplete, `$commandAst, `$cursorPosition)
+    @(
+        'install','uninstall','update','run','start','test','version','init','publish','pack',
+        'config','cache','audit','outdated','ls','list','link','unlink','search','view','prune',
+        'rebuild','restart','stop','adduser','login','logout','whoami','--help','--version'
+    ) | Where-Object { `$_ -like "`$wordToComplete*" } | ForEach-Object {
+        [System.Management.Automation.CompletionResult]::new(`$_, `$_, 'ParameterValue', `$_)
+    }
+}
+Register-ArgumentCompleter -Native -CommandName npx -ScriptBlock {
+    param(`$wordToComplete, `$commandAst, `$cursorPosition)
+    @(
+        '--help','--version','--package','--call','--no-install','--ignore-existing','--yes','--no',
+        '--shell','--cache','--prefer-offline','--prefer-online','--offline','--quiet','--verbose'
+    ) | Where-Object { `$_ -like "`$wordToComplete*" } | ForEach-Object {
+        [System.Management.Automation.CompletionResult]::new(`$_, `$_, 'ParameterValue', `$_)
+    }
+}
+"@
+        }
     }
 
     # Agent apps.
@@ -65,6 +104,23 @@ $Packages = [Package[]]@(
         Id          = 'MarkMichaelis/ClaudeCode'
         CliCommands = @('claude')
         DependsOn   = @('Node.js')
+        Completion  = 'auto'
+        Notes       = 'claude has no completion subcommand and no PSCompletions entry. Hand-curated top-level command list.'
+        ExpectedCompletions = @{ claude = @('--help','--version','mcp') }
+        NativeCommandScript = {
+            @"
+Register-ArgumentCompleter -Native -CommandName claude -ScriptBlock {
+    param(`$wordToComplete, `$commandAst, `$cursorPosition)
+    @(
+        '--help','--version','--print','--continue','--resume','--model','--add-dir',
+        '--allowedTools','--disallowedTools','--mcp-config','--append-system-prompt',
+        '--verbose','--debug','mcp','config','update','migrate-installer','doctor'
+    ) | Where-Object { `$_ -like "`$wordToComplete*" } | ForEach-Object {
+        [System.Management.Automation.CompletionResult]::new(`$_, `$_, 'ParameterValue', `$_)
+    }
+}
+"@
+        }
     }
     [Package]@{
         Name        = 'Codex CLI'
@@ -72,6 +128,23 @@ $Packages = [Package[]]@(
         Id          = 'MarkMichaelis/Codex'
         CliCommands = @('codex')
         DependsOn   = @('Node.js')
+        Completion  = 'auto'
+        Notes       = 'codex has no completion subcommand and no PSCompletions entry. Hand-curated top-level command list.'
+        ExpectedCompletions = @{ codex = @('--help','--version','exec') }
+        NativeCommandScript = {
+            @"
+Register-ArgumentCompleter -Native -CommandName codex -ScriptBlock {
+    param(`$wordToComplete, `$commandAst, `$cursorPosition)
+    @(
+        '--help','--version','--model','--config','--cd','--ask-for-approval','--sandbox',
+        '--dangerously-bypass-approvals-and-sandbox','--full-auto','exec','login','logout',
+        'mcp','completion','update','resume','--profile'
+    ) | Where-Object { `$_ -like "`$wordToComplete*" } | ForEach-Object {
+        [System.Management.Automation.CompletionResult]::new(`$_, `$_, 'ParameterValue', `$_)
+    }
+}
+"@
+        }
     }
     [Package]@{
         Name        = 'Gemini CLI'
@@ -79,6 +152,23 @@ $Packages = [Package[]]@(
         Id          = 'MarkMichaelis/GeminiCli'
         CliCommands = @('gemini')
         DependsOn   = @('Node.js')
+        Completion  = 'auto'
+        Notes       = 'gemini has no completion subcommand and no PSCompletions entry. Hand-curated top-level command/flag list.'
+        ExpectedCompletions = @{ gemini = @('--help','--version','--model') }
+        NativeCommandScript = {
+            @"
+Register-ArgumentCompleter -Native -CommandName gemini -ScriptBlock {
+    param(`$wordToComplete, `$commandAst, `$cursorPosition)
+    @(
+        '--help','--version','--model','--prompt','--sandbox','--debug','--all-files',
+        '--yolo','--checkpointing','--telemetry','--telemetry-target','--allowed-mcp-server-names',
+        '--extensions','--list-extensions','mcp','--show-memory-usage'
+    ) | Where-Object { `$_ -like "`$wordToComplete*" } | ForEach-Object {
+        [System.Management.Automation.CompletionResult]::new(`$_, `$_, 'ParameterValue', `$_)
+    }
+}
+"@
+        }
     }
     [Package]@{
         Name        = 'GitHub Copilot CLI'
@@ -86,7 +176,23 @@ $Packages = [Package[]]@(
         Id          = 'MarkMichaelis/GitHubCopilotCli'
         CliCommands = @('copilot')
         DependsOn   = @('Node.js')
-        Notes       = '`copilot completion` only supports bash/zsh/fish; not in PSCompletions catalog. No PS completion shipped — track upstream (#73).'
+        Completion  = 'auto'
+        Notes       = '`copilot completion` only supports bash/zsh/fish; not in PSCompletions catalog (#73). Hand-curated top-level flag/command list (mirrors DeveloperBasePackages winget GitHub.Copilot package).'
+        ExpectedCompletions = @{ copilot = @('--help','--version','--model') }
+        NativeCommandScript = {
+            @"
+Register-ArgumentCompleter -Native -CommandName copilot -ScriptBlock {
+    param(`$wordToComplete, `$commandAst, `$cursorPosition)
+    @(
+        '--help','--version','--model','--prompt','--allow-tool','--deny-tool',
+        '--allow-all-tools','--add-dir','--no-color','--banner','--resume','--continue',
+        '--screen-reader','--log-level','--log-dir','-p','--allow-all-paths'
+    ) | Where-Object { `$_ -like "`$wordToComplete*" } | ForEach-Object {
+        [System.Management.Automation.CompletionResult]::new(`$_, `$_, 'ParameterValue', `$_)
+    }
+}
+"@
+        }
     }
 )
 

--- a/bucket/Aspire.json
+++ b/bucket/Aspire.json
@@ -1,6 +1,6 @@
 {
     "$schema": "https://raw.githubusercontent.com/lukesampson/scoop/master/schema.json",
-    "version": "1.08.000",
+    "version": "1.09.000",
     "url": [
         "https://raw.githubusercontent.com/MarkMichaelis/ScoopBucket/master/bucket/Aspire.ps1"
     ],

--- a/bucket/Aspire.ps1
+++ b/bucket/Aspire.ps1
@@ -15,7 +15,22 @@ $Packages = [Package[]]@(
         Installer   = 'dotnetTool'
         Id          = 'Aspire.Cli'
         CliCommands = @('aspire')
-        Notes       = 'Global dotnet tool. Requires dotnet SDK on PATH.'
+        Completion  = 'auto'
+        Notes       = 'Global dotnet tool. Requires dotnet SDK on PATH. aspire has no completion subcommand and no PSCompletions entry; hand-curated top-level command list.'
+        ExpectedCompletions = @{ aspire = @('new','run','add') }
+        NativeCommandScript = {
+            @"
+Register-ArgumentCompleter -Native -CommandName aspire -ScriptBlock {
+    param(`$wordToComplete, `$commandAst, `$cursorPosition)
+    @(
+        'new','run','add','publish','deploy','exec','config','update','--help','--version',
+        '-h','--debug','--cli-version','--wait-for-debugger'
+    ) | Where-Object { `$_ -like "`$wordToComplete*" } | ForEach-Object {
+        [System.Management.Automation.CompletionResult]::new(`$_, `$_, 'ParameterValue', `$_)
+    }
+}
+"@
+        }
         PostInstallScript = {
             if (-not (Get-Command dotnet -ErrorAction SilentlyContinue)) {
                 $candidates = @(

--- a/bucket/Bundles.Tests.ps1
+++ b/bucket/Bundles.Tests.ps1
@@ -132,6 +132,16 @@ Describe 'Declarative bundles (data-driven)' -Tag 'Light','Bundle' {
         }
     }
 
+    It '<Pkg.Name> (<Bundle>) registers Completion when CliCommands is non-empty' -ForEach $script:pkgCases {
+        # Inverse of the assertion above: declaring CliCommands without picking
+        # a Completion strategy silently ships a CLI with no Tab-completion.
+        # Matches the Package.Validate() guard introduced after the Everything
+        # CLI / Node.js / dotnet / etc. gap (25 packages were affected).
+        if (@($Pkg.CliCommands).Count -gt 0) {
+            $Pkg.Completion | Should -Not -Be 'none' -Because "package declares CliCommands ($(@($Pkg.CliCommands) -join ', ')) but Completion='none' -- pick native|pscompletions|auto and add ExpectedCompletions"
+        }
+    }
+
     It '<Pkg.Name> (<Bundle>) declares ExpectedCompletions for every CLI when Completion != none' -ForEach $script:pkgCases {
         if ($Pkg.Completion -in @('native','pscompletions','auto')) {
             $Pkg.ExpectedCompletions | Should -Not -BeNullOrEmpty

--- a/bucket/ClientBasePackages.json
+++ b/bucket/ClientBasePackages.json
@@ -1,6 +1,6 @@
 {
     "$schema": "https://raw.githubusercontent.com/lukesampson/scoop/master/schema.json",
-    "version": "1.15.000",
+    "version": "1.16.000",
     "url": [
         "https://raw.githubusercontent.com/MarkMichaelis/ScoopBucket/master/bucket/ClientBasePackages.ps1"
     ],

--- a/bucket/ClientBasePackages.ps1
+++ b/bucket/ClientBasePackages.ps1
@@ -10,11 +10,54 @@ if (Test-Path $scoopBucketPsd1) { Import-Module $scoopBucketPsd1 -Force } else {
 #   #73               bw / gcloud have no PSCompletions catalog entry — ship our own native completer
 
 $Packages = [Package[]]@(
-    [Package]@{ Name = 'exiftool';         Installer = 'choco';  Id = 'exiftool';                                CliCommands = @('exiftool') }
+    [Package]@{
+        Name        = 'exiftool'
+        Installer   = 'choco'
+        Id          = 'exiftool'
+        CliCommands = @('exiftool')
+        Completion  = 'auto'
+        Notes       = 'exiftool has no completion subcommand and no PSCompletions entry. Hand-curated common-options list (full surface is ~500 tag names).'
+        ExpectedCompletions = @{ exiftool = @('-help','-overwrite_original','-r') }
+        NativeCommandScript = {
+            @"
+Register-ArgumentCompleter -Native -CommandName exiftool -ScriptBlock {
+    param(`$wordToComplete, `$commandAst, `$cursorPosition)
+    @(
+        '-help','-ver','-r','-q','-quiet','-overwrite_original','-overwrite_original_in_place',
+        '-preserve','-P','-ext','-ee','-G','-a','-s','-S','-T','-csv','-json','-xml','-html',
+        '-args','-charset','-d','-list','-listw','-listf','-listg','-listr','-listx',
+        '-Filename','-Directory','-FileModifyDate','-Comment','-Keywords','-Subject','-Title'
+    ) | Where-Object { `$_ -like "`$wordToComplete*" } | ForEach-Object {
+        [System.Management.Automation.CompletionResult]::new(`$_, `$_, 'ParameterValue', `$_)
+    }
+}
+"@
+        }
+    }
     [Package]@{ Name = 'GeoSetter';        Installer = 'choco';  Id = 'geosetter' }
 
-    [Package]@{ Name = 'DbxCli';           Installer = 'scoop';  Id = 'MarkMichaelis/DbxCli';                    CliCommands = @('dbxcli')
-                Notes = 'dbxcli delisted from chocolatey (#13). Installed via this bucket''s DbxCli.json which pulls upstream GitHub release.' }
+    [Package]@{
+        Name        = 'DbxCli'
+        Installer   = 'scoop'
+        Id          = 'MarkMichaelis/DbxCli'
+        CliCommands = @('dbxcli')
+        Completion  = 'auto'
+        Notes       = 'dbxcli delisted from chocolatey (#13). Installed via this bucket''s DbxCli.json which pulls upstream GitHub release. dbxcli is a cobra-based tool but ships no completion subcommand; hand-curate the top-level command list.'
+        ExpectedCompletions = @{ dbxcli = @('get','put','ls') }
+        NativeCommandScript = {
+            @"
+Register-ArgumentCompleter -Native -CommandName dbxcli -ScriptBlock {
+    param(`$wordToComplete, `$commandAst, `$cursorPosition)
+    @(
+        'account','du','get','ls','mkdir','mv','put','restore','revs','rm','search','share',
+        'team','version','help','--help','-h'
+    ) | Where-Object { `$_ -like "`$wordToComplete*" } | ForEach-Object {
+        [System.Management.Automation.CompletionResult]::new(`$_, `$_, 'ParameterValue', `$_)
+    }
+}
+"@
+        }
+    }
 
     [Package]@{ Name = 'AIAgents bundle';  Installer = 'scoop';  Id = 'MarkMichaelis/AIAgents'
                 Notes = 'Pulls every AI agent + Claude Desktop and configures MCP servers; see AIAgents.ps1.' }
@@ -23,7 +66,29 @@ $Packages = [Package[]]@(
                 WingetExtraArgs = @('--skip-dependencies')
                 Notes = 'Free open-source local speech-to-text (https://handy.computer). Runs Whisper/Parakeet locally; no cloud. User-scope only. Declares a KhronosGroup.VulkanRT dependency winget cannot resolve on most machines (already present via GPU drivers), so we skip dependency processing.' }
 
-    [Package]@{ Name = 'eSpeak NG';        Installer = 'scoop';  Id = 'main/espeak-ng';    CliCommands = @('espeak-ng') }
+    [Package]@{
+        Name        = 'eSpeak NG'
+        Installer   = 'scoop'
+        Id          = 'main/espeak-ng'
+        CliCommands = @('espeak-ng')
+        Completion  = 'auto'
+        Notes       = 'espeak-ng has no completion subcommand and no PSCompletions entry. Hand-curated flag list.'
+        ExpectedCompletions = @{ 'espeak-ng' = @('--help','-v','-s') }
+        NativeCommandScript = {
+            @"
+Register-ArgumentCompleter -Native -CommandName espeak-ng -ScriptBlock {
+    param(`$wordToComplete, `$commandAst, `$cursorPosition)
+    @(
+        '--help','--version','-v','-s','-p','-a','-g','-k','-l','-f','-w','-x','-X','-q','-m',
+        '-b','--stdin','--stdout','--pho','--phonout','--punct','--split','--path','--ipa',
+        '--voices','--compile','--compile-debug'
+    ) | Where-Object { `$_ -like "`$wordToComplete*" } | ForEach-Object {
+        [System.Management.Automation.CompletionResult]::new(`$_, `$_, 'ParameterValue', `$_)
+    }
+}
+"@
+        }
+    }
     [Package]@{ Name = 'Notion';           Installer = 'scoop';  Id = 'extras/notion' }
     [Package]@{ Name = 'Spotify';          Installer = 'scoop';  Id = 'extras/spotify' }
     [Package]@{ Name = 'Zoom';             Installer = 'scoop';  Id = 'extras/zoom' }
@@ -56,7 +121,29 @@ Register-ArgumentCompleter -Native -CommandName bw -ScriptBlock {
         }
     }
     [Package]@{ Name = 'calibre';          Installer = 'winget'; Id = 'calibre.calibre' }
-    [Package]@{ Name = 'SoX';              Installer = 'winget'; Id = 'ChrisBagwell.SoX';      CliCommands = @('sox') }
+    [Package]@{
+        Name        = 'SoX'
+        Installer   = 'winget'
+        Id          = 'ChrisBagwell.SoX'
+        CliCommands = @('sox')
+        Completion  = 'auto'
+        Notes       = 'sox has no completion subcommand and no PSCompletions entry. Hand-curated common-options list (effect names enumerated via `sox --help-effect` are out of scope).'
+        ExpectedCompletions = @{ sox = @('--help','--version','-r') }
+        NativeCommandScript = {
+            @"
+Register-ArgumentCompleter -Native -CommandName sox -ScriptBlock {
+    param(`$wordToComplete, `$commandAst, `$cursorPosition)
+    @(
+        '--help','--help-effect','--help-format','--version','-r','-c','-b','-e','-t','-V','-S',
+        '-n','-d','-D','-q','-G','-R','--norm','--combine','--effects-file','--multi-threaded',
+        '--no-clobber','--show-progress','--type','--channels','--bits','--rate','--encoding'
+    ) | Where-Object { `$_ -like "`$wordToComplete*" } | ForEach-Object {
+        [System.Management.Automation.CompletionResult]::new(`$_, `$_, 'ParameterValue', `$_)
+    }
+}
+"@
+        }
+    }
     [Package]@{ Name = 'Dropbox';          Installer = 'winget'; Id = 'Dropbox.Dropbox' }
     [Package]@{ Name = 'Foxit PDF Reader'; Installer = 'winget'; Id = 'Foxit.FoxitReader'
                 Notes = 'choco foxitreader times out downloading upstream installer (#27). winget is preferred per README.' }

--- a/bucket/DeveloperBasePackages.json
+++ b/bucket/DeveloperBasePackages.json
@@ -1,6 +1,6 @@
 {
     "$schema": "https://raw.githubusercontent.com/lukesampson/scoop/master/schema.json",
-    "version": "1.20.000",
+    "version": "1.21.000",
     "url": [
         "https://raw.githubusercontent.com/MarkMichaelis/ScoopBucket/master/bucket/DeveloperBasePackages.ps1"
     ],

--- a/bucket/DeveloperBasePackages.ps1
+++ b/bucket/DeveloperBasePackages.ps1
@@ -6,16 +6,79 @@ if (Test-Path $scoopBucketPsd1) { Import-Module $scoopBucketPsd1 -Force } else {
 #   #73      copilot completion via PSCompletions (no native PS completion command)
 
 $Packages = [Package[]]@(
-    [Package]@{ Name = 'Node.js';                       Installer = 'choco';  Id = 'nodejs';                                              CliCommands = @('node','npm') }
+    [Package]@{
+        Name        = 'Node.js'
+        Installer   = 'choco'
+        Id          = 'nodejs'
+        CliCommands = @('node','npm')
+        Completion  = 'pscompletions'
+        ExpectedCompletions = @{
+            node = @('--help','--version','--eval')
+            npm  = @('install','run','version')
+        }
+    }
 
-    [Package]@{ Name = 'dotnet';                        Installer = 'scoop';  Id = 'main/dotnet';                                          CliCommands = @('dotnet') }
-    [Package]@{ Name = 'Visual Studio';                 Installer = 'scoop';  Id = 'MarkMichaelis/VisualStudio2026Enterprise';             CliCommands = @('devenv') }
+    [Package]@{
+        Name        = 'dotnet'
+        Installer   = 'scoop'
+        Id          = 'main/dotnet'
+        CliCommands = @('dotnet')
+        Completion  = 'pscompletions'
+        ExpectedCompletions = @{ dotnet = @('build','run','test') }
+    }
+    [Package]@{
+        Name        = 'Visual Studio'
+        Installer   = 'scoop'
+        Id          = 'MarkMichaelis/VisualStudio2026Enterprise'
+        CliCommands = @('devenv')
+        Completion  = 'auto'
+        Notes       = 'devenv has no completion subcommand and no PSCompletions entry; hand-curated common-options list from `devenv /?`.'
+        ExpectedCompletions = @{ devenv = @('/Build','/Run','/Edit') }
+        NativeCommandScript = {
+            @"
+Register-ArgumentCompleter -Native -CommandName devenv -ScriptBlock {
+    param(`$wordToComplete, `$commandAst, `$cursorPosition)
+    @(
+        '/Build','/Clean','/Rebuild','/Deploy','/Run','/RunExit','/Edit','/Diff','/Merge',
+        '/Out','/Log','/Command','/SafeMode','/ResetSettings','/ResetUserData','/ResetSkipPkgs',
+        '/InstallVSTemplates','/Setup','/NoSplash','/Project','/ProjectConfig','/Help','/?',
+        '/Upgrade','/UseEnv'
+    ) | Where-Object { `$_ -like "`$wordToComplete*" } | ForEach-Object {
+        [System.Management.Automation.CompletionResult]::new(`$_, `$_, 'ParameterValue', `$_)
+    }
+}
+"@
+        }
+    }
     [Package]@{
         Name        = 'Beyond Compare'
         Installer   = 'scoop'
         Id          = 'extras/beyondcompare'
         CliCommands = @('bcomp','bcompare')
-        Notes       = 'Keep scoop default bcomp shim (BComp.exe, GUI launcher). Add a separate bcomp.com shim for BComp.com (console-waiting variant) so git/scripted callers can request blocking semantics on demand. Refs #14/#46.'
+        Completion  = 'auto'
+        Notes       = 'Keep scoop default bcomp shim (BComp.exe, GUI launcher). Add a separate bcomp.com shim for BComp.com (console-waiting variant) so git/scripted callers can request blocking semantics on demand. Refs #14/#46. Neither bcomp nor bcompare has a completion subcommand or PSCompletions entry; hand-curated shared flag list.'
+        ExpectedCompletions = @{
+            bcomp    = @('/?','/closescript','/silent')
+            bcompare = @('/?','/closescript','/silent')
+        }
+        NativeCommandScript = {
+            @"
+@('bcomp','bcompare') | ForEach-Object {
+    `$cli = `$_
+    Register-ArgumentCompleter -Native -CommandName `$cli -ScriptBlock {
+        param(`$wordToComplete, `$commandAst, `$cursorPosition)
+        @(
+            '/?','/help','/silent','/closescript','/automerge','/reviewconflicts',
+            '/title1','/title2','/title3','/lefttitle','/centertitle','/righttitle',
+            '/savetarget','/expandall','/leftreadonly','/centerreadonly','/rightreadonly',
+            '/qc','/quickcompare','/edit','/snapshot','/fv','/iv'
+        ) | Where-Object { `$_ -like "`$wordToComplete*" } | ForEach-Object {
+            [System.Management.Automation.CompletionResult]::new(`$_, `$_, 'ParameterValue', `$_)
+        }
+    }
+}
+"@
+        }
         PostInstallScript = {
             try {
                 $dir = (& scoop prefix beyondcompare 2>$null | Select-Object -First 1)
@@ -32,15 +95,62 @@ $Packages = [Package[]]@(
         }
     }
 
-    [Package]@{ Name = 'Visual Studio Code';            Installer = 'winget'; Id = 'Microsoft.VisualStudioCode';                            CliCommands = @('code') }
+    [Package]@{
+        Name        = 'Visual Studio Code'
+        Installer   = 'winget'
+        Id          = 'Microsoft.VisualStudioCode'
+        CliCommands = @('code')
+        Completion  = 'auto'
+        Notes       = '`code --help` lists CLI switches but `code` has no completion subcommand and no PSCompletions catalog entry. Hand-curated flag list (mirrors OSBasePackages).'
+        ExpectedCompletions = @{ code = @('--help','--diff','--new-window') }
+        NativeCommandScript = {
+            @"
+Register-ArgumentCompleter -Native -CommandName code -ScriptBlock {
+    param(`$wordToComplete, `$commandAst, `$cursorPosition)
+    @(
+        '--help','--version','--diff','--merge','--add','--goto','--new-window','--reuse-window',
+        '--wait','--locale','--user-data-dir','--profile','--extensions-dir','--list-extensions',
+        '--install-extension','--uninstall-extension','--enable-proposed-api','--status',
+        '--prof-startup','--disable-extensions','--disable-extension','--sync','--inspect-extensions',
+        '--inspect-brk-extensions','--verbose','--log','--telemetry'
+    ) | Where-Object { `$_ -like "`$wordToComplete*" } | ForEach-Object {
+        [System.Management.Automation.CompletionResult]::new(`$_, `$_, 'ParameterValue', `$_)
+    }
+}
+"@
+        }
+    }
     [Package]@{
         Name        = 'GitHub Copilot CLI'
         Installer   = 'winget'
         Id          = 'GitHub.Copilot'
         CliCommands = @('copilot')
-        Notes       = '`copilot completion` only supports bash/zsh/fish; not in PSCompletions catalog. No PS completion shipped — track upstream (#73).'
+        Completion  = 'auto'
+        Notes       = '`copilot completion` only supports bash/zsh/fish; not in PSCompletions catalog (#73). Hand-curated top-level flag/command list.'
+        ExpectedCompletions = @{ copilot = @('--help','--version','--model') }
+        NativeCommandScript = {
+            @"
+Register-ArgumentCompleter -Native -CommandName copilot -ScriptBlock {
+    param(`$wordToComplete, `$commandAst, `$cursorPosition)
+    @(
+        '--help','--version','--model','--prompt','--allow-tool','--deny-tool',
+        '--allow-all-tools','--add-dir','--no-color','--banner','--resume','--continue',
+        '--screen-reader','--log-level','--log-dir','-p','--allow-all-paths'
+    ) | Where-Object { `$_ -like "`$wordToComplete*" } | ForEach-Object {
+        [System.Management.Automation.CompletionResult]::new(`$_, `$_, 'ParameterValue', `$_)
     }
-    [Package]@{ Name = 'Python';                        Installer = 'winget'; Id = 'Python.Python.3.14';                                    CliCommands = @('python') }
+}
+"@
+        }
+    }
+    [Package]@{
+        Name        = 'Python'
+        Installer   = 'winget'
+        Id          = 'Python.Python.3.14'
+        CliCommands = @('python')
+        Completion  = 'pscompletions'
+        ExpectedCompletions = @{ python = @('--help','--version','-m') }
+    }
 
     [Package]@{
         Name        = 'Aspire'
@@ -48,7 +158,22 @@ $Packages = [Package[]]@(
         Id          = 'MarkMichaelis/Aspire'
         CliCommands = @('aspire')
         DependsOn   = @('dotnet','Visual Studio')
-        Notes       = 'Bundle manifest invokes `dotnet tool install --global Aspire.Cli` + project templates. DependsOn ensures dotnet+VS are in place first.'
+        Completion  = 'auto'
+        Notes       = 'Bundle manifest invokes `dotnet tool install --global Aspire.Cli` + project templates. DependsOn ensures dotnet+VS are in place first. aspire has no completion subcommand and no PSCompletions entry; hand-curated top-level command list (mirrors Aspire bundle).'
+        ExpectedCompletions = @{ aspire = @('new','run','add') }
+        NativeCommandScript = {
+            @"
+Register-ArgumentCompleter -Native -CommandName aspire -ScriptBlock {
+    param(`$wordToComplete, `$commandAst, `$cursorPosition)
+    @(
+        'new','run','add','publish','deploy','exec','config','update','--help','--version',
+        '-h','--debug','--cli-version','--wait-for-debugger'
+    ) | Where-Object { `$_ -like "`$wordToComplete*" } | ForEach-Object {
+        [System.Management.Automation.CompletionResult]::new(`$_, `$_, 'ParameterValue', `$_)
+    }
+}
+"@
+        }
     }
 )
 

--- a/bucket/OSBasePackages.json
+++ b/bucket/OSBasePackages.json
@@ -1,6 +1,6 @@
 {
     "$schema": "https://raw.githubusercontent.com/lukesampson/scoop/master/schema.json",
-    "version": "1.22.000",
+    "version": "1.23.000",
     "url": [
         "https://raw.githubusercontent.com/MarkMichaelis/ScoopBucket/master/bucket/OSBasePackages.ps1"
     ],

--- a/bucket/OSBasePackages.ps1
+++ b/bucket/OSBasePackages.ps1
@@ -8,15 +8,96 @@ if (Test-Path $scoopBucketPsd1) { Import-Module $scoopBucketPsd1 -Force } else {
 #   #73  rg native completion + gcloud PSCompletions fallback
 
 $Packages = [Package[]]@(
-    [Package]@{ Name = 'Windows Terminal';              Installer = 'winget'; Id = 'Microsoft.WindowsTerminal';                          CliCommands = @('wt') }
-    [Package]@{ Name = '7-Zip';                         Installer = 'winget'; Id = '7Zip.7Zip';                                          CliCommands = @('7z') }
+    [Package]@{
+        Name        = 'Windows Terminal'
+        Installer   = 'winget'
+        Id          = 'Microsoft.WindowsTerminal'
+        CliCommands = @('wt')
+        Completion  = 'pscompletions'
+        ExpectedCompletions = @{ wt = @('new-tab','split-pane','focus-tab') }
+    }
+    [Package]@{
+        Name        = '7-Zip'
+        Installer   = 'winget'
+        Id          = '7Zip.7Zip'
+        CliCommands = @('7z')
+        Completion  = 'pscompletions'
+        ExpectedCompletions = @{ '7z' = @('a','x','l') }
+    }
     [Package]@{ Name = 'Everything';                    Installer = 'winget'; Id = 'voidtools.Everything' }
-    [Package]@{ Name = 'Everything CLI';                Installer = 'winget'; Id = 'voidtools.Everything.Cli';                           CliCommands = @('es') }
+    [Package]@{
+        Name        = 'Everything CLI'
+        Installer   = 'winget'
+        Id          = 'voidtools.Everything.Cli'
+        CliCommands = @('es')
+        Completion  = 'auto'
+        Notes       = 'es.exe has no PowerShell completion subcommand and no PSCompletions catalog entry; ship hand-curated top-level flags so Tab returns the common search-control switches.'
+        ExpectedCompletions = @{ es = @('-s','-r','-n','-sort','-help') }
+        NativeCommandScript = {
+            @"
+Register-ArgumentCompleter -Native -CommandName es -ScriptBlock {
+    param(`$wordToComplete, `$commandAst, `$cursorPosition)
+    @(
+        '-s','-r','-i','-w','-p','-c','-n','-sort','-name','-path','-size','-date-modified',
+        '-date-created','-attributes','-r-name','-r-path','-help','-export-csv','-export-txt',
+        '-folder','-file','-instance','-set-run-count','-inc-run-count'
+    ) | Where-Object { `$_ -like "`$wordToComplete*" } | ForEach-Object {
+        [System.Management.Automation.CompletionResult]::new(`$_, `$_, 'ParameterValue', `$_)
+    }
+}
+"@
+        }
+    }
     [Package]@{ Name = 'Google Chrome';                 Installer = 'winget'; Id = 'Google.Chrome' }
     [Package]@{ Name = 'WinDirStat';                    Installer = 'winget'; Id = 'WinDirStat.WinDirStat' }
     [Package]@{ Name = 'UniversalSilentSwitchFinder';   Installer = 'winget'; Id = 'WindowsPostInstallWizard.UniversalSilentSwitchFinder' }
-    [Package]@{ Name = 'bat';                           Installer = 'winget'; Id = 'sharkdp.bat';                                        CliCommands = @('bat') }
-    [Package]@{ Name = 'fzf';                           Installer = 'winget'; Id = 'junegunn.fzf';                                       CliCommands = @('fzf') }
+    [Package]@{
+        Name        = 'bat'
+        Installer   = 'winget'
+        Id          = 'sharkdp.bat'
+        CliCommands = @('bat')
+        Completion  = 'auto'
+        Notes       = 'bat ships zsh/bash/fish completion only; no PowerShell command and no PSCompletions entry. Hand-curated top-level flag list.'
+        ExpectedCompletions = @{ bat = @('--help','--list-languages','--style') }
+        NativeCommandScript = {
+            @"
+Register-ArgumentCompleter -Native -CommandName bat -ScriptBlock {
+    param(`$wordToComplete, `$commandAst, `$cursorPosition)
+    @(
+        '--help','--version','--list-languages','--list-themes','--language','--theme',
+        '--style','--paging','--color','--decorations','--wrap','--tabs','--line-range',
+        '--show-all','--plain','--number','--cache-build','--diff','--diff-context'
+    ) | Where-Object { `$_ -like "`$wordToComplete*" } | ForEach-Object {
+        [System.Management.Automation.CompletionResult]::new(`$_, `$_, 'ParameterValue', `$_)
+    }
+}
+"@
+        }
+    }
+    [Package]@{
+        Name        = 'fzf'
+        Installer   = 'winget'
+        Id          = 'junegunn.fzf'
+        CliCommands = @('fzf')
+        Completion  = 'auto'
+        Notes       = 'fzf ships shell-key-binding completion for bash/zsh/fish (and a PowerShell PSFzf module) but no native `fzf completion powershell` and no PSCompletions entry. Hand-curated top-level flag list.'
+        ExpectedCompletions = @{ fzf = @('--help','--height','--reverse') }
+        NativeCommandScript = {
+            @"
+Register-ArgumentCompleter -Native -CommandName fzf -ScriptBlock {
+    param(`$wordToComplete, `$commandAst, `$cursorPosition)
+    @(
+        '--help','--version','--height','--reverse','--multi','--query','--filter',
+        '--preview','--preview-window','--bind','--header','--prompt','--ansi',
+        '--no-sort','--exact','--cycle','--layout','--border','--color','--print0',
+        '--read0','--info','--scroll-off','--tabstop','--no-mouse'
+    ) | Where-Object { `$_ -like "`$wordToComplete*" } | ForEach-Object {
+        [System.Management.Automation.CompletionResult]::new(`$_, `$_, 'ParameterValue', `$_)
+    }
+}
+"@
+        }
+    }
     [Package]@{
         Name        = 'Google Cloud SDK'
         Installer   = 'winget'
@@ -47,10 +128,41 @@ Register-ArgumentCompleter -Native -CommandName gcloud -ScriptBlock {
     # text editor available before DeveloperBasePackages runs. The winget
     # engine's AlreadyInstalled probe makes the duplicate declaration in
     # DeveloperBasePackages a no-op on a second pass.
-    [Package]@{ Name = 'Visual Studio Code';            Installer = 'winget'; Id = 'Microsoft.VisualStudioCode';                          CliCommands = @('code') }
+    [Package]@{
+        Name        = 'Visual Studio Code'
+        Installer   = 'winget'
+        Id          = 'Microsoft.VisualStudioCode'
+        CliCommands = @('code')
+        Completion  = 'auto'
+        Notes       = '`code --help` lists CLI switches but `code` has no completion subcommand and no PSCompletions catalog entry. Hand-curated flag list shared with DeveloperBasePackages.'
+        ExpectedCompletions = @{ code = @('--help','--diff','--new-window') }
+        NativeCommandScript = {
+            @"
+Register-ArgumentCompleter -Native -CommandName code -ScriptBlock {
+    param(`$wordToComplete, `$commandAst, `$cursorPosition)
+    @(
+        '--help','--version','--diff','--merge','--add','--goto','--new-window','--reuse-window',
+        '--wait','--locale','--user-data-dir','--profile','--extensions-dir','--list-extensions',
+        '--install-extension','--uninstall-extension','--enable-proposed-api','--status',
+        '--prof-startup','--disable-extensions','--disable-extension','--sync','--inspect-extensions',
+        '--inspect-brk-extensions','--verbose','--log','--telemetry'
+    ) | Where-Object { `$_ -like "`$wordToComplete*" } | ForEach-Object {
+        [System.Management.Automation.CompletionResult]::new(`$_, `$_, 'ParameterValue', `$_)
+    }
+}
+"@
+        }
+    }
 
     # scoop replacements for winget entries with upstream drift
-    [Package]@{ Name = 'ffmpeg';                        Installer = 'scoop';  Id = 'main/ffmpeg';                                         CliCommands = @('ffmpeg') }
+    [Package]@{
+        Name        = 'ffmpeg'
+        Installer   = 'scoop'
+        Id          = 'main/ffmpeg'
+        CliCommands = @('ffmpeg')
+        Completion  = 'pscompletions'
+        ExpectedCompletions = @{ ffmpeg = @('-i','-y','-version') }
+    }
     [Package]@{
         Name        = 'ripgrep'
         Installer   = 'scoop'

--- a/bucket/Package.Tests.ps1
+++ b/bucket/Package.Tests.ps1
@@ -139,7 +139,7 @@ Describe 'Package class — construction and defaults' -Tag 'Light', 'Module' {
 
 Describe 'Package.Validate() — happy paths' -Tag 'Light', 'Module' {
     It 'passes a minimal scoop entry with bucket prefix' {
-        $p = [Package]@{ Name = 'ripgrep'; Installer = 'scoop'; Id = 'main/ripgrep'; CliCommands = @('rg') }
+        $p = [Package]@{ Name = 'ripgrep'; Installer = 'scoop'; Id = 'main/ripgrep' }
         { $p.Validate() } | Should -Not -Throw
     }
 

--- a/bucket/UninstallPackage.Tests.ps1
+++ b/bucket/UninstallPackage.Tests.ps1
@@ -249,7 +249,7 @@ Describe 'Invoke-PackageUninstall pipeline' -Tag 'Light','Module' {
 
     It '-DryRun does not strip completion blocks' {
         $pkgs = [Package[]]@(
-            [Package]@{ Name='A'; Installer='winget'; Id='Foo.A'; CliCommands=@('gh') }
+            [Package]@{ Name='A'; Installer='winget'; Id='Foo.A'; CliCommands=@('gh'); Completion='pscompletions'; ExpectedCompletions=@{ gh = @('auth','repo','pr') } }
         )
         $null = Invoke-PackageUninstall -Packages $pkgs -Bundle 'Test' -DryRun
         Should -Invoke -ModuleName MarkMichaelis.ScoopBucket Remove-PackageCompletionBlock -Times 0
@@ -257,7 +257,7 @@ Describe 'Invoke-PackageUninstall pipeline' -Tag 'Light','Module' {
 
     It '-KeepCompletion skips Remove-PackageCompletionBlock' {
         $pkgs = [Package[]]@(
-            [Package]@{ Name='A'; Installer='winget'; Id='Foo.A'; CliCommands=@('gh') }
+            [Package]@{ Name='A'; Installer='winget'; Id='Foo.A'; CliCommands=@('gh'); Completion='pscompletions'; ExpectedCompletions=@{ gh = @('auth','repo','pr') } }
         )
         $null = Invoke-PackageUninstall -Packages $pkgs -Bundle 'Test' -KeepCompletion
         Should -Invoke -ModuleName MarkMichaelis.ScoopBucket Remove-PackageCompletionBlock -Times 0
@@ -265,7 +265,7 @@ Describe 'Invoke-PackageUninstall pipeline' -Tag 'Light','Module' {
 
     It 'removes completion blocks for every CliCommand by default' {
         $pkgs = [Package[]]@(
-            [Package]@{ Name='A'; Installer='winget'; Id='Foo.A'; CliCommands=@('foo','bar') }
+            [Package]@{ Name='A'; Installer='winget'; Id='Foo.A'; CliCommands=@('foo','bar'); Completion='pscompletions'; ExpectedCompletions=@{ foo = @('a','b','c'); bar = @('a','b','c') } }
         )
         $null = Invoke-PackageUninstall -Packages $pkgs -Bundle 'Test'
         Should -Invoke -ModuleName MarkMichaelis.ScoopBucket Remove-PackageCompletionBlock -Times 2

--- a/module/MarkMichaelis.ScoopBucket/Classes/Package.ps1
+++ b/module/MarkMichaelis.ScoopBucket/Classes/Package.ps1
@@ -100,6 +100,15 @@ class Package {
             throw "Package '$($this.Name)': NativeCommandScript is required when Completion='$($this.Completion)'."
         }
 
+        # Inverse direction: if a Package exposes CLIs on PATH, it MUST register
+        # completion for them (one of native/pscompletions/auto). Leaving
+        # Completion at its 'none' default while declaring CliCommands silently
+        # ships a CLI with no Tab-completion -- the gap that hid Everything CLI
+        # and 24 other packages before this guard existed.
+        if ($this.CliCommands.Count -gt 0 -and $this.Completion -eq 'none') {
+            throw "Package '$($this.Name)': Completion='none' is not allowed when CliCommands is non-empty (CLIs: $($this.CliCommands -join ', ')). Either declare Completion='native'|'pscompletions'|'auto' and supply ExpectedCompletions, or remove CliCommands if the tool truly has no tab-completable surface."
+        }
+
         if ($this.Completion -ne 'none') {
             if ($this.CliCommands.Count -eq 0) {
                 throw "Package '$($this.Name)': CliCommands must be non-empty when Completion='$($this.Completion)'."


### PR DESCRIPTION
## Summary

Closes the silent gap exposed by Everything CLI: when a Package declared `CliCommands` but left `Completion` at its 'none' default, nothing registered Tab-completion and nothing flagged the omission. `Get-Package` listed **25 violators** across 5 bundles.

## Why testing missed it

Existing `Bundles.Tests.ps1` had the *forward* direction (`Completion != none` implies `CliCommands` non-empty) but not the *inverse* (`CliCommands` non-empty implies `Completion != none`). Same gap in `Package.Validate()`. This PR adds both.

## Changes

**Contract (catches future regressions in PR CI, not after Heavy):**
- `Package.Validate()` throws when `CliCommands` is non-empty while `Completion='none'`.
- `Bundles.Tests.ps1` adds a per-Package Light assertion of the same rule.

**Wired all 25 packages:**
- `pscompletions` strategy (catalogue hits): 7-Zip, Windows Terminal, ffmpeg, Node.js+npm, dotnet, Python.
- `auto` + hand-rolled `NativeCommandScript` for the long tail: Everything CLI (es), bat, fzf, VS Code, Visual Studio (devenv), Beyond Compare (bcomp+bcompare shared), Copilot CLI (both winget+scoop), Claude/Codex/Gemini, Aspire (in both bundles), Node.js (with npx in AIAgents), exiftool, DbxCli, eSpeak NG, SoX.
- Every Package declares `ExpectedCompletions` so the Heavy `CompletionEndToEnd.Tests.ps1` exercises real `TabExpansion2` per CLI automatically.

## Tests

Local Light: **898 passed, 0 failed, 4 skipped**. Heavy completion E2E will run on merge to main and may surface `ExpectedCompletions` mismatches for `pscompletions`-strategy packages (subcommand lists guessed; will iterate).