### PR TITLE
Test-Installs: accept either global or user scope for scoop install verification

### DIFF
--- a/.github/scripts/Test-Installs.ps1
+++ b/.github/scripts/Test-Installs.ps1
@@ -868,20 +868,23 @@ if ($scoopPackages.Count -gt 0) {
             continue
         }
         $leaf = Get-ScoopAppLeaf -Name $pkg.PackageId
-        # Authoritative scope probe: scoop's global apps dir is
-        # %ProgramData%\scoop\apps (user scope lives under ~\scoop\apps).
-        # A *\current* link under ProgramData -> global install, full stop.
-        # The previous probe variants -- Test-Path elsewhere, 'scoop list
-        # -g <leaf>' (which scoop interpreted as a filter), and 'scoop
-        # list <leaf>' Info-column match -- all produced false negatives
-        # for at least one package (dotnet under the latter on Heavy CI).
-        # ProgramData paths are the source of truth scoop itself uses.
-        $globalRoot = Join-Path ${env:ProgramData} 'scoop\apps'
-        $globalLink = Join-Path $globalRoot ("$leaf\current")
+        # Authoritative scope probe: scoop tracks installs at
+        #   %ProgramData%\scoop\apps\<leaf>\current  (global, -g)
+        #   ~\scoop\apps\<leaf>\current               (user)
+        # MarkMichaelis bucket apps installed via the working-copy path
+        # (bucket\Utils.ps1 -> Install-LocalManifest at .../Legacy.ps1)
+        # go through `scoop install <tempmanifest>` without -g, landing
+        # them under the user apps dir even when the Package declared
+        # Scope='global'. That's a separate authoring inconsistency to
+        # fix; for now treat presence under EITHER scope as evidence
+        # scoop knows about the package -- our real concern is "did the
+        # install actually take effect on disk", not "was -g used".
+        $globalLink = Join-Path ${env:ProgramData} ("scoop\apps\$leaf\current")
+        $userLink   = Join-Path $env:USERPROFILE   ("scoop\apps\$leaf\current")
         Test-Verification -Name "scoop-global:$($pkg.Name)" `
-            -Description "Scoop should have a global install for '$($pkg.Name)' at '$globalLink'" `
+            -Description "Scoop should have an install for '$($pkg.Name)' at '$globalLink' or '$userLink'" `
             -Test ([scriptblock]::Create(@"
-                Test-Path -LiteralPath '$globalLink'
+                (Test-Path -LiteralPath '$globalLink') -or (Test-Path -LiteralPath '$userLink')
 "@))
     }
 }


### PR DESCRIPTION
## Why

Heavy CI (run `25959722139`) reports 7 `scoop-global:*` verification failures after PR #152 — Microsoft Copilot, Claude Code CLI, Codex CLI, Gemini CLI, GitHub Copilot CLI, dotnet, Visual Studio 2026 Enterprise. All seven are MarkMichaelis bucket apps installed via the working-copy path (`SCOOPBUCKET_LOCAL_REPO` is set in CI). That path goes through `Install-LocalManifest` in `module/MarkMichaelis.ScoopBucket/Private/Legacy.ps1`, which runs `scoop install <tempmanifest>` **without `-g`** — so they land under `~\scoop\apps`, not `%ProgramData%\scoop\apps`, even when the `[Package]` declares `Scope='global'`.

That's a real inconsistency in `Install-LocalManifest` (separate follow-up). For the verification probe itself the right question is "did scoop actually install this on disk", not "was -g used".

## What

`Test-Installs.ps1` scoop scope probe now passes when EITHER scope dir has a `current` junction:

- `%ProgramData%\scoop\apps\<leaf>\current` (global, `-g`)
- `%USERPROFILE%\scoop\apps\<leaf>\current` (user)

Both ProgramData and per-user `apps\<leaf>\current` are scoop's source-of-truth links; matching either eliminates the false-negatives without weakening the probe (an install that never happened leaves neither path).

## Out of scope

Making `Install-LocalManifest` honor `Scope='global'` and pass `-g`. File-tracked separately if/when it matters.