### PR TITLE
feat(sysinternals): use unsuffixed handle/procexp names

### DIFF
--- a/bucket/OSBasePackages.json
+++ b/bucket/OSBasePackages.json
@@ -1,6 +1,6 @@
 {
     "$schema": "https://raw.githubusercontent.com/lukesampson/scoop/master/schema.json",
-    "version": "1.24.000",
+    "version": "1.25.000",
     "url": [
         "https://raw.githubusercontent.com/MarkMichaelis/ScoopBucket/master/bucket/OSBasePackages.ps1"
     ],

--- a/bucket/OSBasePackages.ps1
+++ b/bucket/OSBasePackages.ps1
@@ -182,7 +182,7 @@ Register-ArgumentCompleter -Native -CommandName code -ScriptBlock {
         # tab-completion is registered for them. The full set is still on
         # PATH via scoop's shims; users who want completion for additional
         # tools can extend this list.
-        CliCommands = @('handle64','procexp64','autoruns','autorunsc','accesschk','psexec','pslist','sigcheck','procdump','tcpview')
+        CliCommands = @('handle','procexp','autoruns','autorunsc','accesschk','psexec','pslist','sigcheck','procdump','tcpview')
         Completion  = 'native'
         # Sysinternals tools share a small, stable set of universal flags
         # (Win32 conventions: both slash- and dash-prefixed). No upstream
@@ -204,8 +204,8 @@ Register-ArgumentCompleter -Native -CommandName $Cli -ScriptBlock {
 "@
         }
         ExpectedCompletions = @{
-            handle64   = @('/?','/accepteula','/nobanner')
-            procexp64  = @('/?','/accepteula','/nobanner')
+            handle     = @('/?','/accepteula','/nobanner')
+            procexp    = @('/?','/accepteula','/nobanner')
             autoruns   = @('/?','/accepteula','/nobanner')
             autorunsc  = @('/?','/accepteula','/nobanner')
             accesschk  = @('/?','/accepteula','/nobanner')


### PR DESCRIPTION
## Summary

Switch the curated Sysinternals completion list to the unsuffixed names per user clarification.

`handle.exe` and `procexp.exe` are the 32-bit launchers that detect architecture and auto-relaunch as their `*64.exe` counterpart on x64 systems. Both binaries accept the **identical** universal Sysinternals flag set (`/?`, `/accepteula`, `/nobanner`, ...) -- the suffixed and unsuffixed shims are functionally interchangeable from a CLI perspective.

Using the unsuffixed names matches what Sysinternals documentation and muscle memory expect.

## Changes

- `bucket/OSBasePackages.ps1`: `handle64` -> `handle`, `procexp64` -> `procexp` in `CliCommands` and `ExpectedCompletions`.
- `bucket/OSBasePackages.json`: version `1.24.000` -> `1.25.000`.

Pure metadata change. `extras/sysinternals` shims both names automatically, so no install behavior changes.

## Tests

Full Light suite locally: **917 passed, 0 failed, 3 skipped**. The `CliAvailabilityPinned.Tests.ps1` `Sysinternals suite` context already tests `procexp` and `handle` resolution (unchanged).

Closes #177
