### PR TITLE
feat(completion): repair native-mode blocks in Update-PackageCompletion

### DIFF
--- a/README.md
+++ b/README.md
@@ -295,6 +295,26 @@ Import-Module D:\Git\ScoopBucket\module\MarkMichaelis.ScoopBucket\MarkMichaelis.
 Invoke-CliCompletionsSweep -Force
 ```
 
+To repair completion blocks for CLIs whose owning bundles are already
+installed -- for example after restoring a dev machine where the
+`AllUsersAllHosts` profile wasn't backed up, or after installing
+`PSCompletions` *after* the CLIs it covers -- use the declarative-bundle
+walker `Update-PackageCompletion`. It scans every declarative `[Package]`
+across the bucket, finds CLIs on `PATH` with no sentinel block in the
+profile, and registers them. Native, `PSCompletions`, and `auto`
+completion modes are all repaired:
+
+```powershell
+Import-Module MarkMichaelis.ScoopBucket -Force
+Update-PackageCompletion          # gap-fill: register only missing blocks
+Update-PackageCompletion -Force   # refresh every eligible block
+Update-PackageCompletion -WhatIf  # preview what would change
+```
+
+Native repairs reuse the `NativeCommandOutputs` text captured by
+`Get-BundlePackages` in its child runspace, so no re-install or live
+`<cli> completion powershell` call is needed.
+
 Behavior:
 
 - Each CLI is resolved in order: caller-supplied `-NativeCommand`

--- a/bucket/UpdatePackageCompletion.Tests.ps1
+++ b/bucket/UpdatePackageCompletion.Tests.ps1
@@ -63,7 +63,15 @@ if (Test-Path `$scoopBucketPsd1) { Import-Module `$scoopBucketPsd1 -Force } else
         Id                  = 'Test.AutoWithNative'
         CliCommands         = @('$($script:onPathCli)-native')
         Completion          = 'auto'
-        NativeCommandScript = { 'completion-source' }
+        NativeCommandScript = { 'auto-native-completion-source' }
+    }
+    [Package]@{
+        Name                = 'NativeOnly'
+        Installer           = 'winget'
+        Id                  = 'Test.NativeOnly'
+        CliCommands         = @('$($script:onPathCli)-nativeonly')
+        Completion          = 'native'
+        NativeCommandScript = { 'pure-native-completion-source' }
     }
     [Package]@{
         Name        = 'NoneMode'
@@ -88,7 +96,7 @@ Invoke-PackageInstall -Packages `$Packages -Bundle 'UpdateCompletionBundle'
     # of this Describe block.
     $script:shimDir = Join-Path $script:tmpBucket '_shims'
     New-Item -ItemType Directory -Path $script:shimDir | Out-Null
-    foreach ($shimName in @("$($script:onPathCli)-twin.ps1", "$($script:onPathCli)-native.ps1", "$($script:onPathCli)-none.ps1")) {
+    foreach ($shimName in @("$($script:onPathCli)-twin.ps1", "$($script:onPathCli)-native.ps1", "$($script:onPathCli)-nativeonly.ps1", "$($script:onPathCli)-none.ps1")) {
         Set-Content -Path (Join-Path $script:shimDir $shimName) -Value '# stub' -Encoding UTF8
     }
     $script:savedPath = $env:PATH
@@ -119,13 +127,39 @@ Describe 'Update-PackageCompletion eligibility classification' -Tag 'Light' {
         $offPath.Reason | Should -Match 'not on PATH'
     }
 
-    It "skips Completion='auto' packages with a NativeCommandScript" {
+    It "registers Completion='auto' packages with a NativeCommandScript using pre-captured native output" {
+        # Regression for #170: previously skipped with reason 'native scriptblock'.
+        # Get-BundlePackages pre-captures the NativeCommandScript output
+        # into NativeCommandOutputs[$cli], so we can now write a native
+        # block during a profile-repair walk without re-running the
+        # original installer.
         $results = Update-PackageCompletion -BucketPath $script:tmpBucket `
-            -ProfilePath $script:profilePath -WhatIf
+            -ProfilePath $script:profilePath
         $native = $results | Where-Object Cli -EQ "$($script:onPathCli)-native"
         $native | Should -Not -BeNullOrEmpty
-        $native.Action | Should -Be 'Skipped'
-        $native.Reason | Should -Match 'native scriptblock'
+        $native.Action | Should -Be 'Registered'
+        $native.Source | Should -Be 'Native'
+        $native.Mode   | Should -Be 'native'
+
+        # The block written to the profile must contain the captured
+        # native completion source, wrapped in the standard
+        # Get-Command guard.
+        $profileContent = Get-Content -Raw -Encoding UTF8 $script:profilePath
+        $profileContent | Should -Match 'auto-native-completion-source'
+        $profileContent | Should -Match "ScoopBucket:CliCompletion:$($script:onPathCli)-native:BEGIN v1"
+    }
+
+    It "registers Completion='native' packages whose CLI is on PATH" {
+        $results = Update-PackageCompletion -BucketPath $script:tmpBucket `
+            -ProfilePath $script:profilePath
+        $nativeOnly = $results | Where-Object Cli -EQ "$($script:onPathCli)-nativeonly"
+        $nativeOnly | Should -Not -BeNullOrEmpty
+        $nativeOnly.Action | Should -Be 'Registered'
+        $nativeOnly.Source | Should -Be 'Native'
+        $nativeOnly.Mode   | Should -Be 'native'
+
+        $profileContent = Get-Content -Raw -Encoding UTF8 $script:profilePath
+        $profileContent | Should -Match 'pure-native-completion-source'
     }
 
     It "ignores Completion='none' and packages without CliCommands" {
@@ -135,7 +169,7 @@ Describe 'Update-PackageCompletion eligibility classification' -Tag 'Light' {
         ($results | Where-Object Package -EQ 'NoCliCommands')          | Should -BeNullOrEmpty
     }
 
-    It 'reports WhatIf for eligible CLIs (pscompletions + auto-no-native) when -WhatIf supplied' {
+    It 'reports WhatIf for eligible CLIs (pscompletions + auto-no-native + native) when -WhatIf supplied' {
         $results = Update-PackageCompletion -BucketPath $script:tmpBucket `
             -ProfilePath $script:profilePath -WhatIf
         $bw = $results | Where-Object Cli -EQ $script:onPathCli
@@ -149,6 +183,17 @@ Describe 'Update-PackageCompletion eligibility classification' -Tag 'Light' {
         # auto-mode without NativeCommandScript collapses to pscompletions
         # because that's the only registration path we can safely repair.
         $twin.Mode | Should -Be 'pscompletions'
+
+        # auto-mode WITH a NativeCommandScript now repairs via native too.
+        $autoNative = $results | Where-Object Cli -EQ "$($script:onPathCli)-native"
+        $autoNative | Should -Not -BeNullOrEmpty
+        $autoNative.Action | Should -Be 'WhatIf'
+        $autoNative.Mode   | Should -Be 'native'
+
+        $nativeOnly = $results | Where-Object Cli -EQ "$($script:onPathCli)-nativeonly"
+        $nativeOnly | Should -Not -BeNullOrEmpty
+        $nativeOnly.Action | Should -Be 'WhatIf'
+        $nativeOnly.Mode   | Should -Be 'native'
     }
 
     It "preserves existing sentinel blocks unless -Force is passed" {

--- a/module/MarkMichaelis.ScoopBucket/Public/Update-PackageCompletion.ps1
+++ b/module/MarkMichaelis.ScoopBucket/Public/Update-PackageCompletion.ps1
@@ -2,26 +2,36 @@ function Update-PackageCompletion {
     <#
     .SYNOPSIS
         Repair / refresh tab-completion sentinel blocks for every
-        Package in the bucket whose CliCommand is on PATH and whose
-        Completion mode requests PSCompletions-backed completion.
+        Package in the bucket whose CliCommand is on PATH but has no
+        block in $PROFILE.AllUsersAllHosts.
 
     .DESCRIPTION
-        Solves the "I installed Bitwarden CLI, then installed
-        PSCompletions, but `bw <Tab>` still only completes files"
-        scenario.
+        Solves two related "I have the CLI installed but `<cli> <Tab>`
+        only completes file names" scenarios:
 
-        The cause: when the CLI was originally installed, PSCompletions
-        was missing, so Register-PackageCompletion fell through to its
-        'Skipped' branch and never wrote a sentinel block. Installing
-        PSCompletions afterwards doesn't retroactively re-register the
-        already-installed CLIs.
+          (1) "I installed Bitwarden CLI, then installed PSCompletions,
+              but `bw <Tab>` still only completes files." Originally
+              Register-PackageCompletion fell through to its 'Skipped'
+              branch because PSCompletions wasn't there yet.
+
+          (2) "I restored my dev machine — the CLIs are back on PATH but
+              $PROFILE.AllUsersAllHosts was not part of the backup, so
+              no sentinel blocks exist." For native-completion CLIs
+              (`gh`, `rg`, …) this used to require running the original
+              Install-Package per bundle.
 
         Update-PackageCompletion walks every declarative bundle via
         Get-BundlePackages, finds Packages whose Completion mode is
-        'pscompletions' (or 'auto' without a NativeCommandScript) and
-        whose CliCommands resolve via Get-Command, then calls
-        Register-PackageCompletion for each. Existing sentinel blocks
-        are preserved unless -Force is passed.
+        'pscompletions', 'native', or 'auto' (with or without a
+        NativeCommandScript), confirms each CliCommand resolves via
+        Get-Command, and calls Register-PackageCompletion when no block
+        exists in the profile. Existing sentinel blocks are preserved
+        unless -Force is passed.
+
+        Native-mode repairs use the NativeCommandOutputs hashtable that
+        Get-BundlePackages pre-captures in its child runspace — so the
+        repair walks need no access to the original `<cli> completion
+        powershell` command and no re-install.
 
         Called automatically by the PSCompletions bundle's
         PostInstallScript so `Install-Package PSCompletions` heals
@@ -78,24 +88,19 @@ function Update-PackageCompletion {
             if (-not $p.CliCommands -or $p.CliCommands.Count -eq 0) { continue }
             $mode = "$($p.Completion)"
             if ([string]::IsNullOrWhiteSpace($mode)) { $mode = 'auto' }
-            if ($mode -notin @('pscompletions','auto')) { continue }
+            if ($mode -notin @('pscompletions','auto','native')) { continue }
 
-            # 'auto' with a native scriptblock is best-handled by the
-            # original install path which has the actual native command.
-            # We can only safely repair pscompletions-mode CLIs here.
+            # Decide the effective registration mode per package:
+            #   - 'native' or 'auto' + NativeCommandScript -> native (rebuild
+            #     the block from NativeCommandOutputs, the text the bundle
+            #     loader captured at $Packages-export time).
+            #   - 'auto' without a NativeCommandScript     -> pscompletions
+            #     (only safe repair path when no native source exists).
+            #   - 'pscompletions'                           -> pscompletions.
+            $hasNative = [bool]$p.HasNativeCommandScript -or [bool]$p.NativeCommandScript
             $effectiveMode = $mode
             if ($mode -eq 'auto') {
-                if ($p.HasNativeCommandScript) {
-                    foreach ($cli in $p.CliCommands) {
-                        $results.Add([pscustomobject]@{
-                            Cli = $cli; Package = $p.Name; Bundle = $b.Bundle
-                            Mode = $mode; Action = 'Skipped'; Source = 'Skipped'
-                            Reason = "Package declares Completion='auto' with a native scriptblock; re-run Install-Package to refresh native completion."
-                        })
-                    }
-                    continue
-                }
-                $effectiveMode = 'pscompletions'
+                $effectiveMode = if ($hasNative) { 'native' } else { 'pscompletions' }
             }
 
             foreach ($cli in $p.CliCommands) {
@@ -119,7 +124,44 @@ function Update-PackageCompletion {
                     continue
                 }
 
-                $action = "Register PSCompletions block for '$cli'"
+                # When the package was loaded via Get-BundlePackages
+                # (PSCustomObject path) the live NativeCommandScript
+                # was stripped by JSON serialization, but its pre-invoked
+                # output is preserved in NativeCommandOutputs[$cli].
+                # Synthesize a scriptblock that re-emits that text so
+                # Register-PackageCompletion's resolver can wrap it in
+                # the standard Get-Command guard. For real in-memory
+                # [Package] callers we just forward the live scriptblock.
+                $nativeArg = $null
+                if ($effectiveMode -eq 'native') {
+                    if ($p.NativeCommandScript -is [scriptblock]) {
+                        $nativeArg = $p.NativeCommandScript
+                    } else {
+                        $preCaptured = $null
+                        $no = $p.NativeCommandOutputs
+                        if ($no) {
+                            if ($no -is [hashtable] -and $no.ContainsKey($cli)) {
+                                $preCaptured = [string]$no[$cli]
+                            } elseif ($no.PSObject -and ($no.PSObject.Properties.Name -contains $cli)) {
+                                $preCaptured = [string]$no.$cli
+                            }
+                        }
+                        if ($preCaptured -and $preCaptured.Trim()) {
+                            $literal = $preCaptured.Replace("'","''")
+                            $nativeArg = [scriptblock]::Create("'$literal'")
+                        }
+                    }
+                    if (-not $nativeArg) {
+                        $results.Add([pscustomobject]@{
+                            Cli = $cli; Package = $p.Name; Bundle = $b.Bundle
+                            Mode = $effectiveMode; Action = 'Skipped'; Source = 'Skipped'
+                            Reason = "No pre-captured native completion source for '$cli' (NativeCommandOutputs empty); re-run Install-Package to refresh."
+                        })
+                        continue
+                    }
+                }
+
+                $action = "Register $effectiveMode completion block for '$cli'"
                 if (-not $PSCmdlet.ShouldProcess($profileTarget, $action)) {
                     $results.Add([pscustomobject]@{
                         Cli = $cli; Package = $p.Name; Bundle = $b.Bundle
@@ -133,6 +175,7 @@ function Update-PackageCompletion {
                     Cli   = $cli
                     Mode  = $effectiveMode
                 }
+                if ($nativeArg) { $registerArgs['NativeCommand'] = $nativeArg }
                 if ($ProfilePath) { $registerArgs['ProfilePath'] = $ProfilePath }
 
                 try {


### PR DESCRIPTION
## Summary

Extend Update-PackageCompletion to repair **native-mode** completion blocks too, not just  pscompletions.

Previously the cmdlet explicitly skipped packages whose `Completion` mode is `native` (or `auto` + `NativeCommandScript`), telling users to re-run `Install-Package` per bundle. Since #133 `Get-BundlePackages` pre-captures each `NativeCommandScript`'s output into `NativeCommandOutputs[$cli]` in its child runspace -- that text **is** the `Register-ArgumentCompleter` source we'd write into the profile. We can now rebuild the block from the captured text with no re-install.

## What changed

- `Update-PackageCompletion` now classifies packages into three effective modes per CLI:
  - `native`        -- block built from `NativeCommandOutputs[$cli]` (or live `NativeCommandScript` for in-memory `[Package]` callers)
  - `pscompletions` -- existing PSCompletions catalog probe (unchanged)
  - `auto`          -- `native` when the package has a `NativeCommandScript`, else `pscompletions`
- Tests: regression tests added for both `Completion='native'` and `Completion='auto' + NativeCommandScript` repair paths; existing ""skip"" expectations updated to ""Registered"".
- README: documents the broadened scope, with example invocations.

## Scenario this closes

Restoring a dev machine where `AllUsersAllHosts` wasn't backed up: a single `Update-PackageCompletion` walk now repairs every CLI on PATH regardless of completion mode.

Closes #170

## Test

```powershell
Invoke-Pester -Path .\bucket\UpdatePackageCompletion.Tests.ps1 -Output Detailed
Invoke-Pester -Path .\bucket -Tag Light
```

Light suite locally: 905 passed, 0 failed.