### PR TITLE
AIAgents: install Claude Desktop via user-scope EXE (#85)

### DIFF
--- a/.github/scripts/Test-Installs.Tests.ps1
+++ b/.github/scripts/Test-Installs.Tests.ps1
@@ -665,9 +665,9 @@ Describe 'Get-PackagesNeedingVerification' {
     }
 
     It 'excludes packages that are on the CI skip list (untested status)' {
-        # Anthropic.Claude is on $script:CISkipPackages -> recorded as 'untested'
-        # via Skip-Package, so it must NOT be verified (would generate a duplicate
-        # auto-filed issue).
+        # Skipped packages (recorded as 'untested' via Skip-Package) must NOT be
+        # verified — Get-PackagesNeedingVerification's status filter is what keeps
+        # untested rows from generating duplicate auto-filed issues.
         $results = @(
             [PSCustomObject]@{ Name = 'Anthropic.Claude'; InstallerType = 'winget'; Status = 'untested' }
             [PSCustomObject]@{ Name = 'GitHub.cli';       InstallerType = 'winget'; Status = 'pass' }

--- a/.github/scripts/Test-Installs.ps1
+++ b/.github/scripts/Test-Installs.ps1
@@ -35,10 +35,6 @@ $ProgressPreference = 'SilentlyContinue'  # Speed up web requests
 $script:CISkipPackages = @{
     # winget: user-scope-only MSIX apps (no machine-scope MSI/EXE installer)
     'Pushbullet.Pushbullet'         = 'User-scope MSIX only — no machine installer; no msstore/scoop/choco alternative (#8)'
-    # winget: installer returns APPINSTALLER_CLI_ERROR_INSTALL_SYSTEM_NOT_SUPPORTED (-1978334957)
-    # on hosted runners — the Claude Desktop installer rejects the runner's system
-    # configuration (#85). Tracked separately; not a regression we can resolve in CI.
-    'Anthropic.Claude'              = 'winget installer reports SYSTEM_NOT_SUPPORTED on hosted runners (#85)'
     # choco: delisted or CI-incompatible
     'Office365ProPlus'              = 'Requires GUI session and license activation (exit 17004)'
     # scoop: browser-watch installers requiring interactive Download click

--- a/bucket/AIAgents.json
+++ b/bucket/AIAgents.json
@@ -1,6 +1,6 @@
 {
     "$schema": "https://raw.githubusercontent.com/lukesampson/scoop/master/schema.json",
-    "version": "1.16.001",
+    "version": "1.17.000",
     "url": [
         "https://raw.githubusercontent.com/MarkMichaelis/ScoopBucket/master/bucket/AIAgents.ps1"
     ],

--- a/bucket/AIAgents.ps1
+++ b/bucket/AIAgents.ps1
@@ -80,6 +80,15 @@ Register-ArgumentCompleter -Native -CommandName npx -ScriptBlock {
         Name        = 'Claude Desktop'
         Installer   = 'winget'
         Id          = 'Anthropic.Claude'
+        # Anthropic ships Claude Desktop in two flavors: a machine-context MSIX
+        # (requires the runFullTrust restricted capability, only honored on
+        # interactive Windows desktop sessions with sideloading enabled) and a
+        # user-scope EXE. On headless Windows Server hosted CI runners winget's
+        # default MSIX selection fails with APPINSTALLER_CLI_ERROR_INSTALL_SYSTEM_NOT_SUPPORTED
+        # (-1978334957). Forcing --scope user routes winget to the EXE installer,
+        # which is also Anthropic's actual deployment model (per-user app under
+        # %LOCALAPPDATA%\AnthropicClaude). See #85.
+        Scope       = 'user'
         Notes       = 'MCP-capable desktop client. Local Claude.json manifest also installs this via winget; keeping the declarative entry here is the canonical home for the package.'
     }
     [Package]@{


### PR DESCRIPTION
Fixes #85.

## Root cause

Anthropic's winget manifest (`Anthropic.Claude` 1.7196.1) ships **two** installer flavors:

| # | Type | Scope | Notes |
|---|------|-------|-------|
| 1 | **MSIX** (x64/arm64) | machine-context (implicit) | Declares `RestrictedCapabilities: runFullTrust, unvirtualizedResources, localSystemServices, packagedServices`. Honored only on interactive desktop Windows with sideloading enabled. |
| 2 | **EXE** (x64/arm64) | `Scope: user` (explicit) | Squirrel installer dropping the app into `%LOCALAPPDATA%\AnthropicClaude\`. |

There is **no machine-scope EXE/MSI** offered by Anthropic. With our previous `--scope machine` invocation winget picked the MSIX, which fails on GitHub-hosted Windows Server runners with `APPINSTALLER_CLI_ERROR_INSTALL_SYSTEM_NOT_SUPPORTED` (-1978334957) after hash verification — the runner can't satisfy `runFullTrust`.

## Fix

Set `Scope = 'user'` on the Claude Desktop `[Package]` entry in `bucket/AIAgents.ps1`. Both the module's `Install-WingetPackage` and `.github/scripts/Test-Installs.ps1`'s wrapper already plumb `--scope user` when `Scope='user'`, so winget will now select the per-user EXE installer — which is also Anthropic's actual deployment model (Electron + Squirrel auto-update writes to `%LOCALAPPDATA%`).

Removed `Anthropic.Claude` from `$script:CISkipPackages` in `.github/scripts/Test-Installs.ps1` so the Heavy validate-installs workflow exercises the real install path on the next push to `main`.

## Changes

- `bucket/AIAgents.ps1` — `[Package]` Claude Desktop gains `Scope = 'user'` with an explanatory comment.
- `.github/scripts/Test-Installs.ps1` — drop `Anthropic.Claude` from `CISkipPackages`.
- `.github/scripts/Test-Installs.Tests.ps1` — update one comment that mentioned the now-removed skip.
- `bucket/AIAgents.json` — version 1.16.001 → 1.17.000 (AIAgents.ps1 modified).

## Tradeoffs

- A user running `Install-Package 'Claude Desktop'` now installs into their own profile rather than machine-wide. This matches Anthropic's intent: Claude Desktop is a per-user Electron app whose auto-updater writes to `%LOCALAPPDATA%`. A machine-wide MSIX install couldn't roam to other user profiles either, so no real capability is lost.
- An admin running for someone else's profile would need to run as that user, same as for Slack/Discord/Teams/Cursor.

## Verification

- `Invoke-Pester bucket\Bundles.Tests.ps1` — 752 passed, 0 failed, 1 skipped.
- `Invoke-Pester .github\scripts\Test-Installs.Tests.ps1` — same 17 pre-existing local failures as `main` (local env can't run `Get-Package` discovery; CI Light path is unaffected).
- Heavy `validate-installs.yml` runs on push to `main` only, so the true Claude Desktop install gets validated post-merge. If the user-scope EXE also rejects the runner, the workflow will auto-refile the issue with the new exit code/output.