### PR TITLE
ci: auto-retry validate-installs on hosted-runner outage

### DIFF
--- a/.github/workflows/retry-validate-installs.yml
+++ b/.github/workflows/retry-validate-installs.yml
@@ -1,0 +1,94 @@
+name: Retry validate-installs on runner outage
+
+# When the Validate Package Installs workflow fails because the hosted
+# runner lost communication with the GitHub Actions service (an infra
+# outage, not a code defect), automatically re-run the failed jobs.
+# Real install failures are left alone -- they need human triage.
+#
+# Detection signature (observed in runs 25970594547 and 25974110501,
+# both died at exactly 46:00 in step "Run install validation"):
+#   - The failed job's failing step is frozen at
+#       status: "in_progress", conclusion: null
+#   - All subsequent steps remain status: "pending" (never started)
+# That combination is impossible for a step that exited normally: the
+# runner died before it could report the step result. Real install
+# failures, in contrast, complete the validation step (status:
+# "completed", conclusion: "failure") and then proceed through the
+# remaining steps (artifact upload, issue filing, etc.) before the job
+# is marked failed.
+#
+# Capped at run_attempt < 3 so a persistently-broken main branch can't
+# enter an infinite rerun loop.
+
+on:
+  workflow_run:
+    workflows: ["Validate Package Installs"]
+    types: [completed]
+
+permissions:
+  actions: write
+  contents: read
+
+jobs:
+  retry-on-infra-outage:
+    if: >-
+      github.event.workflow_run.conclusion == 'failure' &&
+      github.event.workflow_run.run_attempt < 3
+    runs-on: ubuntu-latest
+    steps:
+      - name: Decide whether to retry
+        id: decide
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          RUN_ID: ${{ github.event.workflow_run.id }}
+          RUN_ATTEMPT: ${{ github.event.workflow_run.run_attempt }}
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          echo "Inspecting failed run $RUN_ID (attempt $RUN_ATTEMPT)..."
+
+          # Per-attempt jobs endpoint preserves the original timeline even
+          # after later reruns overwrite the run-level view.
+          jobs_json=$(gh api "repos/$REPO/actions/runs/$RUN_ID/attempts/$RUN_ATTEMPT/jobs" --paginate)
+
+          # An in-progress step with no conclusion on a failed job means
+          # the runner died mid-step. Real failures complete the step
+          # (conclusion=failure) before the job is marked failed.
+          abandoned=$(echo "$jobs_json" | jq '
+            [ .jobs[]
+              | select(.conclusion == "failure")
+              | .steps[]?
+              | select(.status == "in_progress" and .conclusion == null)
+            ] | length
+          ')
+
+          echo "abandoned (in_progress, conclusion=null) steps on failed jobs: $abandoned"
+
+          if [ "$abandoned" -gt 0 ]; then
+            echo "::notice::Hosted-runner outage signature detected. Will rerun failed jobs."
+            echo "$jobs_json" | jq -r '
+              .jobs[]
+              | select(.conclusion == "failure")
+              | "job: \(.name)\n" + (
+                  [ .steps[]? | select(.status == "in_progress" and .conclusion == null) | "  abandoned step #\(.number): \(.name)" ]
+                  | join("\n")
+                )
+            '
+            echo "retry=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "::notice::No abandoned in-progress steps found. Treating as a real failure; not retrying."
+            echo "retry=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Rerun failed jobs
+        if: steps.decide.outputs.retry == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          RUN_ID: ${{ github.event.workflow_run.id }}
+        shell: bash
+        run: |
+          echo "Requesting rerun of failed jobs for run $RUN_ID..."
+          gh run rerun "$RUN_ID" --failed --repo "$REPO"


### PR DESCRIPTION
Adds a small companion workflow that automatically re-runs **Validate Package Installs** when its failure is caused by a hosted-runner outage (e.g. _"The hosted runner lost communication with the server"_), not by a real package install regression.

## Why

We just saw two infra-class deaths of validate-installs on the same day  both at exactly the 46-minute mark, both leaving no artifacts and no actionable diagnostics. `gh run rerun --failed` recovered both on the next attempt. Automating that recovery removes a human round-trip and keeps main green.

## Detection signature

For each failed job in the failed attempt, the new workflow queries:

```
GET /repos/{owner}/{repo}/actions/runs/{run_id}/attempts/{run_attempt}/jobs
```

and looks for any step whose state is `status: in_progress, conclusion: null`. That's the runner-eviction fingerprint  the runner died mid-step before it could record a conclusion. Real install failures always _complete_ the validation step (`status: completed, conclusion: failure`) before the job fails, so they don't match.

Verified the predicate locally against the real outage in run [25974110501](https://github.com/MarkMichaelis/ScoopBucket/actions/runs/25974110501): the jq returned `1` (one abandoned step  would retry). A normal success run returns `0`.

## Guardrails

- Trigger: `workflow_run: types: [completed]`, gated on `conclusion == 'failure'`.
- Hard cap at `run_attempt < 3` (so a persistently broken main can't loop).
- Uses `secrets.GITHUB_TOKEN` with `actions: write` only; no PAT.
- Calls `gh run rerun --failed`, so passing jobs (verify-versions) aren't re-charged.

## Testing

- `python -c "import yaml; yaml.safe_load(open(...))"`  parses clean.
- Dry-run of the detection jq against run 25974110501 attempt 1 (the real outage) returns `1`  retry path.
- No local Pester impact (this only adds a workflow file).

Will be exercised for real the next time a hosted runner dies; if you want to force a test, manually fail a step before the install loop completes and observe the watchdog rerun.