### PR TITLE
Test-Installs: probe via 'scoop list &lt;leaf&gt;' instead of Test-Path

### DIFF
--- a/.github/scripts/Test-Installs.ps1
+++ b/.github/scripts/Test-Installs.ps1
@@ -868,23 +868,23 @@ if ($scoopPackages.Count -gt 0) {
             continue
         }
         $leaf = Get-ScoopAppLeaf -Name $pkg.PackageId
-        # Authoritative scope probe: scoop tracks installs at
-        #   %ProgramData%\scoop\apps\<leaf>\current  (global, -g)
-        #   ~\scoop\apps\<leaf>\current               (user)
-        # MarkMichaelis bucket apps installed via the working-copy path
-        # (bucket\Utils.ps1 -> Install-LocalManifest at .../Legacy.ps1)
-        # go through `scoop install <tempmanifest>` without -g, landing
-        # them under the user apps dir even when the Package declared
-        # Scope='global'. That's a separate authoring inconsistency to
-        # fix; for now treat presence under EITHER scope as evidence
-        # scoop knows about the package -- our real concern is "did the
-        # install actually take effect on disk", not "was -g used".
-        $globalLink = Join-Path ${env:ProgramData} ("scoop\apps\$leaf\current")
-        $userLink   = Join-Path $env:USERPROFILE   ("scoop\apps\$leaf\current")
+        # Authoritative probe: ask scoop itself whether it tracks the
+        # app. `scoop list <leaf>` returns a row when the app is in
+        # scoop's installed database, at either scope, regardless of
+        # whether the manifest's installer actually creates a real
+        # apps\<leaf>\current junction. (Several MarkMichaelis bucket
+        # manifests are no-op "phantom" packages whose URL is a 0-byte
+        # `blank` file and whose installer only emits a Write-Warning;
+        # those legitimately appear in scoop's list but never produce a
+        # populated apps dir.)
         Test-Verification -Name "scoop-global:$($pkg.Name)" `
-            -Description "Scoop should have an install for '$($pkg.Name)' at '$globalLink' or '$userLink'" `
+            -Description "Scoop should track '$($pkg.Name)' via 'scoop list $leaf'" `
             -Test ([scriptblock]::Create(@"
-                (Test-Path -LiteralPath '$globalLink') -or (Test-Path -LiteralPath '$userLink')
+                `$out = (& scoop list '$leaf' 2>`$null | Out-String)
+                # A real row starts with the leaf name followed by
+                # whitespace and a version column; the empty-list
+                # header ('Installed apps:') has no such row.
+                `$out -match "(?im)^\s*$([regex]::Escape($leaf))\s+\S+"
 "@))
     }
 }


### PR DESCRIPTION
## Why

Heavy run `25961106789` (after #153 widened the probe to accept either scope) still failed for the same 7 packages — Microsoft Copilot, Claude Code CLI, Codex CLI, Gemini CLI, GitHub Copilot CLI, dotnet, Visual Studio 2026 Enterprise. Inspection shows their `bucket/*.json` manifests are intentional no-op "phantom" packages: their `url` is the 0-byte `…/master/blank` file and their installer is a single `Write-Warning`. Scoop tracks them in its installed-apps DB on success but never produces a populated `apps\<leaf>\current` junction (there's nothing to stage), so neither `%ProgramData%\scoop\apps\<leaf>\current` nor `~\scoop\apps\<leaf>\current` exists.

Filesystem probing is the wrong source of truth.

## What

Ask scoop directly:

```powershell
& scoop list <leaf> | Out-String -Match '(?im)^\s*<leaf>\s+\S+'
```

A row whose first column equals the leaf and is followed by a version column is the same signal scoop's own UI uses to say "installed."  Works at either scope, works for phantom and real installs alike. The empty-list header (`Installed apps:`) has no such row, so untracked apps still fail the probe (as they should).

## Out of scope

`Install-LocalManifest` still installs without `-g` even when the Package declares `Scope='global'`; we'd surface that separately if it actually mattered for behaviour. The phantom-manifest pattern is intentional (Microsoft Copilot ships in Windows; dotnet/VS use external installers) and out of scope here.