### PR TITLE
chore: sync IntelliSDLC.ai content

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,23 @@
+# Ephemeral evidence-capture working directory (see .github/skills/evidence-capture/SKILL.md).
+.evidence/
+
+# Playwright MCP server output directory (per repo conventions).
+.playwright-mcp/
+
+# OS/editor cruft.
+.DS_Store
+Thumbs.db
+*.swp
+*~
+
+# Git worktrees managed by Cleanup-Worktree.ps1.
+.worktrees/
+
+# Dogfood / dry-run artifacts (see scripts/run-dogfood.ps1 and
+# docs/dogfood/tripit-dry-run-report.md). Real HAR captures contain auth
+# cookies and request URLs that can leak account info even after PII scrubbing
+# -- never commit them. The dogfood-output directory is the default -Out
+# location when -Out is not passed and TEMP is unsuitable.
+Samples/HAR-Original/
+.dogfood-output/
+testResults.xml

--- a/.sdlc-ai-sync.json
+++ b/.sdlc-ai-sync.json
@@ -1,6 +1,6 @@
 {
   "remote": "sdlc.ai",
   "ref": "main",
-  "lastSyncCommit": "cdde27a7c9463ccd1904aa65446de63e8ecf57b3",
-  "syncedAt": "2026-05-17T04:27:54Z"
+  "lastSyncCommit": "168b59f519b82e6858eae6ffb7bbc15e9241c7ab",
+  "syncedAt": "2026-05-18T04:31:13Z"
 }


### PR DESCRIPTION
Automated sync from upstream IntelliSDLC.ai. See commit log for replayed ops.

Generated by Pull-SDLC.ai.ps1 auto-worktree mode.