### PR TITLE
feat(office): add OneDrive shim + native tab-completion (#183)

### DIFF
--- a/bucket/Bundles.Tests.ps1
+++ b/bucket/Bundles.Tests.ps1
@@ -253,6 +253,16 @@ Describe 'Specific cross-bundle placement contracts' -Tag 'Light','Bundle' {
         $script:byBundle.ClientBasePackages.Name | Should -Not -Contain 'Claude for Excel'
     }
 
+    It 'OneDrive CLI shim is owned by the MicrosoftOffice365 bundle' {
+        # OneDrive.exe is a Windows OS component already present on every box,
+        # so we colocate its curated shim + tab-completion with the rest of
+        # the Microsoft 365 surface (same file already owns the OneDrive
+        # tenant-redirection policy). See issue #183.
+        $script:byBundle.MicrosoftOffice365.Name | Should -Contain 'OneDrive CLI shim'
+        $script:byBundle.AIAgents.Name           | Should -Not -Contain 'OneDrive CLI shim'
+        $script:byBundle.OSBasePackages.Name     | Should -Not -Contain 'OneDrive CLI shim'
+    }
+
     It 'Claude Desktop is owned by the AIAgents bundle' {
         $script:byBundle.AIAgents.Name           | Should -Contain 'Claude Desktop'
         $script:byBundle.ClientBasePackages.Name | Should -Not -Contain 'Claude Desktop'

--- a/bucket/MicrosoftOffice365.json
+++ b/bucket/MicrosoftOffice365.json
@@ -1,6 +1,6 @@
 {
     "$schema": "https://raw.githubusercontent.com/lukesampson/scoop/master/schema.json",
-    "version": "1.10.000",
+    "version": "1.11.000",
     "url": [
         "https://raw.githubusercontent.com/MarkMichaelis/ScoopBucket/master/bucket/MicrosoftOffice365.ps1"
     ],

--- a/bucket/MicrosoftOffice365.ps1
+++ b/bucket/MicrosoftOffice365.ps1
@@ -182,6 +182,101 @@ Register-ArgumentCompleter -Native -CommandName $Cli -ScriptBlock {
         }
     }
     [Package]@{
+        # Issue #183. OneDrive.exe is a Windows OS component pre-installed
+        # per-machine under C:\Program Files\Microsoft OneDrive\ but is NOT
+        # on PATH and has no first-party PowerShell completer. We create a
+        # thin .cmd shim under ~\scoop\shims (already on PATH via scoop)
+        # so `onedrive` works from a terminal, and register a native
+        # argument completer for the curated set of top-level switches.
+        #
+        # Curated switches are sourced from long-standing community/MS
+        # support documentation of OneDrive client command-line flags.
+        # Microsoft does not publish a stable PowerShell completion
+        # grammar, so we deliberately keep this list short and obvious.
+        Name        = 'OneDrive CLI shim'
+        Installer   = 'custom'
+        CliCommands = @('onedrive')
+        Completion  = 'native'
+        Notes       = 'OneDrive.exe ships with Windows (per-machine install). This package only manages a launcher shim plus tab-completion -- it does not install OneDrive itself. Switches curated from MS support docs; no upstream PSCompletions catalog entry exists.'
+        ExpectedCompletions = @{
+            onedrive = @('/background','/reset','/shutdown','/restart','/addaccount','/configure_business','/silentconfig','/diag','/checkforupdates','/forcedeleteonedrive','/InternalAddBusiness')
+        }
+        CustomInstallScript = {
+            param($pkg)
+
+            $candidates = @(
+                'C:\Program Files\Microsoft OneDrive\OneDrive.exe',
+                'C:\Program Files (x86)\Microsoft OneDrive\OneDrive.exe'
+            )
+            $binary = $candidates | Where-Object { Test-Path -LiteralPath $_ } | Select-Object -First 1
+            if (-not $binary) {
+                throw "OneDrive.exe not found. Tried: $($candidates -join ', '). OneDrive ships with Windows; if it is missing, run 'winget install --id Microsoft.OneDrive' first."
+            }
+
+            $shimDir = Join-Path $env:USERPROFILE 'scoop\shims'
+            if (-not (Test-Path -LiteralPath $shimDir)) {
+                throw "Scoop shim directory '$shimDir' not found. Install scoop first (this bucket depends on it)."
+            }
+
+            $shimPath = Join-Path $shimDir 'onedrive.cmd'
+            # @start "" "<binary>" %* detaches the GUI from the terminal so
+            # the shell prompt returns immediately. The empty "" is the
+            # window-title arg required by cmd's start command when the path
+            # itself is quoted.
+            $content = "@echo off`r`n" +
+                       "@rem ScoopBucket:OneDriveShim -- managed by MicrosoftOffice365.ps1 (issue #183)`r`n" +
+                       "@start `"`" `"$binary`" %*`r`n"
+            Set-Content -LiteralPath $shimPath -Value $content -Encoding ASCII -NoNewline
+            Write-Host "  Created OneDrive shim: $shimPath -> $binary"
+        }
+        CustomUninstallScript = {
+            param($pkg)
+            $shimDir = Join-Path $env:USERPROFILE 'scoop\shims'
+            if (-not (Test-Path -LiteralPath $shimDir)) { return }
+            $shimPath = Join-Path $shimDir 'onedrive.cmd'
+            if (-not (Test-Path -LiteralPath $shimPath)) { return }
+            $raw = Get-Content -LiteralPath $shimPath -Raw -ErrorAction SilentlyContinue
+            if ($raw -and $raw -match 'ScoopBucket:OneDriveShim') {
+                Remove-Item -LiteralPath $shimPath -Force
+                Write-Host "  Removed OneDrive shim: $shimPath"
+            }
+        }
+        VerifyScript = {
+            $shimDir = Join-Path $env:USERPROFILE 'scoop\shims'
+            if (-not (Test-Path -LiteralPath $shimDir)) { return $false }
+            $shimPath = Join-Path $shimDir 'onedrive.cmd'
+            if (-not (Test-Path -LiteralPath $shimPath)) { return $false }
+            $raw = Get-Content -LiteralPath $shimPath -Raw -ErrorAction SilentlyContinue
+            if (-not $raw -or $raw -notmatch 'ScoopBucket:OneDriveShim') { return $false }
+            return $true
+        }
+        NativeCommandScript = {
+            param($Cli)
+
+            $switchMap = @{
+                onedrive = @(
+                    '/background','/reset','/shutdown','/restart','/addaccount',
+                    '/configure_business','/silentconfig','/diag','/checkforupdates',
+                    '/forcedeleteonedrive','/InternalAddBusiness'
+                )
+            }
+
+            $switches = $switchMap[$Cli]
+            if (-not $switches) { return '' }
+            $list = ($switches | ForEach-Object { "'$_'" }) -join ','
+@"
+Register-ArgumentCompleter -Native -CommandName $Cli -ScriptBlock {
+    param(`$wordToComplete, `$commandAst, `$cursorPosition)
+    @($list) |
+        Where-Object { `$_ -like "`$wordToComplete*" } |
+        ForEach-Object {
+            [System.Management.Automation.CompletionResult]::new(`$_, `$_, 'ParameterValue', `$_)
+        }
+}
+"@
+        }
+    }
+    [Package]@{
         Name        = 'Claude for Excel'
         Installer   = 'custom'
         DependsOn   = @('Microsoft 365 Apps for Enterprise')

--- a/docs/designs/2026-05-18-onedrive-completion-plan.md
+++ b/docs/designs/2026-05-18-onedrive-completion-plan.md
@@ -1,0 +1,47 @@
+# OneDrive completion plan (Issue #183)
+
+## Tasks
+
+### Task 1 - Add red placement test
+File: bucket/Bundles.Tests.ps1
+Inside the "Specific cross-bundle placement contracts" Describe, add:
+
+    It "OneDrive CLI shim is owned by the MicrosoftOffice365 bundle" {
+        $script:byBundle.MicrosoftOffice365.Name | Should -Contain "OneDrive CLI shim"
+    }
+
+Run: `Invoke-Pester bucket/Bundles.Tests.ps1 -Tag Light` -> the new test fails.
+
+### Task 2 - Add the Package entry (green)
+File: bucket/MicrosoftOffice365.ps1
+Insert a new [Package] entry into $Packages array, after "Microsoft Office CLI shims" and before "Claude for Excel". Properties:
+
+- Name = "OneDrive CLI shim"
+- Installer = "custom"
+- CliCommands = @("onedrive")
+- Completion = "native"
+- ExpectedCompletions = @{ onedrive = @("/background","/reset","/shutdown","/restart","/addaccount","/configure_business","/silentconfig","/diag","/checkforupdates","/forcedeleteonedrive","/InternalAddBusiness") }
+- Notes = curated; OneDrive.exe ships with Windows and has no first-party PowerShell completer.
+- CustomInstallScript: locate OneDrive.exe under "C:\Program Files\Microsoft OneDrive\" or the (x86) twin; write ~\scoop\shims\onedrive.cmd with ScoopBucket:OneDriveShim sentinel; detached via @start "" "<bin>" %*.
+- CustomUninstallScript: only remove the shim if our sentinel is present.
+- VerifyScript: shim exists and contains the sentinel.
+- NativeCommandScript: emits Register-ArgumentCompleter -Native -CommandName onedrive with the curated switch list (here-string identical in shape to the Office shims pattern).
+
+Run: `Invoke-Pester bucket/Bundles.Tests.ps1 -Tag Light` -> all green (placement test passes, data-driven invariants pass).
+
+### Task 3 - Bump manifest version
+File: bucket/MicrosoftOffice365.json
+version: "1.10.000" -> "1.11.000" (README: minor for added package).
+
+### Task 4 - Run full Light suite for the bundle area
+Run: `Invoke-Pester bucket/Bundles.Tests.ps1, bucket/Package.Tests.ps1, bucket/ManifestVersionBumps.Tests.ps1 -Tag Light` -> all green.
+
+### Task 5 - Evidence capture
+Capture a real TabExpansion2 run for `onedrive ` showing the curated switches. Save to .evidence/<phase-id>/.
+
+### Task 6 - Commit + PR
+- test(office): add OneDrive placement assertion
+- feat(office): add OneDrive shim + native completion (#183)
+- chore(manifest): bump MicrosoftOffice365 to 1.11.000
+
+PR via gh pr create --body-file ..., includes "Closes #183".


### PR DESCRIPTION
## Summary

Adds curated PowerShell tab-completion for the Windows OneDrive client (`OneDrive.exe`). Typing `onedrive <Tab>` now offers the 11 documented top-level switches.

Closes #183.

## Why

`OneDrive.exe` is a Windows OS component pre-installed per-machine under `C:\Program Files\Microsoft OneDrive\` but is not on `PATH` and has no first-party PowerShell completer. The Microsoft 365 bundle already owns the OneDrive tenant-redirection policy, so colocating the shim + completion keeps every OneDrive concern in one file. Pattern mirrors the existing `Microsoft Office CLI shims` package added in PR #173.

## What changed

1. New `[Package]` entry `OneDrive CLI shim` in `bucket/MicrosoftOffice365.ps1`:
   - `Installer = 'custom'` (OneDrive ships with Windows; this package only manages the shim + completion, not the OneDrive install itself).
   - `CustomInstallScript` writes `~\scoop\shims\onedrive.cmd` carrying a `ScoopBucket:OneDriveShim` sentinel; the shim detaches via `@start "" "<binary>" %*` so the terminal returns immediately.
   - `CustomUninstallScript` removes the shim only if our sentinel is present.
   - `VerifyScript` confirms shim + sentinel exist.
   - `NativeCommandScript` emits a `Register-ArgumentCompleter -Native -CommandName onedrive` block for these curated switches:
     `/background`, `/reset`, `/shutdown`, `/restart`, `/addaccount`, `/configure_business`, `/silentconfig`, `/diag`, `/checkforupdates`, `/forcedeleteonedrive`, `/InternalAddBusiness`.
   - `ExpectedCompletions` declares the same 11 switches so `CompletionEndToEnd.Tests.ps1` (Heavy) can verify TabExpansion2 end-to-end after validate-installs.
2. `bucket/Bundles.Tests.ps1` gains a placement assertion in the "Specific cross-bundle placement contracts" Describe.
3. `bucket/MicrosoftOffice365.json` version `1.10.000` -> `1.11.000` (README rule: minor segment bumps when a package is added).

## Tests

Light suite (`bucket/Bundles.Tests.ps1` `-Tag Light`): 778 passed, 0 failed, 1 skipped (unrelated pre-existing skip).

The 12 data-driven invariants in `Bundles.Tests.ps1` automatically apply to the new package (Installer, CliCommands, Completion, NativeCommandScript-emits-Register-ArgumentCompleter, ExpectedCompletions coverage, Scope, etc.).

## Evidence (Phase 5b)

Real `[CommandCompletion]::CompleteInput` probe in a fresh `pwsh -NoProfile` runspace, fed the `NativeCommandScript` output captured by `Get-Package`:

- Input `onedrive ` -> 11 ParameterValue matches (all curated switches).
- Input `onedrive /re` -> 2 matches: `/reset`, `/restart` (prefix filter works).

See `.evidence/phase-5b-*/probe.txt` and `REVIEW.md` on this branch.

## Out of scope

- No winget/choco install path. OneDrive is built into Windows.
- No PSCompletions catalog change. No first-party completion grammar exists; switches are curated from MS support docs.
- Unrelated OneDrive auth investigation files were not touched.
