### PR TITLE
Get-Package: propagate WingetExtraArgs through bundle loader (#161)

### DIFF
--- a/bucket/Bundles.Tests.ps1
+++ b/bucket/Bundles.Tests.ps1
@@ -272,4 +272,18 @@ Describe 'Specific cross-bundle placement contracts' -Tag 'Light','Bundle' {
         $bc = $script:byBundle.DeveloperBasePackages | Where-Object Name -eq 'Beyond Compare'
         $bc.HasPostInstallScript | Should -BeTrue
     }
+
+    It 'Get-Package surfaces WingetExtraArgs through the child-runspace bundle loader (#161)' {
+        # Regression: PR #159 added WingetExtraArgs on the [Package] class
+        # and to Test-Installs.ps1's CI wrapper, but the curated hashtable
+        # in Get-BundlePackages.ps1's probe (and Get-Package's flattener)
+        # omitted the field, so it round-tripped as $null. Result: Handy
+        # was installed in CI without --skip-dependencies and failed with
+        # APPINSTALLER_CLI_ERROR_INSTALL_MISSING_DEPENDENCY (-1978334972)
+        # on KhronosGroup.VulkanRT 1.4.350.0. Lock in the contract.
+        $handy = $script:byBundle.ClientBasePackages | Where-Object Name -eq 'Handy'
+        $handy                                          | Should -Not -BeNullOrEmpty
+        $handy.PSObject.Properties.Name                 | Should -Contain 'WingetExtraArgs'
+        @($handy.WingetExtraArgs)                       | Should -Contain '--skip-dependencies'
+    }
 }

--- a/module/MarkMichaelis.ScoopBucket/Private/Get-BundlePackages.ps1
+++ b/module/MarkMichaelis.ScoopBucket/Private/Get-BundlePackages.ps1
@@ -105,6 +105,7 @@ function global:Invoke-PackageInstall {
             DependsOn   = @(`$p.DependsOn)
             CISkip      = `$p.CISkip
             Notes       = `$p.Notes
+            WingetExtraArgs = @(`$p.WingetExtraArgs)
             HasPostInstallScript   = [bool]`$p.PostInstallScript
             HasCustomInstallScript = [bool]`$p.CustomInstallScript
             HasVerifyScript        = [bool]`$p.VerifyScript

--- a/module/MarkMichaelis.ScoopBucket/Public/Get-Package.ps1
+++ b/module/MarkMichaelis.ScoopBucket/Public/Get-Package.ps1
@@ -37,7 +37,7 @@ function Get-Package {
 
     .OUTPUTS
         PSCustomObject[] with Bundle, Name, Installer, Id, Source, Scope,
-        CliCommands, Completion, DependsOn, CISkip, Notes.
+        CliCommands, Completion, DependsOn, CISkip, Notes, WingetExtraArgs.
 
     .EXAMPLE
         Get-Package -Installer scoop
@@ -103,6 +103,7 @@ function Get-Package {
                 DependsOn   = @($p.DependsOn)
                 CISkip      = $p.CISkip
                 Notes       = $p.Notes
+                WingetExtraArgs = @($p.WingetExtraArgs)
                 HasPostInstallScript   = [bool]$p.HasPostInstallScript
                 HasCustomInstallScript = [bool]$p.HasCustomInstallScript
                 HasVerifyScript        = [bool]$p.HasVerifyScript


### PR DESCRIPTION
Fixes #161.

## Root cause

PR #159 added `WingetExtraArgs` to the `[Package]` class and to the CI wrapper in `.github/scripts/Test-Installs.ps1` (which already reads `$p.WingetExtraArgs` from `Get-Package` output). The in-process module path (`module/.../Private/Install-WingetPackage.ps1`) honored the field correctly.

But `Get-Package` flattens packages through the **child-runspace bundle loader** in `module/MarkMichaelis.ScoopBucket/Private/Get-BundlePackages.ps1`, which serializes each `[Package]` into a **curated hashtable** (scriptblocks would be lost across JSON anyway). That curated hashtable — and the matching `pscustomobject` projection in `Public/Get-Package.ps1` — both **omitted `WingetExtraArgs`**, so the field round-tripped as `$null`.

Net effect in CI: `Test-Installs.ps1`'s `Get-AllPackages` read `@($p.WingetExtraArgs)` → `@()`, the install command got built without the per-package extras, and **Handy (`cjpais.Handy`)** was invoked without `--skip-dependencies`. Winget then resolved its declared `KhronosGroup.VulkanRT 1.4.350.0` dependency, found no applicable installer for it on the hosted runner, and exited `-1978334972` (`APPINSTALLER_CLI_ERROR_INSTALL_MISSING_DEPENDENCY`).

## Fix

Add `WingetExtraArgs = @($p.WingetExtraArgs)` to:

1. `module/MarkMichaelis.ScoopBucket/Private/Get-BundlePackages.ps1` — the probe-side hashtable that the child runspace serializes to JSON.
2. `module/MarkMichaelis.ScoopBucket/Public/Get-Package.ps1` — the parent-side flattened `pscustomobject` (and update its docstring `.OUTPUTS` list).

## Regression test

Added one focused assertion to `bucket/Bundles.Tests.ps1`:

```powershell
It 'Get-Package surfaces WingetExtraArgs through the child-runspace bundle loader (#161)' {
    $handy = $script:byBundle.ClientBasePackages | Where-Object Name -eq 'Handy'
    $handy                                          | Should -Not -BeNullOrEmpty
    $handy.PSObject.Properties.Name                 | Should -Contain 'WingetExtraArgs'
    @($handy.WingetExtraArgs)                       | Should -Contain '--skip-dependencies'
}
```

This locks in the contract end-to-end (bundle source → child runspace → JSON → parent runspace → `Get-Package` consumer).

## Verification

- `Invoke-Pester bucket\Bundles.Tests.ps1` → **753 passed, 0 failed, 1 skipped** (was 752/0/1; the new test adds one).
- Definitive Heavy validation runs post-merge on `main` via `validate-installs.yml`. If Handy still fails (e.g. for an unrelated reason), the workflow will auto-refile #161 with new diagnostics.