### PR TITLE
feat(sysinternals): add autorunsc CLI to curated completion list

### DIFF
--- a/bucket/OSBasePackages.json
+++ b/bucket/OSBasePackages.json
@@ -1,6 +1,6 @@
 {
     "$schema": "https://raw.githubusercontent.com/lukesampson/scoop/master/schema.json",
-    "version": "1.23.000",
+    "version": "1.24.000",
     "url": [
         "https://raw.githubusercontent.com/MarkMichaelis/ScoopBucket/master/bucket/OSBasePackages.ps1"
     ],

--- a/bucket/OSBasePackages.ps1
+++ b/bucket/OSBasePackages.ps1
@@ -182,7 +182,7 @@ Register-ArgumentCompleter -Native -CommandName code -ScriptBlock {
         # tab-completion is registered for them. The full set is still on
         # PATH via scoop's shims; users who want completion for additional
         # tools can extend this list.
-        CliCommands = @('handle64','procexp64','autoruns','accesschk','psexec','pslist','sigcheck','procdump','tcpview')
+        CliCommands = @('handle64','procexp64','autoruns','autorunsc','accesschk','psexec','pslist','sigcheck','procdump','tcpview')
         Completion  = 'native'
         # Sysinternals tools share a small, stable set of universal flags
         # (Win32 conventions: both slash- and dash-prefixed). No upstream
@@ -207,6 +207,7 @@ Register-ArgumentCompleter -Native -CommandName $Cli -ScriptBlock {
             handle64   = @('/?','/accepteula','/nobanner')
             procexp64  = @('/?','/accepteula','/nobanner')
             autoruns   = @('/?','/accepteula','/nobanner')
+            autorunsc  = @('/?','/accepteula','/nobanner')
             accesschk  = @('/?','/accepteula','/nobanner')
             psexec     = @('/?','/accepteula','/nobanner')
             pslist     = @('/?','/accepteula','/nobanner')


### PR DESCRIPTION
## Summary

Adds `autorunsc` (the CLI counterpart of `autoruns`) to the curated `Sysinternals Suite` completion list in `bucket/OSBasePackages.ps1`. `extras/sysinternals` already shims it automatically, so this is a metadata-only change: it gains the same universal Sysinternals flag tab completion (`/?`, `/accepteula`, `/nobanner`, ...) the other tools receive.

## Changes

- `bucket/OSBasePackages.ps1`: append `autorunsc` to `CliCommands` and `ExpectedCompletions`.
- `bucket/OSBasePackages.json`: version `1.23.000` -> `1.24.000`.

## Out of scope

- `handle64` / `procexp64` naming: user previously confirmed 64-bit preference.
- Dropping GUI entries (`autoruns`, `procexp64`, `tcpview`): they still accept universal Sysinternals flags (`/accepteula` etc.), so completion remains valuable.

## Tests

Full Light suite locally: **917 passed, 0 failed, 3 skipped**. The generic Bundles invariants automatically validate the new CLI's completion block.

Closes #175
