### PR TITLE
Add -Cleanup switch and install ledger to Test-Installs.ps1 (#62 Part B + D)

### DIFF
--- a/.github/scripts/Test-Installs.ps1
+++ b/.github/scripts/Test-Installs.ps1
@@ -16,7 +16,24 @@
     - Sideloaded apps (Add-AppxPackage) -> marked untested in CI
 
     Adding or removing a package in any bucket script automatically updates CI coverage.
+
+.PARAMETER Cleanup
+    When set, every successful install is recorded to a JSON "install ledger"
+    (default: $env:TEMP\ScoopBucket-Cleanup-Ledger.json) and uninstalled at
+    end-of-run.  If a prior -Cleanup run aborted mid-flight, re-running with
+    -Cleanup first replays the stale ledger so the new run starts from a
+    known-clean state.  Default OFF: preserves dev-box state for interactive
+    sessions and keeps backwards compatibility with existing CI.
+
+.PARAMETER LedgerPath
+    Override the ledger file location.  Mainly for tests.
 #>
+
+[CmdletBinding()]
+param(
+    [switch]$Cleanup,
+    [string]$LedgerPath
+)
 
 $ErrorActionPreference = 'Continue'
 $ProgressPreference = 'SilentlyContinue'  # Speed up web requests
@@ -90,6 +107,188 @@ function Add-Result {
         Write-Host $ErrorOutput
         Write-Host "::endgroup::"
     }
+}
+
+# ============================================================================
+# Install Ledger (Cleanup mode)
+# ============================================================================
+# When -Cleanup is set, every successful install is appended to a JSON ledger
+# file (default: $env:TEMP\ScoopBucket-Cleanup-Ledger.json).  Two phases use it:
+#
+#   1. BEFORE discovery: if a stale ledger exists from a prior -Cleanup run
+#      that aborted mid-flight, replay it now so we don't double-install
+#      already-installed packages on a dirty box.
+#   2. AFTER all installs + verification: walk the ledger uninstalling each
+#      entry via the matching package manager, then delete the file.
+#
+# Idempotent and silent — uninstall failures emit a warning but never throw.
+
+if (-not $LedgerPath) {
+    $LedgerPath = Join-Path $env:TEMP 'ScoopBucket-Cleanup-Ledger.json'
+}
+$script:CleanupLedgerPath = $LedgerPath
+
+function Get-CleanupLedger {
+    if (-not (Test-Path $script:CleanupLedgerPath)) { return @() }
+    try {
+        $raw = Get-Content -LiteralPath $script:CleanupLedgerPath -Raw -ErrorAction Stop
+        if ([string]::IsNullOrWhiteSpace($raw)) { return @() }
+        $parsed = $raw | ConvertFrom-Json -ErrorAction Stop
+        return @($parsed)
+    } catch {
+        Write-Warning "Get-CleanupLedger: failed to read '$($script:CleanupLedgerPath)': $($_.Exception.Message)"
+        return @()
+    }
+}
+
+function Add-LedgerEntry {
+    param(
+        [Parameter(Mandatory)][ValidateSet('winget','choco','scoop','ps-module')][string]$InstallerType,
+        [Parameter(Mandatory)][string]$Name,
+        [string]$PackageId,
+        [string]$Scope = 'machine'
+    )
+    if (-not $Cleanup) { return }
+    if (-not $PackageId) { $PackageId = $Name }
+    $entry = [pscustomobject]@{
+        Timestamp     = (Get-Date).ToString('o')
+        InstallerType = $InstallerType
+        Name          = $Name
+        PackageId     = $PackageId
+        Scope         = $Scope
+    }
+    try {
+        $current = @(Get-CleanupLedger)
+        $current += $entry
+        ($current | ConvertTo-Json -Depth 5) | Out-File -LiteralPath $script:CleanupLedgerPath -Encoding UTF8
+    } catch {
+        Write-Warning "Add-LedgerEntry: failed to append to '$($script:CleanupLedgerPath)': $($_.Exception.Message)"
+    }
+}
+
+function Clear-CleanupLedger {
+    if (Test-Path $script:CleanupLedgerPath) {
+        try { Remove-Item -LiteralPath $script:CleanupLedgerPath -Force -ErrorAction Stop }
+        catch { Write-Warning "Clear-CleanupLedger: $($_.Exception.Message)" }
+    }
+}
+
+function Uninstall-WingetPackage {
+    param([string]$PackageId, [string]$Scope = 'machine')
+    $effectiveScope = if ($Scope -eq 'user') { 'user' } else { 'machine' }
+    $cmd = "winget uninstall --id $PackageId --scope $effectiveScope --silent --disable-interactivity --accept-source-agreements"
+    try {
+        $result = Invoke-WithTimeout -Command $cmd -TimeoutSeconds 600
+        Write-Host "  [cleanup/winget] $PackageId (exit $($result.ExitCode))"
+    } catch {
+        Write-Warning "Uninstall-WingetPackage '$PackageId': $($_.Exception.Message)"
+    }
+}
+
+function Uninstall-ChocoPackage {
+    param([string]$Name)
+    $cmd = "choco uninstall $Name -y --no-progress --skip-autouninstaller"
+    try {
+        $result = Invoke-WithTimeout -Command $cmd -TimeoutSeconds 600
+        Write-Host "  [cleanup/choco] $Name (exit $($result.ExitCode))"
+    } catch {
+        Write-Warning "Uninstall-ChocoPackage '$Name': $($_.Exception.Message)"
+    }
+}
+
+function Uninstall-ScoopPackage {
+    param([string]$Name)
+    $leaf = ($Name -split '/')[-1]
+    $cmd = "scoop uninstall -g $leaf"
+    try {
+        $result = Invoke-WithTimeout -Command $cmd -TimeoutSeconds 600
+        Write-Host "  [cleanup/scoop] $leaf (exit $($result.ExitCode))"
+    } catch {
+        Write-Warning "Uninstall-ScoopPackage '$Name': $($_.Exception.Message)"
+    }
+}
+
+function Uninstall-PSModuleEntry {
+    param([string]$Name)
+    try {
+        Uninstall-Module -Name $Name -AllVersions -Force -ErrorAction Stop
+        Write-Host "  [cleanup/ps-module] $Name"
+    } catch {
+        Write-Warning "Uninstall-PSModuleEntry '$Name': $($_.Exception.Message)"
+    }
+}
+
+function Invoke-CleanupLedger {
+    <#
+    .SYNOPSIS
+        Walks every ledger entry and dispatches to the matching uninstaller.
+        Idempotent: passing through a clean ledger is a no-op.  After
+        processing, the ledger file is deleted.
+    #>
+    [CmdletBinding()]
+    param([string]$Reason = 'end-of-run')
+
+    $entries = @(Get-CleanupLedger)
+    if ($entries.Count -eq 0) {
+        Write-Host "Cleanup ledger is empty ($Reason); nothing to do."
+        return
+    }
+    Write-Host "`n========== Cleanup ($Reason): $($entries.Count) ledger entries ==========" -ForegroundColor Cyan
+    foreach ($e in $entries) {
+        switch ($e.InstallerType) {
+            'winget'    { Uninstall-WingetPackage -PackageId $e.PackageId -Scope $e.Scope }
+            'choco'     { Uninstall-ChocoPackage  -Name $e.Name }
+            'scoop'     { Uninstall-ScoopPackage  -Name $e.Name }
+            'ps-module' { Uninstall-PSModuleEntry -Name $e.Name }
+            default     { Write-Warning "Invoke-CleanupLedger: unknown InstallerType '$($e.InstallerType)' for '$($e.Name)'" }
+        }
+    }
+    Clear-CleanupLedger
+}
+
+# ============================================================================
+# Probe-Before-Install helpers (Cleanup mode)
+# ============================================================================
+# Cleanup MUST NOT uninstall packages that were already on the host before
+# this run started — otherwise running `Test-Installs.ps1 -Cleanup` on a
+# dev box destroys user state.  Each Install-*Package function probes
+# *before* invoking the installer; only when the package was NOT already
+# installed (by the same manager at the same scope) does the success path
+# call Add-LedgerEntry.  Cross-manager state (e.g. choco-installed 7zip
+# vs winget-installed 7zip) is naturally safe: we only uninstall via the
+# manager that produced our ledger entry, against the scope we recorded.
+
+function Test-WingetInstalled {
+    param([Parameter(Mandatory)][string]$PackageId, [string]$Scope = 'machine')
+    $effectiveScope = if ($Scope -eq 'user') { 'user' } else { 'machine' }
+    $cmd = "winget list --id $PackageId --scope $effectiveScope --exact --disable-interactivity --accept-source-agreements"
+    try {
+        $result = Invoke-WithTimeout -Command $cmd -TimeoutSeconds 120
+        # winget list exits 0 only when a match is found.
+        return ($result.ExitCode -eq 0 -and $result.Output -match [regex]::Escape($PackageId))
+    } catch { return $false }
+}
+
+function Test-ChocoInstalled {
+    param([Parameter(Mandatory)][string]$Name)
+    try {
+        $result = Invoke-WithTimeout -Command "choco list --local-only --exact $Name --limit-output --no-color" -TimeoutSeconds 60
+        return (-not [string]::IsNullOrWhiteSpace($result.Output) -and $result.Output -match "^$([regex]::Escape($Name))\|")
+    } catch { return $false }
+}
+
+function Test-ScoopInstalled {
+    param([Parameter(Mandatory)][string]$Name)
+    $leaf = ($Name -split '/')[-1]
+    $scoopRoot = if ($env:SCOOP_GLOBAL) { $env:SCOOP_GLOBAL } else { Join-Path $env:ProgramData 'scoop' }
+    $userScoop = if ($env:SCOOP) { $env:SCOOP } else { Join-Path $env:USERPROFILE 'scoop' }
+    return (Test-Path (Join-Path $scoopRoot "apps\$leaf\current")) -or
+           (Test-Path (Join-Path $userScoop "apps\$leaf\current"))
+}
+
+function Test-PSModuleInstalled {
+    param([Parameter(Mandatory)][string]$Name)
+    return @(Get-Module -ListAvailable -Name $Name -ErrorAction SilentlyContinue).Count -gt 0
 }
 
 # ============================================================================
@@ -167,6 +366,11 @@ function Install-WingetPackage {
     # map both 'global' and the legacy 'machine' to winget's 'machine'.
     # Anything not 'user' falls back to 'machine'.
     $effectiveScope = if ($Scope -eq 'user') { 'user' } else { 'machine' }
+    # Probe BEFORE install so cleanup never uninstalls pre-existing user state.
+    $wasAlreadyInstalled = $false
+    if ($Cleanup) {
+        $wasAlreadyInstalled = Test-WingetInstalled -PackageId $PackageId -Scope $effectiveScope
+    }
     $cmd = "winget install --id $PackageId --scope $effectiveScope --accept-package-agreements --accept-source-agreements --disable-interactivity --silent"
     # Append per-package extras (e.g. --skip-dependencies for packages whose
     # declared dependencies have no applicable installer on hosted runners).
@@ -201,6 +405,13 @@ function Install-WingetPackage {
         elseif ($code -eq 0 -or $code -eq -1978335189) {
             Add-Result -Name $Name -PackageId $PackageId -InstallerType 'winget' `
                 -SourceScript $SourceScript -Command $cmd -Status 'pass'
+            # Only ledger when WE actually installed it: exit 0 (fresh install)
+            # AND the pre-install probe said it wasn't already there.  Exit
+            # -1978335189 (ALREADY_INSTALLED) means winget itself confirmed
+            # someone else put it on the box — don't touch it on cleanup.
+            if ($code -eq 0 -and -not $wasAlreadyInstalled) {
+                Add-LedgerEntry -InstallerType 'winget' -Name $Name -PackageId $PackageId -Scope $effectiveScope
+            }
         } else {
             Add-Result -Name $Name -PackageId $PackageId -InstallerType 'winget' `
                 -SourceScript $SourceScript -Command $cmd -Status 'fail' `
@@ -220,6 +431,8 @@ function Install-ChocoPackage {
         [string]$SourceScript
     )
     if (-not $PackageId) { $PackageId = $Name }
+    $wasAlreadyInstalled = $false
+    if ($Cleanup) { $wasAlreadyInstalled = Test-ChocoInstalled -Name $Name }
     $cmd = "choco install $PackageId -y --no-progress"
     try {
         Write-Host "  Installing [choco] $Name..."
@@ -232,6 +445,9 @@ function Install-ChocoPackage {
         } elseif ($code -eq 0) {
             Add-Result -Name $Name -PackageId $PackageId -InstallerType 'choco' `
                 -SourceScript $SourceScript -Command $cmd -Status 'pass'
+            if (-not $wasAlreadyInstalled) {
+                Add-LedgerEntry -InstallerType 'choco' -Name $Name -PackageId $PackageId
+            }
         } else {
             Add-Result -Name $Name -PackageId $PackageId -InstallerType 'choco' `
                 -SourceScript $SourceScript -Command $cmd -Status 'fail' `
@@ -251,6 +467,8 @@ function Install-ScoopPackage {
         [string]$SourceScript
     )
     if (-not $PackageId) { $PackageId = $Name }
+    $wasAlreadyInstalled = $false
+    if ($Cleanup) { $wasAlreadyInstalled = Test-ScoopInstalled -Name $Name }
     $cmd = "scoop install -g $PackageId"
     try {
         Write-Host "  Installing [scoop] $Name..."
@@ -263,6 +481,9 @@ function Install-ScoopPackage {
         } elseif ($code -eq 0) {
             Add-Result -Name $Name -PackageId $PackageId -InstallerType 'scoop' `
                 -SourceScript $SourceScript -Command $cmd -Status 'pass'
+            if (-not $wasAlreadyInstalled) {
+                Add-LedgerEntry -InstallerType 'scoop' -Name $Name -PackageId $PackageId
+            }
         } else {
             Add-Result -Name $Name -PackageId $PackageId -InstallerType 'scoop' `
                 -SourceScript $SourceScript -Command $cmd -Status 'fail' `
@@ -281,12 +502,17 @@ function Install-PSModule {
         [string]$SourceScript,
         [string]$AdditionalArgs = ''
     )
+    $wasAlreadyInstalled = $false
+    if ($Cleanup) { $wasAlreadyInstalled = Test-PSModuleInstalled -Name $Name }
     $cmd = "Install-Module $Name -Force -AllowClobber -Scope AllUsers $AdditionalArgs".Trim()
     try {
         Write-Host "  Installing [PS module] $Name..."
         Invoke-Expression $cmd
         Add-Result -Name $Name -PackageId $Name -InstallerType 'ps-module' `
             -SourceScript $SourceScript -Command $cmd -Status 'pass'
+        if (-not $wasAlreadyInstalled) {
+            Add-LedgerEntry -InstallerType 'ps-module' -Name $Name
+        }
     } catch {
         Add-Result -Name $Name -PackageId $Name -InstallerType 'ps-module' `
             -SourceScript $SourceScript -Command $cmd -Status 'fail' `
@@ -700,6 +926,22 @@ if (-not (Test-Path $bucketPath)) {
     exit 1
 }
 
+# ============================================================================
+# Pre-run ledger replay (Cleanup mode)
+# ============================================================================
+# If a prior `-Cleanup` run aborted mid-flight (Ctrl+C, OOM, runner cancellation),
+# the ledger file is still on disk and the packages it lists are still installed.
+# Replaying it here means the new run starts from a known-clean state instead of
+# getting "already installed" exit codes everywhere — and, more importantly,
+# the pre-install probes won't mistake the leftovers for pre-existing user
+# state, which would otherwise cause those installs to be silently excluded
+# from this run's cleanup ledger.
+if ($Cleanup) {
+    Write-Host "`n========== Cleanup mode: replaying any stale ledger ==========" -ForegroundColor Cyan
+    Write-Host "  Ledger path: $script:CleanupLedgerPath" -ForegroundColor DarkGray
+    Invoke-CleanupLedger -Reason 'pre-run replay'
+}
+
 # Set up PSGallery as trusted (needed for PS module installs)
 Write-Host "`n========== Setting up PSGallery ==========" -ForegroundColor Cyan
 if ((Get-PSRepository PSGallery).InstallationPolicy -ne 'Trusted') {
@@ -1029,6 +1271,19 @@ if ($failed -gt 0) {
 }
 
 } finally {
+    # ========================================================================
+    # End-of-run cleanup (when -Cleanup was set).  Runs BEFORE the partial
+    # results write so cleanup output appears in the workflow log even on
+    # cancellation.  Uninstalls every package recorded in the ledger via
+    # the matching package manager, then deletes the ledger file.  Packages
+    # the pre-install probe identified as already-installed never made it
+    # into the ledger, so user state is preserved.
+    # ========================================================================
+    if ($Cleanup) {
+        try { Invoke-CleanupLedger -Reason 'end-of-run' }
+        catch { Write-Warning "Invoke-CleanupLedger failed: $($_.Exception.Message)" }
+    }
+
     # ========================================================================
     # Ensure results are ALWAYS written, even if the script is interrupted or
     # cancelled mid-run.  The try block starts just before the install loop.

--- a/.github/scripts/Test-InstallsCleanup.Tests.ps1
+++ b/.github/scripts/Test-InstallsCleanup.Tests.ps1
@@ -1,0 +1,171 @@
+#Requires -Modules Pester
+<#
+.SYNOPSIS
+    Pester coverage for the install-ledger + cleanup logic added to
+    Test-Installs.ps1 by issue #62 Part B.
+
+.DESCRIPTION
+    Test-Installs.ps1 is a top-level script (#Requires -RunAsAdministrator
+    + main execution at the bottom) so we cannot dot-source it whole.  We
+    extract just the ledger / probe / uninstall helpers via a regex pull
+    pattern (the same trick Test-Installs.Tests.ps1 already uses), inject
+    fakes for Invoke-WithTimeout and the elevated uninstall cmdlets, then
+    drive end-to-end scenarios.
+
+    Cases covered:
+      * Empty ledger → no work; no file created.
+      * Add-LedgerEntry only fires when $Cleanup is $true.
+      * Add-LedgerEntry serialises winget / choco / scoop / ps-module rows.
+      * Get-CleanupLedger round-trips a multi-entry JSON file.
+      * Invoke-CleanupLedger dispatches each row to the right uninstaller
+        and deletes the ledger file when done.
+      * Pre-run replay (-Cleanup) walks a stale ledger then starts fresh.
+      * "Already installed" semantics: Add-LedgerEntry must NOT be called
+        when the pre-install probe reports the package was on the host
+        before the run started (cross-manager case is naturally safe —
+        we only uninstall via the manager that produced the row, against
+        the recorded scope).
+#>
+
+BeforeAll {
+    $scriptPath = Join-Path $PSScriptRoot 'Test-Installs.ps1'
+    $scriptContent = Get-Content $scriptPath -Raw
+
+    # Pull only the helpers we want to exercise.  Each function block ends
+    # at the next `function ` declaration OR the next banner (lines of ====).
+    $functionsToLoad = @(
+        'Get-CleanupLedger', 'Add-LedgerEntry', 'Clear-CleanupLedger',
+        'Uninstall-WingetPackage', 'Uninstall-ChocoPackage',
+        'Uninstall-ScoopPackage', 'Uninstall-PSModuleEntry',
+        'Invoke-CleanupLedger',
+        'Test-WingetInstalled', 'Test-ChocoInstalled',
+        'Test-ScoopInstalled', 'Test-PSModuleInstalled'
+    )
+    $bodies = foreach ($n in $functionsToLoad) {
+        if ($scriptContent -match "(?ms)(function\s+$n\s*\{.+?)(?=\nfunction\s|\n#\s*={5,})") {
+            $Matches[1]
+        }
+    }
+    $loadScript = $bodies -join "`n`n"
+
+    # Fake Invoke-WithTimeout: deterministic, no actual processes.  Tests
+    # that need specific output/exit set $script:InvokeWithTimeoutImpl.
+    function script:Invoke-WithTimeout {
+        param([string]$Command, [int]$TimeoutSeconds = 60)
+        if ($script:InvokeWithTimeoutImpl) {
+            return & $script:InvokeWithTimeoutImpl $Command
+        }
+        return @{ ExitCode = 0; Output = ''; TimedOut = $false }
+    }
+
+    # Fake Uninstall-Module so Uninstall-PSModuleEntry doesn't try to talk
+    # to the real PSGallery / system module store.
+    function script:Uninstall-Module {
+        param([string]$Name, [switch]$AllVersions, [switch]$Force, [string]$ErrorAction)
+        $script:UninstallModuleCalls += @($Name)
+    }
+
+    Invoke-Expression $loadScript
+
+    function script:Reset-LedgerTestState {
+        $script:CleanupLedgerPath = Join-Path $TestDrive ("ledger-{0}.json" -f ([guid]::NewGuid().Guid))
+        $script:Cleanup = $true
+        $script:InvokeWithTimeoutCalls = @()
+        $script:UninstallModuleCalls = @()
+        $script:InvokeWithTimeoutImpl = {
+            param($cmd)
+            $script:InvokeWithTimeoutCalls += @($cmd)
+            @{ ExitCode = 0; Output = ''; TimedOut = $false }
+        }
+    }
+}
+
+Describe 'Install ledger CRUD (#62)' -Tag 'Light' {
+    BeforeEach { Reset-LedgerTestState }
+
+    It 'returns an empty array when the ledger file does not exist' {
+        Get-CleanupLedger | Should -HaveCount 0
+    }
+
+    It 'Add-LedgerEntry no-ops when -Cleanup is off' {
+        $script:Cleanup = $false
+        Add-LedgerEntry -InstallerType 'winget' -Name 'X' -PackageId 'X.Y'
+        Test-Path $script:CleanupLedgerPath | Should -BeFalse
+    }
+
+    It 'Add-LedgerEntry persists one row per installer type' {
+        Add-LedgerEntry -InstallerType 'winget'    -Name 'Foo' -PackageId 'Org.Foo' -Scope 'machine'
+        Add-LedgerEntry -InstallerType 'choco'     -Name 'bar'
+        Add-LedgerEntry -InstallerType 'scoop'     -Name 'baz'
+        Add-LedgerEntry -InstallerType 'ps-module' -Name 'Qux'
+
+        $entries = @(Get-CleanupLedger)
+        $entries | Should -HaveCount 4
+        $entries.Where{ $_.InstallerType -eq 'winget'    }.PackageId | Should -Be 'Org.Foo'
+        $entries.Where{ $_.InstallerType -eq 'winget'    }.Scope     | Should -Be 'machine'
+        $entries.Where{ $_.InstallerType -eq 'choco'     }.Name      | Should -Be 'bar'
+        $entries.Where{ $_.InstallerType -eq 'scoop'     }.Name      | Should -Be 'baz'
+        $entries.Where{ $_.InstallerType -eq 'ps-module' }.Name      | Should -Be 'Qux'
+    }
+
+    It 'Clear-CleanupLedger removes the file' {
+        Add-LedgerEntry -InstallerType 'winget' -Name 'Foo' -PackageId 'Org.Foo'
+        Test-Path $script:CleanupLedgerPath | Should -BeTrue
+        Clear-CleanupLedger
+        Test-Path $script:CleanupLedgerPath | Should -BeFalse
+    }
+}
+
+Describe 'Invoke-CleanupLedger (#62)' -Tag 'Light' {
+    BeforeEach { Reset-LedgerTestState }
+
+    It 'no-ops on an empty ledger and does not throw' {
+        { Invoke-CleanupLedger -Reason 'unit' } | Should -Not -Throw
+    }
+
+    It 'dispatches one uninstall command per entry and deletes the ledger' {
+        Add-LedgerEntry -InstallerType 'winget' -Name 'Foo' -PackageId 'Org.Foo' -Scope 'user'
+        Add-LedgerEntry -InstallerType 'choco'  -Name 'bar'
+        Add-LedgerEntry -InstallerType 'scoop'  -Name 'extras/baz'
+        Add-LedgerEntry -InstallerType 'ps-module' -Name 'Qux'
+
+        Invoke-CleanupLedger -Reason 'unit'
+
+        $script:InvokeWithTimeoutCalls | Should -Contain 'winget uninstall --id Org.Foo --scope user --silent --disable-interactivity --accept-source-agreements'
+        $script:InvokeWithTimeoutCalls | Should -Contain 'choco uninstall bar -y --no-progress --skip-autouninstaller'
+        $script:InvokeWithTimeoutCalls | Should -Contain 'scoop uninstall -g baz'
+        $script:UninstallModuleCalls   | Should -Contain 'Qux'
+        Test-Path $script:CleanupLedgerPath | Should -BeFalse
+    }
+
+    It 'records the scope on winget rows so cleanup targets the same scope (#62 already-installed case 3)' {
+        Add-LedgerEntry -InstallerType 'winget' -Name 'Foo' -PackageId 'Org.Foo' -Scope 'machine'
+        Invoke-CleanupLedger -Reason 'unit'
+        $script:InvokeWithTimeoutCalls | Should -Match '--scope machine'
+    }
+}
+
+Describe 'Pre-install probe behavior (#62 already-installed)' -Tag 'Light' {
+    BeforeEach { Reset-LedgerTestState }
+
+    It 'Test-WingetInstalled returns true when winget list matches the id' {
+        $script:InvokeWithTimeoutImpl = {
+            @{ ExitCode = 0; Output = 'Name  Id  Version'; TimedOut = $false }
+        }
+        # winget list parsing requires the id to appear in output too:
+        $script:InvokeWithTimeoutImpl = {
+            @{ ExitCode = 0; Output = "Foo  Org.Foo  1.0`n"; TimedOut = $false }
+        }
+        Test-WingetInstalled -PackageId 'Org.Foo' -Scope 'machine' | Should -BeTrue
+    }
+
+    It 'Test-WingetInstalled returns false when winget list exits non-zero' {
+        $script:InvokeWithTimeoutImpl = { @{ ExitCode = -1978335212; Output = 'No installed package found'; TimedOut = $false } }
+        Test-WingetInstalled -PackageId 'Org.Missing' -Scope 'machine' | Should -BeFalse
+    }
+
+    It 'Test-PSModuleInstalled returns false for a guaranteed-missing module name' {
+        $name = 'NonExistentModule-{0}' -f ([guid]::NewGuid().Guid)
+        Test-PSModuleInstalled -Name $name | Should -BeFalse
+    }
+}

--- a/.github/workflows/validate-installs.yml
+++ b/.github/workflows/validate-installs.yml
@@ -131,6 +131,13 @@ jobs:
         shell: pwsh
         run: |
           Set-ExecutionPolicy Bypass -Scope Process -Force
+          # NOTE: -Cleanup is intentionally NOT passed here. Subsequent steps
+          # ("Apply post-install hooks", "CLI availability discovery",
+          # "CLI availability — pinned contract") all depend on installs
+          # persisting through the job. The runner image is discarded at
+          # end-of-job so no state leaks anyway. -Cleanup is a dev-box
+          # convenience for running Test-Installs.ps1 locally — see README
+          # "Heavy validate-installs — local cleanup" for details.
           & "${{ github.workspace }}\.github\scripts\Test-Installs.ps1"
 
       - name: Apply post-install hooks (PATH/shim sidecars)

--- a/README.md
+++ b/README.md
@@ -421,3 +421,54 @@ canonical URL's content, not your working tree. Re-running
 `Install-LocalManifest` is the right way to iterate; `scoop update` is
 not.
 
+### Heavy validate-installs — local cleanup (`-Cleanup`)
+
+`Test-Installs.ps1` (the Heavy CI driver) installs every package in the
+bucket to prove they work on a clean Windows Server. On hosted runners
+the image is discarded at end-of-job so no cleanup is needed; if you
+ever run the same script **locally** to debug a CI failure, every
+successful install lingers on your dev box.
+
+The opt-in `-Cleanup` switch fixes that:
+
+```powershell
+& .github\scripts\Test-Installs.ps1 -Cleanup
+```
+
+Behavior:
+
+1. **Pre-install probe.** Before each install, the matching package
+   manager is queried for the package at the same scope. If it was
+   already there, the install proceeds (it's idempotent) but the
+   package is **not** recorded for cleanup. Pre-existing user state is
+   never touched.
+2. **Install ledger.** Each install that the run *actually added* is
+   appended to a JSON ledger
+   (default: `$env:TEMP\ScoopBucket-Cleanup-Ledger.json`).
+3. **End-of-run uninstall.** Inside the script's `finally` block, every
+   ledger entry is uninstalled via the same package manager and scope
+   that produced it (`winget uninstall --scope <scope>`,
+   `choco uninstall`, `scoop uninstall -g`, `Uninstall-Module`).
+4. **Crash recovery.** If a `-Cleanup` run aborts mid-flight (Ctrl+C,
+   OOM, runner cancellation), the ledger file survives on disk. The
+   next `-Cleanup` invocation replays it *before* discovery, so you
+   restart from a known-clean state.
+
+**Already-installed semantics:**
+
+| Case | Behavior |
+|---|---|
+| Package was on host before the run, same manager + scope | Probe sees it → no ledger entry → cleanup leaves it. |
+| Package was on host via a *different* manager (e.g. choco-installed 7zip vs winget bucket) | Each manager only sees its own database. Cleanup uninstalls only what *our* manager installed, against its own database. The other manager's copy is untouched. |
+| Package installed at a different scope than what the bundle requested | Probe is scope-scoped; cleanup uninstalls only at the scope we recorded. |
+
+**Why CI does not pass `-Cleanup`.** The workflow's subsequent steps
+("Apply post-install hooks", "CLI availability discovery", "CLI
+availability — pinned contract") all read from the installs left by
+Test-Installs.ps1. Uninstalling between them would break the contract
+checks. Runners are ephemeral so no state leaks anyway. `-Cleanup` is
+a dev-box convenience, not a CI invariant.
+
+Light unit coverage lives in
+`.github/scripts/Test-InstallsCleanup.Tests.ps1`.
+


### PR DESCRIPTION
Closes Part B + D of #62 (Parts A + C shipped in #163 and #164).

## What

Heavy `Test-Installs.ps1` gets an opt-in `-Cleanup` switch that uninstalls — at end-of-run — only the packages **this run actually added**. Pre-existing user state on the dev box is never touched.

## Design

- **Pre-install probe** per manager (`winget list --scope`, `choco list --local-only`, scoop apps dir presence, `Get-Module -ListAvailable`). If the package was already on the host, the install still proceeds (idempotent) but is **not** ledgered.
- **Install ledger** persisted to JSON at `$env:TEMP\ScoopBucket-Cleanup-Ledger.json` (overridable via `-LedgerPath`). winget rows include scope so uninstall matches the same `--scope`.
- **End-of-run uninstall** runs inside `finally` so it fires on cancellation too. Failures warn, never throw.
- **Crash recovery:** a stale ledger from a previously aborted `-Cleanup` run is replayed *before* discovery, so the next run starts clean.

### Already-installed semantics (the three cases from review)

| Case | Behavior |
|---|---|
| Same manager + same scope | Probe sees it → no ledger entry → cleanup leaves it. |
| Different manager (choco vs winget) | Each manager only sees its own DB; we only uninstall via the manager that produced the ledger row. |
| Different scope | Ledger records scope; uninstall passes the same `--scope`. |

## Why CI does not pass `-Cleanup`

Subsequent workflow steps (post-install hooks, CLI availability discovery, the pinned CLI contract) all depend on installs persisting through the job. Runners are ephemeral so nothing leaks. Inline comment in `validate-installs.yml` documents the decision.

## Tests

`.github/scripts/Test-InstallsCleanup.Tests.ps1` (10 Light cases):
- Ledger CRUD + Clear
- `Invoke-CleanupLedger` dispatch + scope propagation
- Pre-install probe true/false branches

Existing `Test-Installs.Tests.ps1` shows the same 65 pass / 17 pre-existing local-only failures on this branch as on `main` — no regression.

## README

New "Heavy validate-installs — local cleanup (`-Cleanup`)" subsection documents the switch, ledger semantics, already-installed cases, and the CI exception.