### PR TITLE
Fix: 'scoop list' has no -g flag; switch to Info='Global install' probe

### DIFF
--- a/.github/scripts/Test-Installs.ps1
+++ b/.github/scripts/Test-Installs.ps1
@@ -872,14 +872,20 @@ if ($scoopPackages.Count -gt 0) {
         # global install down outside %ProgramData%\scoop\apps depending on
         # the manifest's installer (msi/inno can target Program Files), so a
         # bare Test-Path on the apps tree produces false negatives. 'scoop
-        # list -g <leaf>' returns a row IFF scoop tracks a global install.
+        # list <leaf>' returns a PSObject row whose 'Info' column reads
+        # 'Global install' when scoop tracks it globally. (Note: there is
+        # NO '-g' flag for `scoop list` -- earlier versions of this check
+        # used `scoop list -g <leaf>` which scoop interpreted as a query
+        # filter and silently matched nothing, marking every install as a
+        # verification failure.)
         Test-Verification -Name "scoop-global:$($pkg.Name)" `
-            -Description "Scoop should report '$($pkg.Name)' as a global install ('scoop list -g $leaf')" `
+            -Description "Scoop should report '$($pkg.Name)' as a global install ('scoop list $leaf' Info column == 'Global install')" `
             -Test ([scriptblock]::Create(@"
-                `$output = cmd /c 'scoop list -g $leaf 2>&1'
-                # 'scoop list -g <name>' prints a header + one row per match;
-                # match presence of the leaf token anywhere in the output.
-                (`$output -join "``n") -match [regex]::Escape('$leaf')
+                `$rows = @(scoop list '$leaf' 2>`$null)
+                `$match = `$rows | Where-Object {
+                    `$_.Name -eq '$leaf' -and (`$_.Info -as [string]) -match 'Global'
+                }
+                [bool](`$match)
 "@))
     }
 }

--- a/install.ps1
+++ b/install.ps1
@@ -45,8 +45,10 @@ Add-ScoopBucket -Name 'extras'
 
 <#'McAfeeUninstall',#> 'OSBasePackages' | ForEach-Object {
   $app = $_
-  # Check if app is already installed globally
-  $installed = scoop list -g 2>&1 | Select-String -Pattern "^\s*$app\s" -Quiet
+  # Check if app is already installed globally. `scoop list` has NO `-g`
+  # flag -- it's `scoop list [query]`. A row with Info='Global install' is
+  # how scoop signals scope; treat its presence as the "installed" probe.
+  $installed = @(scoop list $app 2>$null | Where-Object { $_.Name -eq $app -and ($_.Info -as [string]) -match 'Global' }).Count -gt 0
   
   if ($installed) {
     Write-Host "✓ '$app' is already installed. Checking for updates..." -ForegroundColor Green


### PR DESCRIPTION
## Symptom

The Heavy run validating PR #141 reported **22 scoop verification failures** (every scoop install), even though each install logged exit 0:

`[verification] scoop-global:<pkg> - fail`
`Verification returned false: Scoop should report '<pkg>' as a global install ('scoop list -g <leaf>')`

## Root cause

Scoop's CLI is `scoop list [query]`  there is **no `-g` flag for list**. When invoked as `scoop list -g <leaf>` scoop treats `-g` as the query and prints `Installed apps matching '-g'` with zero rows. The regex check in PR #140's verification scriptblock then matched nothing, marking every install as a verification failure.

Reproduces locally: `scoop list -g dotnet` outputs `Installed apps matching '-g'` and nothing else.

## Fix

Switch to `scoop list <leaf>` and filter by `Name -eq <leaf>` and `Info -match 'Global'`. Scoop's `list` PSObjects expose an Info column whose value reads `Global install` for globally-scoped apps.

Applied in two places:
- `.github/scripts/Test-Installs.ps1`  the post-install verification block (the file PR #140 modified).
- `install.ps1`  the already-installed gate that uses the same broken form.

## Tests

Light suite: **898 passed, 0 failed**. The Heavy `Install & Validate Packages` job is what's needed to confirm  it runs on merge to main.