### PR TITLE
test(completions): pin Get-CompletionProfilePath default to AllUsersAllHosts (refs #185)

### DIFF
--- a/bucket/CompletionProfileTarget.Tests.ps1
+++ b/bucket/CompletionProfileTarget.Tests.ps1
@@ -1,0 +1,106 @@
+#requires -Version 7.0
+#requires -Modules @{ ModuleName = 'Pester'; ModuleVersion = '5.0.0' }
+
+<#
+.SYNOPSIS
+    Regression test for #185: Get-CompletionProfilePath must default to
+    $PROFILE.AllUsersAllHosts under elevation, never the CurrentUser*
+    variants. The originally-reported symptom was sentinel blocks landing
+    in $PROFILE.CurrentUserCurrentHost (Microsoft.PowerShell_profile.ps1)
+    despite an elevated session and no -ProfilePath override.
+
+    This test pins the default-target contract so any future regression
+    in Get-CompletionProfilePath (or callers that fail to thread the
+    override) surfaces in CI.
+#>
+
+BeforeAll {
+    $script:moduleManifest = Resolve-Path (Join-Path (Split-Path -Parent $PSScriptRoot) 'module\MarkMichaelis.ScoopBucket\MarkMichaelis.ScoopBucket.psd1')
+    Import-Module $script:moduleManifest -Force
+}
+
+Describe 'Get-CompletionProfilePath default target (#185)' -Tag 'Light','Module' {
+
+    It 'returns $PROFILE.AllUsersAllHosts when no -OverridePath is supplied and the host is elevated' {
+        InModuleScope MarkMichaelis.ScoopBucket {
+            # Shadow $PROFILE with a sandbox-rooted equivalent so the
+            # function's writability probe doesn't require Administrator
+            # access to C:\Program Files\PowerShell\7\profile.ps1 in CI.
+            # The contract under test is: the function picks the
+            # AllUsersAllHosts member of $PROFILE -- not which absolute
+            # path that member happens to resolve to on this host.
+            $sandboxDir = Join-Path ([System.IO.Path]::GetTempPath()) ("CPT-AUAH-" + [guid]::NewGuid().ToString('N'))
+            New-Item -ItemType Directory -Path $sandboxDir -Force | Out-Null
+            $sandboxAUAH = Join-Path $sandboxDir 'profile.ps1'
+            $sandboxCUCH = Join-Path $sandboxDir 'Microsoft.PowerShell_profile.ps1'
+            $sandboxCUAH = Join-Path $sandboxDir 'cuah-profile.ps1'
+
+            try {
+                $PROFILE = [pscustomobject]@{
+                    AllUsersAllHosts       = $sandboxAUAH
+                    AllUsersCurrentHost    = Join-Path $sandboxDir 'auch-profile.ps1'
+                    CurrentUserAllHosts    = $sandboxCUAH
+                    CurrentUserCurrentHost = $sandboxCUCH
+                }
+                Mock Test-IsElevated { $true }
+
+                $result = Get-CompletionProfilePath
+
+                $result | Should -Be $sandboxAUAH
+                # Defense-in-depth: the value must NOT match any of the
+                # CurrentUser* profile variants. This is the exact symptom
+                # reported in #185.
+                $result | Should -Not -Be $sandboxCUAH
+                $result | Should -Not -Be $sandboxCUCH
+            } finally {
+                Remove-Item -Path $sandboxDir -Recurse -Force -ErrorAction Ignore
+            }
+        }
+    }
+
+    It 'honors -OverridePath verbatim (sandbox usage)' {
+        InModuleScope MarkMichaelis.ScoopBucket {
+            Mock Test-IsElevated { $true }
+            $sandbox = Join-Path ([System.IO.Path]::GetTempPath()) ("CPT-" + [guid]::NewGuid().ToString('N') + '.ps1')
+            try {
+                $result = Get-CompletionProfilePath -OverridePath $sandbox
+                $result | Should -Be $sandbox
+            } finally {
+                Remove-Item -Path $sandbox -ErrorAction Ignore
+            }
+        }
+    }
+
+    It 'throws (does not silently fall back to CurrentUser) when not elevated' {
+        InModuleScope MarkMichaelis.ScoopBucket {
+            Mock Test-IsElevated { $false }
+            { Get-CompletionProfilePath } | Should -Throw -ExpectedMessage '*elevated*'
+        }
+    }
+}
+
+Describe 'Register-CliCompletion default target (#185)' -Tag 'Light','Module' {
+
+    It 'resolves the profile target via Get-CompletionProfilePath when -ProfilePath is omitted' {
+        InModuleScope MarkMichaelis.ScoopBucket {
+            $sandbox = Join-Path ([System.IO.Path]::GetTempPath()) ("CPT-RCC-" + [guid]::NewGuid().ToString('N') + '.ps1')
+            try {
+                # Pin the resolver to the sandbox so the test never
+                # touches the real machine-wide profile. The point is
+                # that Register-CliCompletion delegates target choice
+                # to Get-CompletionProfilePath -- not that it invents
+                # its own path.
+                Mock Get-CompletionProfilePath { param($OverridePath) if ($OverridePath) { $OverridePath } else { $sandbox } }
+
+                $native = [scriptblock]::Create("Write-Output 'Register-ArgumentCompleter -CommandName demo -ScriptBlock { }'")
+                $result = Register-CliCompletion -Cli 'demo' -NativeCommand $native -Force -Confirm:$false
+
+                $result.ProfilePath | Should -Be $sandbox
+                Test-Path $sandbox | Should -BeTrue
+                (Get-Content -Raw -Path $sandbox) | Should -Match '# ScoopBucket:CliCompletion:demo:BEGIN'
+            } finally {
+                Remove-Item -Path $sandbox -ErrorAction Ignore
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Adds a Light-tagged Pester regression test pinning the default profile target chosen by Get-CompletionProfilePath to $PROFILE.AllUsersAllHosts. This is the contract that broke (silently) in the bug reported as #185, where sentinel-delimited completion blocks landed in $PROFILE.CurrentUserCurrentHost (Microsoft.PowerShell_profile.ps1) despite an elevated session and no `-ProfilePath` override.

## What the test covers

Four cases in `bucket/CompletionProfileTarget.Tests.ps1` (tag `Light,Module`):

1. `Get-CompletionProfilePath` with no `-OverridePath` + elevated -> returns `D:\OneDrive\OneDrive - Michaelis\OneDrive - Michaelis\Documents\PowerShell\Microsoft.PowerShell_profile.ps1.AllUsersAllHosts` (and explicitly NOT either CurrentUser* variant). The test shadows `D:\OneDrive\OneDrive - Michaelis\OneDrive - Michaelis\Documents\PowerShell\Microsoft.PowerShell_profile.ps1` with a sandbox-rooted `pscustomobject` so the function's writability probe never has to touch `C:\Program Files\PowerShell\7\profile.ps1` on CI runners.
2. `-OverridePath` is honored verbatim.
3. Non-elevated session throws -- the function does NOT silently fall back to a CurrentUser path.
4. `Register-CliCompletion` (without `-ProfilePath`) delegates target choice to `Get-CompletionProfilePath` and writes to that resolved path.

## Anti-collusion verification

Before committing, mutated `Get-CompletionProfilePath` to ` = $PROFILE.CurrentUserCurrentHost` and re-ran the test. Case 1 failed with a behavioral assertion (string mismatch on the file path) -- not a compile error -- pointing exactly at the #185 symptom path:

```
Expected: '...sandbox.../profile.ps1'
But was:  '...sandbox.../Microsoft.PowerShell_profile.ps1'
```

Code was reverted before commit.

## Does this fix #185?

No -- this PR only **pins the current contract**. The underlying #185 bug (something is writing completion blocks to CurrentUserCurrentHost despite the resolver returning AllUsersAllHosts) is most likely in the `pscompletions`-side bootstrap (the catalog module is installed at `CurrentUser` scope on the affected machine), not in our resolver. Root-causing #185 stays open. This test ensures the resolver itself can't silently regress.

## Verification

`powershell
Invoke-Pester -Path .\bucket\CompletionProfileTarget.Tests.ps1 -Output Detailed
# Tests Passed: 4, Failed: 0
`

Refs #185