### PR TITLE
Invoke-PackageInstall: split success/failure across PowerShell streams

### DIFF
--- a/bucket/InvokePackageInstallSummary.Tests.ps1
+++ b/bucket/InvokePackageInstallSummary.Tests.ps1
@@ -4,7 +4,9 @@
 <#
 .SYNOPSIS
     Light test for Invoke-PackageInstall's summary output: each row must
-    be color-coded by State so Failed rows can't be mistaken for success.
+    be color-coded *and* glyph-marked by State so Failed rows can't be
+    mistaken for success (color alone isn't colorblind-safe, so the
+    glyph carries the same signal).
 #>
 
 BeforeAll {
@@ -14,7 +16,7 @@ BeforeAll {
 
 Describe 'Invoke-PackageInstall summary coloring' -Tag 'Light','Module' {
 
-    It 'writes Failed rows in Red and Installed rows in Green' {
+    It 'writes Failed rows in Red (with ✗ glyph) and Installed rows in Green (with ✓ glyph)' {
         InModuleScope MarkMichaelis.ScoopBucket {
             $captured = New-Object System.Collections.Generic.List[object]
             Mock Write-Host -MockWith {
@@ -33,7 +35,10 @@ Describe 'Invoke-PackageInstall summary coloring' -Tag 'Light','Module' {
                             CustomInstallScript = { throw 'simulated failure' } }
             )
 
-            $null = Invoke-PackageInstall -Bundle 'Test' -Packages $pkgs
+            # BadPkg writes to the error stream now; silence it so the
+            # mock doesn't get confused but the summary still renders.
+            $null = Invoke-PackageInstall -Bundle 'Test' -Packages $pkgs `
+                -ErrorAction SilentlyContinue
 
             $summaryLines = @($captured | Where-Object { $_.Message -match '^\s{2}\S' -and $_.Color })
             $goodLine = $summaryLines | Where-Object Message -match 'GoodPkg' | Select-Object -Last 1
@@ -41,14 +46,11 @@ Describe 'Invoke-PackageInstall summary coloring' -Tag 'Light','Module' {
 
             $goodLine | Should -Not -BeNullOrEmpty
             $badLine  | Should -Not -BeNullOrEmpty
-            $goodLine.Color | Should -Be 'Green'
-            $badLine.Color  | Should -Be 'Red'
-
-            # The post-summary red banner — must appear and must be red.
-            $banner = $captured | Where-Object { $_.Message -match '^!! .*failed' } | Select-Object -Last 1
-            $banner          | Should -Not -BeNullOrEmpty
-            $banner.Color    | Should -Be 'Red'
-            $banner.Message  | Should -Match '1 package failed'
+            $goodLine.Color   | Should -Be 'Green'
+            $badLine.Color    | Should -Be 'Red'
+            # Glyph carries the signal even when color is stripped.
+            $goodLine.Message | Should -Match ([char]0x2713)   # ✓
+            $badLine.Message  | Should -Match ([char]0x2717)   # ✗
         }
     }
 }

--- a/bucket/PackageInstall.Tests.ps1
+++ b/bucket/PackageInstall.Tests.ps1
@@ -223,7 +223,9 @@ Describe 'Invoke-PackageInstall pipeline' -Tag 'Light','Module' {
         )
         $r = Invoke-PackageInstall -Packages $pkgs -Bundle 'Test' -SkipCompletion
         $r.Count | Should -Be 3
-        ($r | ForEach-Object State) -join ',' | Should -Be 'Installed,Installed,Installed'
+        # Success stream emits [Package] instances on Installed.
+        ($r | ForEach-Object Name) -join ',' | Should -Be 'A,B,C'
+        $r[0] | Should -BeOfType ([Package])
         # Verify each engine got called exactly once.
         Should -Invoke -ModuleName MarkMichaelis.ScoopBucket Install-WingetPackage -Times 1 -Exactly
         Should -Invoke -ModuleName MarkMichaelis.ScoopBucket Install-ChocoPackage  -Times 1 -Exactly
@@ -255,9 +257,21 @@ Describe 'Invoke-PackageInstall pipeline' -Tag 'Light','Module' {
             [Package]@{ Name='A'; Installer='winget'; Id='Foo.A'
                         PostInstallScript = { throw 'boom' } }
         )
-        $r = Invoke-PackageInstall -Packages $pkgs -Bundle 'Test' -SkipCompletion -WarningAction SilentlyContinue
-        $r[0].State | Should -Be 'Failed'
-        $r[0].Reason | Should -Match 'boom'
+        # Failures go to the error stream as ErrorRecords; capture via
+        # -ErrorVariable to inspect FullyQualifiedErrorId / TargetObject.
+        # NOTE: PowerShell's own throw-propagation also pushes the raw
+        # inner RuntimeException ('boom') onto -ErrorVariable in addition
+        # to our wrapper. Filter to our contract: exactly one
+        # PackageInstallFailed record per failed package.
+        $r = Invoke-PackageInstall -Packages $pkgs -Bundle 'Test' -SkipCompletion `
+            -ErrorAction SilentlyContinue -ErrorVariable errs
+        $r | Should -BeNullOrEmpty
+        $ours = @($errs | Where-Object { $_.FullyQualifiedErrorId -like 'PackageInstallFailed*' })
+        $ours.Count | Should -Be 1
+        $ours[0].Exception.Message | Should -Match 'boom'
+        $ours[0].Exception.Message | Should -Match 'PostInstallScript threw'
+        $ours[0].TargetObject | Should -BeOfType ([Package])
+        $ours[0].TargetObject.Name | Should -Be 'A'
     }
 
     It 'invokes CustomInstallScript for Installer=custom' {
@@ -268,7 +282,8 @@ Describe 'Invoke-PackageInstall pipeline' -Tag 'Light','Module' {
         )
         $r = Invoke-PackageInstall -Packages $pkgs -Bundle 'Test' -SkipCompletion
         $script:customRan | Should -BeTrue
-        $r[0].State | Should -Be 'Installed'
+        $r.Count | Should -Be 1
+        $r[0].Name | Should -Be 'Readwise'
     }
 
     It 'skips packages with CISkip set when $env:CI is truthy' {
@@ -280,8 +295,15 @@ Describe 'Invoke-PackageInstall pipeline' -Tag 'Light','Module' {
                 [Package]@{ Name='Other';      Installer='winget'; Id='Foo.X' }
             )
             $r = Invoke-PackageInstall -Packages $pkgs -Bundle 'Test' -SkipCompletion
-            ($r | Where-Object Name -eq 'Pushbullet').State | Should -Be 'Skipped'
-            ($r | Where-Object Name -eq 'Other').State      | Should -Be 'Installed'
+            # Both packages emit on the success stream (Skipped + Installed).
+            $r.Count | Should -Be 2
+            ($r | ForEach-Object Name) | Should -Contain 'Pushbullet'
+            ($r | ForEach-Object Name) | Should -Contain 'Other'
+            # The skipped one never reached the engine; the other did.
+            Should -Invoke -ModuleName MarkMichaelis.ScoopBucket Install-WingetPackage -Times 1 -Exactly `
+                -ParameterFilter { $Package.Name -eq 'Other' }
+            Should -Invoke -ModuleName MarkMichaelis.ScoopBucket Install-WingetPackage -Times 0 -Exactly `
+                -ParameterFilter { $Package.Name -eq 'Pushbullet' }
         } finally {
             if ($null -eq $oldCi) { Remove-Item Env:\CI -ErrorAction Ignore }
             else { $env:CI = $oldCi }
@@ -296,16 +318,16 @@ Describe 'Invoke-PackageInstall pipeline' -Tag 'Light','Module' {
             [Package]@{ Name='Bad';  Installer='winget'; Id='Foo.Bad' }
             [Package]@{ Name='Good'; Installer='choco';  Id='good' }
         )
-        $r = Invoke-PackageInstall -Packages $pkgs -Bundle 'Test' -SkipCompletion -WarningAction SilentlyContinue
-        ($r | Where-Object Name -eq 'Bad').State  | Should -Be 'Failed'
-        ($r | Where-Object Name -eq 'Good').State | Should -Be 'Installed'
-    }
-
-    It 'stores the result on $global:LASTINSTALLREPORT' {
-        $pkgs = [Package[]]@([Package]@{ Name='A'; Installer='winget'; Id='Foo.A' })
-        $null = Invoke-PackageInstall -Packages $pkgs -Bundle 'Test' -SkipCompletion
-        $global:LASTINSTALLREPORT | Should -Not -BeNullOrEmpty
-        $global:LASTINSTALLREPORT[0].Bundle | Should -Be 'Test'
+        $r = Invoke-PackageInstall -Packages $pkgs -Bundle 'Test' -SkipCompletion `
+            -ErrorAction SilentlyContinue -ErrorVariable errs
+        # Success stream: only the Good package.
+        $r.Count | Should -Be 1
+        $r[0].Name | Should -Be 'Good'
+        # Error stream: one ErrorRecord for the Bad package.
+        $errs.Count | Should -Be 1
+        $errs[0].FullyQualifiedErrorId | Should -Match '^PackageInstallFailed'
+        $errs[0].TargetObject.Name | Should -Be 'Bad'
+        $errs[0].Exception.Message | Should -Match 'simulated'
     }
 
     It 'rejects non-Package elements' {
@@ -324,7 +346,8 @@ Describe 'Invoke-PackageInstall pipeline' -Tag 'Light','Module' {
     It 'respects -DryRun: dispatchers receive -WhatIf, returns Installed records' {
         $pkgs = [Package[]]@([Package]@{ Name='A'; Installer='winget'; Id='Foo.A' })
         $r = Invoke-PackageInstall -Packages $pkgs -Bundle 'Test' -SkipCompletion -DryRun
-        $r[0].State | Should -Be 'Installed'
+        $r.Count | Should -Be 1
+        $r[0].Name | Should -Be 'A'
         # Dispatcher is still invoked (to emit "[WhatIf] ..." log lines), it
         # just must not run the underlying engine.
         Should -Invoke -ModuleName MarkMichaelis.ScoopBucket Install-WingetPackage -Times 1 -Exactly -ParameterFilter { $WhatIf -eq $true }

--- a/module/MarkMichaelis.ScoopBucket/MarkMichaelis.ScoopBucket.format.ps1xml
+++ b/module/MarkMichaelis.ScoopBucket/MarkMichaelis.ScoopBucket.format.ps1xml
@@ -1,0 +1,65 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  Compact default view for [Package] instances.
+
+  Without this file, PowerShell auto-formats [Package] (which has
+  17+ properties, many of them scriptblocks) as a verbose Format-List
+  - one row per property, repeated per package. After splitting
+  Invoke-PackageInstall's output across the success/error streams
+  (each Installed/AlreadyInstalled/Skipped Package now lands on the
+  success stream), interactive use degenerated into a wall of
+  property dumps.
+
+  This file ships a single compact Table view (Name, Installer, Id,
+  Scope) that fits one row per Package. Pipeline consumers are
+  unaffected - format views don't change object identity or
+  property access - they only change how PowerShell renders an
+  unassigned Package to the host.
+-->
+<Configuration>
+  <ViewDefinitions>
+    <View>
+      <Name>Package</Name>
+      <ViewSelectedBy>
+        <TypeName>Package</TypeName>
+      </ViewSelectedBy>
+      <TableControl>
+        <TableHeaders>
+          <TableColumnHeader>
+            <Label>Name</Label>
+            <Width>28</Width>
+          </TableColumnHeader>
+          <TableColumnHeader>
+            <Label>Installer</Label>
+            <Width>11</Width>
+          </TableColumnHeader>
+          <TableColumnHeader>
+            <Label>Id</Label>
+          </TableColumnHeader>
+          <TableColumnHeader>
+            <Label>Scope</Label>
+            <Width>8</Width>
+          </TableColumnHeader>
+        </TableHeaders>
+        <TableRowEntries>
+          <TableRowEntry>
+            <TableColumnItems>
+              <TableColumnItem>
+                <PropertyName>Name</PropertyName>
+              </TableColumnItem>
+              <TableColumnItem>
+                <PropertyName>Installer</PropertyName>
+              </TableColumnItem>
+              <TableColumnItem>
+                <PropertyName>Id</PropertyName>
+              </TableColumnItem>
+              <TableColumnItem>
+                <PropertyName>Scope</PropertyName>
+              </TableColumnItem>
+            </TableColumnItems>
+          </TableRowEntry>
+        </TableRowEntries>
+      </TableControl>
+    </View>
+  </ViewDefinitions>
+</Configuration>

--- a/module/MarkMichaelis.ScoopBucket/MarkMichaelis.ScoopBucket.psd1
+++ b/module/MarkMichaelis.ScoopBucket/MarkMichaelis.ScoopBucket.psd1
@@ -19,6 +19,8 @@
 
     ScriptsToProcess  = @('Classes\Package.ps1')
 
+    FormatsToProcess  = @('MarkMichaelis.ScoopBucket.format.ps1xml')
+
     FunctionsToExport = @(
         'Install-Package',
         'Uninstall-Package',

--- a/module/MarkMichaelis.ScoopBucket/Public/Invoke-PackageInstall.ps1
+++ b/module/MarkMichaelis.ScoopBucket/Public/Invoke-PackageInstall.ps1
@@ -154,12 +154,13 @@ function Invoke-PackageInstall {
                     Write-Host "  [DryRun] CustomInstallScript"
                     $result = @{ State = 'Installed'; Reason = '(DryRun)' }
                 } else {
-                    # 2>$null swallows any error-stream emissions from the
-                    # scriptblock. We re-emit a single structured
-                    # PackageInstallFailed ErrorRecord in the catch below,
-                    # so without the swallow the user would see both the
-                    # raw inner error AND our wrapper for one failure.
-                    & $pkg.CustomInstallScript $pkg 2>$null
+                    # Discard any pipeline output the user's
+                    # CustomInstallScript may emit — we treat it as
+                    # purely side-effecting (the synthesized $result
+                    # below is what we actually use). Without the
+                    # [void], stray return values land on our function's
+                    # success stream and pollute the [Package] output.
+                    [void](& $pkg.CustomInstallScript $pkg 2>$null)
                     $result = @{ State = 'Installed'; Reason = $null }
                 }
             } else {
@@ -206,7 +207,10 @@ function Invoke-PackageInstall {
                 Write-Host "  [DryRun] PostInstallScript"
             } else {
                 try {
-                    & $pkg.PostInstallScript $pkg 2>$null
+                    # PostInstallScript is purely side-effecting; discard
+                    # any pipeline output so it doesn't pollute our
+                    # function's success stream of [Package] objects.
+                    [void](& $pkg.PostInstallScript $pkg 2>$null)
                     Update-PathFromRegistry
                 } catch {
                     $reason = "PostInstallScript threw: $($_.Exception.Message)"

--- a/module/MarkMichaelis.ScoopBucket/Public/Invoke-PackageInstall.ps1
+++ b/module/MarkMichaelis.ScoopBucket/Public/Invoke-PackageInstall.ps1
@@ -34,8 +34,23 @@ function Invoke-PackageInstall {
          10. Record an [installed | already-installed | skipped | failed]
              entry on the summary.
 
-        Returns the array of summary records and stores it on
-        `$global:LASTINSTALLREPORT` for cross-bundle inspection.
+        Outputs are split across PowerShell's standard streams:
+          - **Success stream** — each Installed / AlreadyInstalled /
+            Skipped Package is emitted via Write-Output. The function's
+            return value is therefore a `[Package[]]` of successes,
+            pipeline-friendly:
+              `Invoke-PackageInstall ... | Where-Object Installer -eq 'winget'`.
+          - **Error stream** — each Failed package emits a structured
+            `ErrorRecord` (FullyQualifiedErrorId = 'PackageInstallFailed',
+            TargetObject = the [Package], Exception.Message = the
+            failure reason). Renders red by default; `$?` flips false;
+            `-ErrorAction Stop` makes it terminating; `-ErrorVariable`
+            captures it.
+          - **Host / information stream** — the per-package install
+            log lines and the final per-package summary table (with
+            ✓ ↺ ✗ → glyphs for colorblind-safe disambiguation) are
+            written via Write-Host as before. Color is now redundant
+            with the glyph, not load-bearing.
 
     .PARAMETER Packages
         The declarative [Package[]] collection for this bundle.
@@ -61,7 +76,7 @@ function Invoke-PackageInstall {
         the AllUsersAllHosts profile isn't writable).
     #>
     [CmdletBinding(SupportsShouldProcess, ConfirmImpact = 'Medium')]
-    [OutputType([object[]])]
+    [OutputType([Package])]
     param(
         [Parameter(Mandatory)][object[]]$Packages,
         [Parameter(Mandatory)][string]$Bundle,
@@ -89,7 +104,13 @@ function Invoke-PackageInstall {
     Write-Host ""
     Write-Host "=== Invoke-PackageInstall: $Bundle ($($ordered.Count) packages) ==="
 
-    $summary = New-Object System.Collections.Generic.List[object]
+    # Host-stream summary state — collected per package so the final
+    # summary table can render each row with the right glyph/color. The
+    # success-stream output is the [Package] itself; the error-stream
+    # output is a structured ErrorRecord written below at each failure
+    # site. This list is intentionally NOT returned to callers — they
+    # should consume the success/error streams instead.
+    $states = New-Object System.Collections.Generic.List[object]
     $isCi = [bool]$env:CI
 
     # If any package in this run requests PSCompletions-backed tab completion
@@ -112,24 +133,15 @@ function Invoke-PackageInstall {
     }
 
     foreach ($pkg in $ordered) {
-        $record = [pscustomobject]@{
-            Bundle      = $Bundle
-            Name        = $pkg.Name
-            Installer   = $pkg.Installer
-            Id          = $pkg.Id
-            Scope       = $pkg.Scope
-            CliCommands = $pkg.CliCommands
-            State       = 'Pending'
-            Reason      = $null
-            Verified    = $null
-            Completion  = $null
-        }
+        $state  = 'Pending'
+        $reason = $null
 
         if ($pkg.CISkip -and $isCi) {
-            $record.State  = 'Skipped'
-            $record.Reason = "CISkip: $($pkg.CISkip)"
-            Write-Host "[skip] $($pkg.Name) -- $($record.Reason)"
-            $summary.Add($record)
+            $state  = 'Skipped'
+            $reason = "CISkip: $($pkg.CISkip)"
+            Write-Host "[skip] $($pkg.Name) -- $reason"
+            $states.Add([pscustomobject]@{ Pkg = $pkg; State = $state; Reason = $reason })
+            Write-Output $pkg
             continue
         }
 
@@ -142,7 +154,12 @@ function Invoke-PackageInstall {
                     Write-Host "  [DryRun] CustomInstallScript"
                     $result = @{ State = 'Installed'; Reason = '(DryRun)' }
                 } else {
-                    & $pkg.CustomInstallScript $pkg
+                    # 2>$null swallows any error-stream emissions from the
+                    # scriptblock. We re-emit a single structured
+                    # PackageInstallFailed ErrorRecord in the catch below,
+                    # so without the swallow the user would see both the
+                    # raw inner error AND our wrapper for one failure.
+                    & $pkg.CustomInstallScript $pkg 2>$null
                     $result = @{ State = 'Installed'; Reason = $null }
                 }
             } else {
@@ -155,100 +172,105 @@ function Invoke-PackageInstall {
                     default       { throw "Invoke-PackageInstall: unknown Installer '$($pkg.Installer)' for '$($pkg.Name)'." }
                 }
             }
-            $record.State  = $result.State
-            $record.Reason = $result.Reason
+            $state  = $result.State
+            $reason = $result.Reason
         } catch {
-            $record.State  = 'Failed'
-            $record.Reason = "Install threw: $($_.Exception.Message)"
-            Write-Warning "  $($pkg.Name): $($record.Reason)"
-            $summary.Add($record)
+            $reason = "Install threw: $($_.Exception.Message)"
+            $states.Add([pscustomobject]@{ Pkg = $pkg; State = 'Failed'; Reason = $reason })
+            $PSCmdlet.WriteError(
+                [System.Management.Automation.ErrorRecord]::new(
+                    [System.Exception]::new("$($pkg.Name): $reason"),
+                    'PackageInstallFailed',
+                    [System.Management.Automation.ErrorCategory]::NotInstalled,
+                    $pkg))
+            continue
+        }
+
+        if ($state -eq 'Failed') {
+            # Engine returned a structured Failed result (e.g. winget
+            # exit code mapped to State='Failed').
+            $states.Add([pscustomobject]@{ Pkg = $pkg; State = 'Failed'; Reason = $reason })
+            $PSCmdlet.WriteError(
+                [System.Management.Automation.ErrorRecord]::new(
+                    [System.Exception]::new("$($pkg.Name): $reason"),
+                    'PackageInstallFailed',
+                    [System.Management.Automation.ErrorCategory]::NotInstalled,
+                    $pkg))
             continue
         }
 
         if (-not $DryRun) { Update-PathFromRegistry }
 
-        if ($pkg.PostInstallScript -and $record.State -ne 'Failed') {
+        if ($pkg.PostInstallScript) {
             if ($DryRun) {
                 Write-Host "  [DryRun] PostInstallScript"
             } else {
                 try {
-                    & $pkg.PostInstallScript $pkg
+                    & $pkg.PostInstallScript $pkg 2>$null
                     Update-PathFromRegistry
                 } catch {
-                    $record.State  = 'Failed'
-                    $record.Reason = "PostInstallScript threw: $($_.Exception.Message)"
-                    Write-Warning "  $($pkg.Name): $($record.Reason)"
-                    $summary.Add($record)
+                    $reason = "PostInstallScript threw: $($_.Exception.Message)"
+                    $states.Add([pscustomobject]@{ Pkg = $pkg; State = 'Failed'; Reason = $reason })
+                    $PSCmdlet.WriteError(
+                        [System.Management.Automation.ErrorRecord]::new(
+                            [System.Exception]::new("$($pkg.Name): $reason"),
+                            'PackageInstallFailed',
+                            [System.Management.Automation.ErrorCategory]::NotInstalled,
+                            $pkg))
                     continue
                 }
             }
         }
 
-        if (-not $DryRun -and $record.State -ne 'Failed') {
-            $record.Verified = Test-PackageInstalled -Package $pkg
-            if (-not $record.Verified -and ($pkg.CliCommands.Count -gt 0 -or $pkg.VerifyScript)) {
+        if (-not $DryRun) {
+            $verified = Test-PackageInstalled -Package $pkg
+            if (-not $verified -and ($pkg.CliCommands.Count -gt 0 -or $pkg.VerifyScript)) {
                 Write-Warning "  $($pkg.Name): verification failed (CliCommands not on PATH and/or VerifyScript=false)."
             }
         }
 
         if (-not $SkipCompletion -and -not $DryRun -and
             $pkg.Completion -ne 'none' -and $pkg.CliCommands.Count -gt 0) {
-            $completionResults = New-Object System.Collections.Generic.List[object]
             foreach ($cli in $pkg.CliCommands) {
                 $registerArgs = @{ Cli = $cli; Mode = $pkg.Completion }
                 if ($pkg.NativeCommandScript) { $registerArgs['NativeCommand'] = $pkg.NativeCommandScript }
                 try {
-                    $r = Register-PackageCompletion @registerArgs
-                    $completionResults.Add($r)
+                    $null = Register-PackageCompletion @registerArgs
                 } catch {
                     Write-Warning "  $($pkg.Name)/$cli completion registration failed: $($_.Exception.Message)"
-                    $completionResults.Add([pscustomobject]@{
-                        Cli = $cli; Source = 'Skipped'; Action = 'Skipped'
-                        Reason = $_.Exception.Message
-                    })
                 }
             }
-            $record.Completion = $completionResults.ToArray()
         }
 
-        $summary.Add($record)
+        $states.Add([pscustomobject]@{ Pkg = $pkg; State = $state; Reason = $reason })
+        Write-Output $pkg
     }
-
-    $arr = $summary.ToArray()
-    $global:LASTINSTALLREPORT = $arr
 
     Write-Host ""
     Write-Host "=== $Bundle summary ==="
-    $arr | ForEach-Object {
-        $line = "  {0,-18} {1,-12} {2}" -f $_.State, $_.Installer, $_.Name
-        if ($_.Reason) { $line += "  -- $($_.Reason)" }
-        # Colorize by state so a glance at the summary tells the story.
-        # Without this, every line — Installed, Failed, Skipped — rendered
-        # in the default foreground and "Failed" was easy to overlook.
-        $color = switch ($_.State) {
+    foreach ($s in $states) {
+        # Glyph carries the success/failure signal so a colorblind reader
+        # (or any pipeline that strips ANSI) can still scan the table.
+        # Color reinforces the glyph but is no longer load-bearing.
+        $glyph = switch ($s.State) {
+            'Installed'        { [char]0x2713 }   # ✓
+            'AlreadyInstalled' { [char]0x21BA }   # ↺
+            'Failed'           { [char]0x2717 }   # ✗
+            'Skipped'          { [char]0x2192 }   # →
+            default            { ' ' }
+        }
+        $color = switch ($s.State) {
             'Installed'        { 'Green' }
             'AlreadyInstalled' { 'DarkGreen' }
             'Failed'           { 'Red' }
             'Skipped'          { 'Yellow' }
             default            { $Host.UI.RawUI.ForegroundColor }
         }
+        $line = "  {0} {1,-18} {2,-12} {3}" -f $glyph, $s.State, $s.Pkg.Installer, $s.Pkg.Name
+        if ($s.Reason) { $line += "  -- $($s.Reason)" }
         Write-Host $line -ForegroundColor $color
     }
     Write-Host ""
-
-    # PowerShell auto-renders the returned PSCustomObject array as
-    # Format-List with green property names; on a failed install, that
-    # green can mislead a quick eye into thinking the operation
-    # succeeded. Emit a final, unambiguous red banner so failures can't
-    # be skimmed past.
-    $failedCount = @($arr | Where-Object State -eq 'Failed').Count
-    if ($failedCount -gt 0) {
-        $noun = if ($failedCount -eq 1) { 'package' } else { 'packages' }
-        Write-Host "!! $failedCount $noun failed in '$Bundle' — see [Reason] above." -ForegroundColor Red
-        Write-Host ""
-    }
-
-    return ,$arr
 }
 
 function Test-PackageInstalled {


### PR DESCRIPTION
## Problem

`Invoke-PackageInstall` returned a `PSCustomObject[]` that mixed success and failure records into one shape. PowerShell auto-formats that as `Format-List` with green property labels, so a failed install rendered nearly identical to a successful one in screenshots. The red `!! N failed` banner fired *before* auto-format, putting it far from the prompt.

The root cause was the single-channel shape  success and failure were sharing the output stream.

## Fix

Use PowerShell's standard streams the way they're designed:

* **Success stream**  Installed / AlreadyInstalled / Skipped emit the `[Package]` itself via `Write-Output`. Pipeline-friendly:

  \\\powershell
  Install-Package foo | Where-Object Installer -eq 'winget'
  \\\

* **Error stream**  Failed packages emit a structured `ErrorRecord`:
  * `FullyQualifiedErrorId = 'PackageInstallFailed'`
  * `ErrorCategory = NotInstalled`
  * `TargetObject = the [Package]`
  * `Exception.Message = the failure reason`

  Renders red by default; `\True` flips false; respects `-ErrorAction Stop` and `-ErrorVariable`.

* **Host stream**  per-package summary table keeps colour and now carries glyphs (`` Installed, `` AlreadyInstalled, `` Failed, `` Skipped) so colourblind readers and ANSI-stripped pipelines still get the signal.

## Drops

* `!! N failed` banner (visibility now lives in the error stream).
* `\` side-channel (no consumer besides one test, which is removed).
* `return ,\`.

## Tests

* Updated existing tests to read `[Package]` directly on success.
* Updated failure-path tests to assert the `PackageInstallFailed` FQID / `TargetObject` / `Exception.Message` contract via `-ErrorVariable`.
* Updated summary-coloring test to check both colour AND glyph.

Full Light suite green (898 passed, 0 failed).

Per plan in session `7431d81a-435f-4632-85c1-c66dca4034e7`.