### PR TITLE
feat(completions): bucket-scoped Register-AllCliCompletions + psc-handler rollback (#179, #180)

### DIFF
--- a/README.md
+++ b/README.md
@@ -286,13 +286,62 @@ Bundles that install many CLIs (`AIAgents`, `ClientBasePackages`,
 `DeveloperBasePackages`) additionally call `Invoke-CliCompletionsSweep
 -Force` at the end of their install, which (a) ensures the
 [`PSCompletions`](https://github.com/abgox/PSCompletions) module is
-installed and (b) registers a PSCompletions-fallback block for any CLI
-on `PATH` whose owning bundle didn't supply a native command. To
-re-run the sweep manually after installing other tools by hand:
+installed and (b) registers a PSCompletions-fallback block for every
+CLI declared by a bucket package whose owning bundle didn't supply a
+native command. To re-run the sweep manually after installing other
+tools by hand:
 
 ```powershell
 Import-Module D:\Git\ScoopBucket\module\MarkMichaelis.ScoopBucket\MarkMichaelis.ScoopBucket.psd1 -Force
 Invoke-CliCompletionsSweep -Force
+```
+
+By default the sweep is **bucket-scoped**: it registers completions only
+for CLIs declared in bucket package manifests (the union of `CliCommands`
+across every `[Package]` returned by `Get-Package` whose `Completion`
+field is not `'none'`). To opt into the legacy behavior of registering
+completions for every executable on `PATH`, pass `-IncludeAllPath`:
+
+```powershell
+Register-AllCliCompletions -IncludeAllPath
+```
+
+`-Names <cli1>,<cli2>` overrides scope entirely.
+
+### Recovering from a broken completion block
+
+`PSCompletions` is third-party content and has occasionally shipped
+completions whose PSReadLine key handler references a property that
+doesn't exist on the object PSReadLine actually passes — the symptom
+is every Tab press emitting:
+
+```
+An exception occurred in custom key handler, see $error for more
+information: The property 'buffer' cannot be found on this object.
+```
+
+`Register-CliCompletion` defends against this by re-invoking the
+freshly-added completion through `[CommandCompletion]::CompleteInput`
+in a fresh `pwsh -NoProfile` child runspace. If validation errors the
+add is rolled back with `psc remove <cli>` and the result row shows
+`Action='Failed'` with the underlying reason — no sentinel block is
+written.
+
+If a broken handler nonetheless lands in your shell, restore Tab
+behavior immediately with:
+
+```powershell
+Set-PSReadLineKeyHandler -Chord Tab -Function MenuComplete
+```
+
+Then surgically remove the offending sentinel block:
+
+```powershell
+$profile = $PROFILE.AllUsersAllHosts
+$pattern = '(?ms)^\# ScoopBucket:CliCompletion:<CLI>:BEGIN \w+.*?^\# ScoopBucket:CliCompletion:<CLI>:END\r?\n?'
+$text = Get-Content $profile -Raw
+[System.IO.File]::WriteAllText($profile, ($text -replace $pattern, ''))
+psc remove <CLI>
 ```
 
 To repair completion blocks for CLIs whose owning bundles are already

--- a/bucket/RegisterAllCliCompletionsScope.Tests.ps1
+++ b/bucket/RegisterAllCliCompletionsScope.Tests.ps1
@@ -1,0 +1,92 @@
+# ----------------------------------------------------------------------------
+# Issue #180: Register-AllCliCompletions must default to bucket-declared CLIs
+# (the union of CliCommands across packages whose Completion != 'none'),
+# NOT every executable on PATH. Power users opt into the legacy PATH sweep
+# via -IncludeAllPath.
+# ----------------------------------------------------------------------------
+
+Describe 'Register-AllCliCompletions default scope' -Tag 'Light','BucketScope' {
+
+    BeforeAll {
+        $scoopBucketPsd1 = Join-Path $PSScriptRoot '..\module\MarkMichaelis.ScoopBucket\MarkMichaelis.ScoopBucket.psd1'
+        if (Test-Path $scoopBucketPsd1) { Import-Module $scoopBucketPsd1 -Force }
+        else { Import-Module MarkMichaelis.ScoopBucket -Force }
+
+        $script:sandbox = Join-Path ([System.IO.Path]::GetTempPath()) ("RACLI-" + [guid]::NewGuid().ToString('N'))
+        New-Item -ItemType Directory -Path $script:sandbox -Force | Out-Null
+        $script:profilePath = Join-Path $script:sandbox 'Profile.ps1'
+
+        # Fake bucket inventory: two registrable CLIs, one explicitly opted out.
+        $script:fakePackages = @(
+            [pscustomobject]@{ Name = 'tool-a'; CliCommands = @('aaa','aab'); Completion = 'auto' }
+            [pscustomobject]@{ Name = 'tool-b'; CliCommands = @('bbb');       Completion = 'native' }
+            [pscustomobject]@{ Name = 'tool-c'; CliCommands = @('ccc');       Completion = 'none' }
+        )
+    }
+
+    AfterAll {
+        if (Test-Path $script:sandbox) {
+            Remove-Item -Path $script:sandbox -Recurse -Force -ErrorAction SilentlyContinue
+        }
+    }
+
+    It 'defaults to the union of bucket CliCommands and skips Completion=none' {
+        $registered = New-Object System.Collections.Generic.List[string]
+        Mock -ModuleName MarkMichaelis.ScoopBucket Get-Package { $script:fakePackages }
+        Mock -ModuleName MarkMichaelis.ScoopBucket Register-CliCompletion {
+            param($Cli)
+            $registered.Add($Cli)
+            [pscustomobject]@{ Cli = $Cli; Source = 'Test'; Action = 'Added'; ProfilePath = $ProfilePath; Reason = $null }
+        }
+
+        Register-AllCliCompletions -ProfilePath $script:profilePath -Confirm:$false | Out-Null
+
+        ($registered | Sort-Object) -join ',' | Should -Be 'aaa,aab,bbb'
+    }
+
+    It '-IncludeAllPath bypasses the bucket discovery (registers >0 PATH binaries)' {
+        $script:invokeCount = 0
+        $script:getPackageCalled = $false
+        Mock -ModuleName MarkMichaelis.ScoopBucket Get-Package {
+            $script:getPackageCalled = $true
+            @()
+        }
+        Mock -ModuleName MarkMichaelis.ScoopBucket Register-CliCompletion {
+            $script:invokeCount++
+            [pscustomobject]@{ Cli = $Cli; Source = 'Test'; Action = 'Added'; ProfilePath = $ProfilePath; Reason = $null }
+        }
+
+        Register-AllCliCompletions -IncludeAllPath -ProfilePath $script:profilePath -Confirm:$false | Out-Null
+
+        $script:invokeCount | Should -BeGreaterThan 0
+        $script:getPackageCalled | Should -Be $false
+    }
+
+    It '-Names overrides scope and skips both bucket discovery and PATH sweep' {
+        $registered = New-Object System.Collections.Generic.List[string]
+        Mock -ModuleName MarkMichaelis.ScoopBucket Get-Package {
+            throw 'Get-Package must not be called when -Names is supplied'
+        }
+        Mock -ModuleName MarkMichaelis.ScoopBucket Register-CliCompletion {
+            param($Cli)
+            $registered.Add($Cli)
+            [pscustomobject]@{ Cli = $Cli; Source = 'Test'; Action = 'Added'; ProfilePath = $ProfilePath; Reason = $null }
+        }
+
+        Register-AllCliCompletions -Names 'foo','bar' -ProfilePath $script:profilePath -Confirm:$false | Out-Null
+
+        ($registered | Sort-Object) -join ',' | Should -Be 'bar,foo'
+    }
+
+    It 'warns and returns empty when bucket discovery yields no CLIs' {
+        Mock -ModuleName MarkMichaelis.ScoopBucket Get-Package { @() }
+        Mock -ModuleName MarkMichaelis.ScoopBucket Register-CliCompletion {
+            throw 'Register-CliCompletion should not be invoked when scope is empty'
+        }
+
+        $warnings = @()
+        $result = Register-AllCliCompletions -ProfilePath $script:profilePath -Confirm:$false -WarningVariable warnings -WarningAction SilentlyContinue
+        @($result).Count | Should -Be 0
+        ($warnings -join ' ') | Should -Match 'no bucket-declared CLIs'
+    }
+}

--- a/bucket/RegisterCliCompletionRollback.Tests.ps1
+++ b/bucket/RegisterCliCompletionRollback.Tests.ps1
@@ -1,0 +1,75 @@
+# ----------------------------------------------------------------------------
+# Issue #179: Register-CliCompletion must validate a freshly-added
+# PSCompletions handler in a child runspace. If validation fails (e.g. the
+# PSCompletions catalog entry registers a buggy PSReadLine key handler whose
+# scriptblock references a non-existent property and therefore breaks Tab
+# completion globally), Register-CliCompletion must:
+#   - call `psc remove <cli>` to undo the catalog change
+#   - return Action='Failed' with the reason
+#   - NOT write the sentinel block into the profile
+# ----------------------------------------------------------------------------
+
+Describe 'Register-CliCompletion PSCompletions validation + rollback' -Tag 'Light','PSCompletionsRollback' {
+
+    BeforeAll {
+        $scoopBucketPsd1 = Join-Path $PSScriptRoot '..\module\MarkMichaelis.ScoopBucket\MarkMichaelis.ScoopBucket.psd1'
+        if (Test-Path $scoopBucketPsd1) { Import-Module $scoopBucketPsd1 -Force }
+        else { Import-Module MarkMichaelis.ScoopBucket -Force }
+
+        $script:sandbox = Join-Path ([System.IO.Path]::GetTempPath()) ("RCC-rb-" + [guid]::NewGuid().ToString('N'))
+        New-Item -ItemType Directory -Path $script:sandbox -Force | Out-Null
+    }
+
+    AfterAll {
+        if (Test-Path $script:sandbox) {
+            Remove-Item -Path $script:sandbox -Recurse -Force -ErrorAction SilentlyContinue
+        }
+    }
+
+    It 'rolls back via psc remove and reports Action=Failed when validation fails' {
+        $profile = Join-Path $script:sandbox 'profile-fail.ps1'
+        $script:pscRemoveCalled = $false
+        $script:pscRemoveCli = $null
+
+        Mock -ModuleName MarkMichaelis.ScoopBucket Resolve-CliCompletionSource {
+            @{ Source = 'PSCompletions'; Code = '# stub'; PSCompletionsName = $Cli }
+        }
+        Mock -ModuleName MarkMichaelis.ScoopBucket Import-Module { }
+        Mock -ModuleName MarkMichaelis.ScoopBucket Invoke-PscAdd { }
+        Mock -ModuleName MarkMichaelis.ScoopBucket Invoke-PscRemove {
+            param($Cli)
+            $script:pscRemoveCalled = $true
+            $script:pscRemoveCli = $Cli
+        }
+        Mock -ModuleName MarkMichaelis.ScoopBucket Test-PSCompletionsHandler {
+            [pscustomobject]@{ Ok = $false; Reason = "The property 'buffer' cannot be found on this object." }
+        }
+
+        $result = Register-CliCompletion -Cli 'borkcli' -ProfilePath $profile -Confirm:$false -WarningAction SilentlyContinue
+        $result.Action      | Should -Be 'Failed'
+        $result.Source      | Should -Be 'PSCompletions'
+        $result.Reason      | Should -Match 'buffer'
+        $script:pscRemoveCalled | Should -Be $true
+        $script:pscRemoveCli    | Should -Be 'borkcli'
+        (Test-Path $profile)    | Should -Be $false
+    }
+
+    It 'writes the sentinel block when validation passes' {
+        $profile = Join-Path $script:sandbox 'profile-ok.ps1'
+
+        Mock -ModuleName MarkMichaelis.ScoopBucket Resolve-CliCompletionSource {
+            @{ Source = 'PSCompletions'; Code = '# stub OK'; PSCompletionsName = $Cli }
+        }
+        Mock -ModuleName MarkMichaelis.ScoopBucket Import-Module { }
+        Mock -ModuleName MarkMichaelis.ScoopBucket Invoke-PscAdd { }
+        Mock -ModuleName MarkMichaelis.ScoopBucket Invoke-PscRemove { }
+        Mock -ModuleName MarkMichaelis.ScoopBucket Test-PSCompletionsHandler {
+            [pscustomobject]@{ Ok = $true; Reason = $null }
+        }
+
+        $result = Register-CliCompletion -Cli 'goodcli' -ProfilePath $profile -Confirm:$false
+        $result.Action | Should -Be 'Added'
+        (Test-Path $profile) | Should -Be $true
+        (Get-Content $profile -Raw) | Should -Match 'ScoopBucket:CliCompletion:goodcli:BEGIN'
+    }
+}

--- a/module/MarkMichaelis.ScoopBucket/MarkMichaelis.ScoopBucket.psd1
+++ b/module/MarkMichaelis.ScoopBucket/MarkMichaelis.ScoopBucket.psd1
@@ -9,7 +9,7 @@
 #
 @{
     RootModule        = 'MarkMichaelis.ScoopBucket.psm1'
-    ModuleVersion     = '1.1.0'
+    ModuleVersion     = '1.2.0'
     GUID              = 'b7e8a4c2-9f3d-4b76-8e6a-1c5d2f7b9e10'
     Author            = 'Mark Michaelis'
     CompanyName       = 'IntelliTect'

--- a/module/MarkMichaelis.ScoopBucket/Private/Legacy.ps1
+++ b/module/MarkMichaelis.ScoopBucket/Private/Legacy.ps1
@@ -619,6 +619,83 @@ function Set-CompletionProfileBlock {
     return $newBlock
 }
 
+function Invoke-PscAdd {
+    [CmdletBinding()]
+    param([Parameter(Mandatory)][string]$Cli)
+    & psc add $Cli 2>$null | Out-Null
+}
+
+function Invoke-PscRemove {
+    [CmdletBinding()]
+    param([Parameter(Mandatory)][string]$Cli)
+    try { & psc remove $Cli 2>$null | Out-Null } catch { }
+}
+
+function Test-PSCompletionsHandler {
+    <#
+    .SYNOPSIS
+        Internal: validate that a freshly-added PSCompletions entry for
+        `$Cli` doesn't crash tab completion. Runs in a fresh pwsh
+        -NoProfile child runspace so it doesn't poison the caller's
+        session. Returns @{ Ok = $bool; Reason = <string> }.
+    .DESCRIPTION
+        Defensive guard for #179. PSCompletions is third-party content
+        and has historically shipped completions whose PSReadLine key
+        handler references properties that don't exist on the object
+        PSReadLine actually passes (e.g. lowercase `.buffer`). When
+        that happens the only feedback the user gets is a broken Tab
+        key in every shell after the next profile reload — extremely
+        difficult to diagnose. This probe attempts a synthetic
+        CommandCompletion against `<cli> ` and treats any error as a
+        validation failure so the caller can roll back.
+    #>
+    [OutputType([pscustomobject])]
+    [CmdletBinding()]
+    param([Parameter(Mandatory)][string]$Cli)
+
+    $pwsh = $null
+    try { $pwsh = (Get-Process -Id $PID).Path } catch { }
+    if (-not $pwsh) { $pwsh = 'pwsh' }
+
+    $probe = @"
+`$ErrorActionPreference = 'SilentlyContinue'
+try { Import-Module PSReadLine -Force -ErrorAction Stop } catch { }
+try { Import-Module PSCompletions -Force -ErrorAction Stop } catch {
+    Write-Output ('__SBVAL_ERR__' + `$_.Exception.Message); return
+}
+`$Error.Clear()
+try {
+    `$line = '$Cli '
+    [void][System.Management.Automation.CommandCompletion]::CompleteInput(`$line, `$line.Length, `$null)
+} catch {
+    Write-Output ('__SBVAL_ERR__' + `$_.Exception.Message); return
+}
+if (`$Error.Count) {
+    `$msgs = (`$Error | ForEach-Object { `$_.Exception.Message } | Select-Object -Unique) -join '; '
+    Write-Output ('__SBVAL_ERR__' + `$msgs); return
+}
+Write-Output '__SBVAL_OK__'
+"@
+
+    $safe = ($Cli -replace '[^A-Za-z0-9_.-]','_')
+    $tmp = Join-Path $env:TEMP "ScoopBucket-pscval-$safe-$PID.ps1"
+    try {
+        Set-Content -Path $tmp -Value $probe -Encoding UTF8 -WhatIf:$false
+        $out = & $pwsh -NoProfile -NonInteractive -ExecutionPolicy Bypass -File $tmp 2>$null | Out-String
+        if ($out -match '__SBVAL_ERR__(.+)') {
+            return [pscustomobject]@{ Ok = $false; Reason = $Matches[1].Trim() }
+        }
+        if ($out -match '__SBVAL_OK__') {
+            return [pscustomobject]@{ Ok = $true; Reason = $null }
+        }
+        return [pscustomobject]@{ Ok = $false; Reason = "PSCompletions validation produced no verdict for '$Cli'." }
+    } catch {
+        return [pscustomobject]@{ Ok = $false; Reason = $_.Exception.Message }
+    } finally {
+        Remove-Item -Path $tmp -ErrorAction Ignore
+    }
+}
+
 function Register-CliCompletion {
     <#
     .SYNOPSIS
@@ -674,9 +751,25 @@ function Register-CliCompletion {
         if ($PSCmdlet.ShouldProcess($Cli, $pscAction)) {
             try {
                 Import-Module PSCompletions -ErrorAction Stop
-                & psc add $Cli 2>$null | Out-Null
+                Invoke-PscAdd -Cli $Cli
             } catch {
                 Write-Warning "psc add $Cli failed: $($_.Exception.Message)"
+            }
+
+            # #179: validate the freshly-added PSCompletions handler in a
+            # child runspace. If CommandCompletion errors (e.g. the handler
+            # references a property the input object doesn't expose, as has
+            # happened with several PSCompletions catalog entries), roll
+            # the add back via `psc remove` and report Action=Failed instead
+            # of polluting the user's profile.
+            $validation = Test-PSCompletionsHandler -Cli $Cli
+            if (-not $validation.Ok) {
+                Write-Warning "Register-CliCompletion: PSCompletions handler for '$Cli' failed validation: $($validation.Reason). Rolling back."
+                Invoke-PscRemove -Cli $Cli
+                return [pscustomobject]@{
+                    Cli         = $Cli; Source = 'PSCompletions'; Action = 'Failed'
+                    ProfilePath = $target; Reason = $validation.Reason
+                }
             }
         }
     }
@@ -721,21 +814,109 @@ function Install-PSCompletionsModule {
     }
 }
 
+function Get-BucketCliName {
+    <#
+    .SYNOPSIS
+        Internal: union of CLI command names declared by every bundle's
+        [Package] objects (excluding those with Completion='none').
+
+        Used as the default scope for Register-AllCliCompletions so we
+        only register completions for the CLIs the bucket actually
+        manages — not every executable on PATH (#180).
+    #>
+    [OutputType([string[]])]
+    [CmdletBinding()]
+    param([string]$BucketPath)
+
+    $set = New-Object 'System.Collections.Generic.HashSet[string]' ([System.StringComparer]::OrdinalIgnoreCase)
+    $pkgArgs = @{}
+    if ($BucketPath) { $pkgArgs['BucketPath'] = $BucketPath }
+    $packages = @()
+    try {
+        $packages = Get-Package @pkgArgs -ErrorAction Stop
+    } catch {
+        Write-Warning "Get-BucketCliName: Get-Package failed: $($_.Exception.Message)"
+    }
+    foreach ($pkg in $packages) {
+        # Skip packages that explicitly opt out of completion registration.
+        if ($pkg.Completion -and ([string]$pkg.Completion).ToLowerInvariant() -eq 'none') { continue }
+        foreach ($cli in @($pkg.CliCommands)) {
+            if ($cli) { [void]$set.Add([string]$cli) }
+        }
+    }
+    return @($set | Sort-Object)
+}
+
 function Register-AllCliCompletions {
+    <#
+    .SYNOPSIS
+        Register tab-completion for CLIs declared by this bucket's
+        bundles (default), an explicit -Names list, or every executable
+        on PATH (-IncludeAllPath).
+
+    .DESCRIPTION
+        Default scope is the union of `CliCommands` across every
+        [Package] returned by Get-Package whose `Completion` field is
+        not 'none'. This avoids the surprising and slow behavior
+        of sweeping every binary on PATH and registering PSCompletions
+        entries for tools the user never asked about (#180).
+
+        -IncludeAllPath restores the legacy PATH-sweep behavior for
+        power users who want completions registered for every CLI
+        they happen to have installed.
+
+        -Names <subset> overrides scope entirely.
+
+    .PARAMETER Force
+        Replace existing sentinel-delimited completion blocks instead
+        of preserving them.
+
+    .PARAMETER ProfilePath
+        Override the AllUsersAllHosts profile target (testing).
+
+    .PARAMETER Names
+        Explicit CLI names. When supplied, neither bucket discovery
+        nor PATH sweep runs.
+
+    .PARAMETER IncludeAllPath
+        Opt into the legacy PATH sweep: enumerate every
+        `Get-Command -CommandType Application` binary and try to
+        register completion for each.
+
+    .PARAMETER BucketPath
+        Override the auto-detected bucket directory used when
+        discovering CLIs from declared packages.
+    #>
     [CmdletBinding(SupportsShouldProcess, ConfirmImpact = 'Medium')]
     [OutputType([pscustomobject[]])]
     param(
         [switch]$Force,
         [string]$ProfilePath,
-        [string[]]$Names
+        [string[]]$Names,
+        [switch]$IncludeAllPath,
+        [string]$BucketPath
     )
 
-    if (-not $Names) {
+    $scope = 'Bucket'
+    if ($Names) {
+        $scope = 'Explicit'
+    } elseif ($IncludeAllPath) {
+        $scope = 'PathSweep'
         $Names = Get-Command -CommandType Application -ErrorAction SilentlyContinue |
             Select-Object -ExpandProperty Name -Unique |
             ForEach-Object { [System.IO.Path]::GetFileNameWithoutExtension($_) } |
             Sort-Object -Unique
+    } else {
+        $bucketArgs = @{}
+        if ($BucketPath) { $bucketArgs['BucketPath'] = $BucketPath }
+        $Names = Get-BucketCliName @bucketArgs
+        if (-not $Names) {
+            Write-Warning "Register-AllCliCompletions: no bucket-declared CLIs found. Pass -Names <cli...> or -IncludeAllPath to scan PATH."
+            return @()
+        }
     }
+
+    Write-Verbose "Register-AllCliCompletions: scope=$scope, registering $($Names.Count) CLI(s)."
 
     $results = foreach ($n in $Names) {
         Register-CliCompletion -Cli $n -Force:$Force -ProfilePath $ProfilePath `
@@ -743,7 +924,7 @@ function Register-AllCliCompletions {
     }
 
     $byAction = $results | Group-Object Action | ForEach-Object { "$($_.Name)=$($_.Count)" }
-    Write-Host "Completion registration summary: $($byAction -join ', ')"
+    Write-Host "Completion registration summary [scope=$scope]: $($byAction -join ', ')"
     return @($results)
 }
 
@@ -753,7 +934,9 @@ function Invoke-CliCompletionsSweep {
     param(
         [switch]$Force,
         [string]$ProfilePath,
-        [string[]]$Names
+        [string[]]$Names,
+        [switch]$IncludeAllPath,
+        [string]$BucketPath
     )
 
     Write-Host 'Configuring PowerShell tab completion for installed CLI tools...'
@@ -763,6 +946,8 @@ function Invoke-CliCompletionsSweep {
     $splat = @{ Force = [bool]$Force }
     if ($ProfilePath) { $splat['ProfilePath'] = $ProfilePath }
     if ($Names) { $splat['Names'] = $Names }
+    if ($IncludeAllPath) { $splat['IncludeAllPath'] = $true }
+    if ($BucketPath) { $splat['BucketPath'] = $BucketPath }
 
     $results = Register-AllCliCompletions @splat -WhatIf:$WhatIfPreference
 


### PR DESCRIPTION
Closes #179, closes #180.

## #180 — bucket-scoped default

`Register-AllCliCompletions` now defaults to the union of `CliCommands` declared by bucket packages (filtered to `Completion != 'none'`) instead of enumerating every executable on `PATH`. Discovery delegates to a new private `Get-BucketCliName` helper backed by `Get-Package`.

- `-IncludeAllPath` opts back into the legacy PATH sweep.
- `-Names <cli...>` continues to override scope entirely.
- The summary banner now reports the selected scope: `Completion registration summary [scope=Bucket]: Added=N, …`.
- Empty bucket → `Write-Warning` and an empty result (the sweep no longer silently runs against PATH).
- `Invoke-CliCompletionsSweep` forwards the new `-IncludeAllPath` / `-BucketPath` parameters.

## #179 — psc-handler validation + rollback

After `psc add <cli>` succeeds, `Register-CliCompletion` now probes the freshly-added completion in a fresh `pwsh -NoProfile` child runspace via `[System.Management.Automation.CommandCompletion]::CompleteInput`. If the probe errors (e.g. the PSCompletions catalog entry registers a PSReadLine key handler whose scriptblock references a property that doesn't exist on the object PSReadLine actually passes — the exact symptom that broke Tab on my dev box), the catalog entry is rolled back via `psc remove <cli>` and the result row becomes `Action='Failed'` with the underlying reason. No sentinel block is written.

To keep this mockable from Pester, the raw `psc add` / `psc remove` invocations were extracted into `Invoke-PscAdd` / `Invoke-PscRemove` private helpers.

## README

- Documents the new bucket-scoped default and `-IncludeAllPath` escape hatch.
- New **Recovering from a broken completion block** section with the immediate `Set-PSReadLineKeyHandler -Chord Tab -Function MenuComplete` one-liner and the sentinel-block removal pattern.

## Tests

- `bucket/RegisterAllCliCompletionsScope.Tests.ps1` (Light) — 4 cases: bucket default union, `-IncludeAllPath` PATH sweep, `-Names` override, empty-bucket warning.
- `bucket/RegisterCliCompletionRollback.Tests.ps1` (Light) — 2 cases: failed validation triggers `psc remove` + `Action='Failed'` + no profile write; passing validation writes the sentinel block.
- Full Light suite: `924 passed, 0 failed`.

## Version

Module bumped to `1.2.0` (minor — public surface gains `-IncludeAllPath`/`-BucketPath` parameters and a new `Action='Failed'` result state).