### PR TITLE
Probe scoop global scope via ProgramData\scoop\apps\<leaf>\current

### DIFF
--- a/.github/scripts/Test-Installs.ps1
+++ b/.github/scripts/Test-Installs.ps1
@@ -868,24 +868,20 @@ if ($scoopPackages.Count -gt 0) {
             continue
         }
         $leaf = Get-ScoopAppLeaf -Name $pkg.PackageId
-        # Authoritative: ask scoop. Some packages (e.g. dotnet) lay their
-        # global install down outside %ProgramData%\scoop\apps depending on
-        # the manifest's installer (msi/inno can target Program Files), so a
-        # bare Test-Path on the apps tree produces false negatives. 'scoop
-        # list <leaf>' returns a PSObject row whose 'Info' column reads
-        # 'Global install' when scoop tracks it globally. (Note: there is
-        # NO '-g' flag for `scoop list` -- earlier versions of this check
-        # used `scoop list -g <leaf>` which scoop interpreted as a query
-        # filter and silently matched nothing, marking every install as a
-        # verification failure.)
+        # Authoritative scope probe: scoop's global apps dir is
+        # %ProgramData%\scoop\apps (user scope lives under ~\scoop\apps).
+        # A *\current* link under ProgramData -> global install, full stop.
+        # The previous probe variants -- Test-Path elsewhere, 'scoop list
+        # -g <leaf>' (which scoop interpreted as a filter), and 'scoop
+        # list <leaf>' Info-column match -- all produced false negatives
+        # for at least one package (dotnet under the latter on Heavy CI).
+        # ProgramData paths are the source of truth scoop itself uses.
+        $globalRoot = Join-Path ${env:ProgramData} 'scoop\apps'
+        $globalLink = Join-Path $globalRoot ("$leaf\current")
         Test-Verification -Name "scoop-global:$($pkg.Name)" `
-            -Description "Scoop should report '$($pkg.Name)' as a global install ('scoop list $leaf' Info column == 'Global install')" `
+            -Description "Scoop should have a global install for '$($pkg.Name)' at '$globalLink'" `
             -Test ([scriptblock]::Create(@"
-                `$rows = @(scoop list '$leaf' 2>`$null)
-                `$match = `$rows | Where-Object {
-                    `$_.Name -eq '$leaf' -and (`$_.Info -as [string]) -match 'Global'
-                }
-                [bool](`$match)
+                Test-Path -LiteralPath '$globalLink'
 "@))
     }
 }


### PR DESCRIPTION
## Context

The Heavy run for PR #151 (which itself fixed PR #140's broken `scoop list -g` probe) still flagged `dotnet` as a verification failure. Heavy logs:

\\\
Installed apps matching 'dotnet':
[verification] scoop-global:dotnet - fail
\\\

`scoop list dotnet` does return rows on the runner, but the row's Info-column match for `Global` is fragile across scoop versions and manifest installer types. Three separate probe variants (Test-Path on the wrong paths, `scoop list -g`, `scoop list <leaf>` + Info column) have each produced false negatives.

## Fix

Use the source of truth scoop itself uses: scoop tracks **global** installs at `%ProgramData%\scoop\apps\<leaf>\current`; user-scope installs live under `~\scoop\apps`. A `Test-Path` on the global link is unambiguous, works across MSI-installer manifests, archive manifests, and the dotnet edge case.

## Tests

Local Light: 898 passed, 0 failed.

Remaining Heavy failures (Handy #131, Claude Desktop #85) are pre-existing recurring winget runner issues, not regressions from this change.