### PR TITLE
feat(office365): machine-wide OneDrive install supersedes legacy shim (closes #188)

### DIFF
--- a/bucket/Bundles.Tests.ps1
+++ b/bucket/Bundles.Tests.ps1
@@ -253,14 +253,62 @@ Describe 'Specific cross-bundle placement contracts' -Tag 'Light','Bundle' {
         $script:byBundle.ClientBasePackages.Name | Should -Not -Contain 'Claude for Excel'
     }
 
-    It 'OneDrive CLI shim is owned by the MicrosoftOffice365 bundle' {
-        # OneDrive.exe is a Windows OS component already present on every box,
-        # so we colocate its curated shim + tab-completion with the rest of
-        # the Microsoft 365 surface (same file already owns the OneDrive
-        # tenant-redirection policy). See issue #183.
-        $script:byBundle.MicrosoftOffice365.Name | Should -Contain 'OneDrive CLI shim'
-        $script:byBundle.AIAgents.Name           | Should -Not -Contain 'OneDrive CLI shim'
-        $script:byBundle.OSBasePackages.Name     | Should -Not -Contain 'OneDrive CLI shim'
+    It 'Microsoft OneDrive (machine-wide) is owned by the MicrosoftOffice365 bundle' {
+        # Issue #188: supersedes the shim-only 'OneDrive CLI shim' (issue
+        # #183). The new package both installs OneDrive machine-wide via
+        # OneDriveSetup.exe /allusers /silent AND manages the onedrive
+        # scoop shim. The legacy shim-only package must NOT coexist with
+        # this one (they both register CliCommands=@('onedrive') and would
+        # collide on the shim file + completion registration).
+        $script:byBundle.MicrosoftOffice365.Name | Should -Contain 'Microsoft OneDrive (machine-wide)'
+        $script:byBundle.MicrosoftOffice365.Name | Should -Not -Contain 'OneDrive CLI shim'
+        $script:byBundle.AIAgents.Name           | Should -Not -Contain 'Microsoft OneDrive (machine-wide)'
+        $script:byBundle.OSBasePackages.Name     | Should -Not -Contain 'Microsoft OneDrive (machine-wide)'
+    }
+
+    It 'Microsoft OneDrive (machine-wide) advertises the install-time switches the user actually needs post-/allusers' {
+        # /addaccount, /signout, /configure_business: are the user-facing
+        # entry points after a fresh machine-wide install (linking the
+        # first AAD identity, signing out, pointing at a tenant). The
+        # legacy shim-only package omitted /addaccount and /signout
+        # because it presumed a per-user OneDrive that was already
+        # signed in. Asserting these here ensures the new package's
+        # completion table reflects the post-install workflow.
+        $od = $script:byBundle.MicrosoftOffice365 | Where-Object Name -eq 'Microsoft OneDrive (machine-wide)'
+        $od | Should -Not -BeNullOrEmpty
+        $od.ExpectedCompletions.ContainsKey('onedrive') | Should -BeTrue
+        $od.ExpectedCompletions['onedrive'] | Should -Contain '/addaccount'
+        $od.ExpectedCompletions['onedrive'] | Should -Contain '/signout'
+        $od.ExpectedCompletions['onedrive'] | Should -Contain '/configure_business:'
+    }
+
+    It 'no two packages within a bundle declare the same CliCommands entry' {
+        # Regression guard for the issue #188 conflict: the new
+        # machine-wide OneDrive package and the legacy 'OneDrive CLI
+        # shim' both declared CliCommands=@('onedrive'). Two packages
+        # in the same bundle owning the same CLI means the bundle
+        # loader writes one shim then immediately overwrites it, and
+        # the completion registration runs twice -- a silent ambiguity
+        # that no other test caught.
+        $collisions = foreach ($bundle in $script:byBundle.Keys) {
+            $byCli = @{}
+            foreach ($pkg in $script:byBundle[$bundle]) {
+                foreach ($cli in @($pkg.CliCommands)) {
+                    if (-not $byCli.ContainsKey($cli)) { $byCli[$cli] = @() }
+                    $byCli[$cli] += $pkg.Name
+                }
+            }
+            foreach ($cli in $byCli.Keys) {
+                if (@($byCli[$cli]).Count -gt 1) {
+                    [pscustomobject]@{
+                        Bundle   = $bundle
+                        Cli      = $cli
+                        Packages = $byCli[$cli]
+                    }
+                }
+            }
+        }
+        $collisions | Should -BeNullOrEmpty -Because "within-bundle CLI duplicates: $(($collisions | ForEach-Object { "$($_.Bundle):$($_.Cli) -> $($_.Packages -join '+')" }) -join '; ')"
     }
 
     It 'Claude Desktop is owned by the AIAgents bundle' {

--- a/bucket/MicrosoftOffice365.json
+++ b/bucket/MicrosoftOffice365.json
@@ -1,6 +1,6 @@
 {
     "$schema": "https://raw.githubusercontent.com/lukesampson/scoop/master/schema.json",
-    "version": "1.11.000",
+    "version": "1.12.000",
     "url": [
         "https://raw.githubusercontent.com/MarkMichaelis/ScoopBucket/master/bucket/MicrosoftOffice365.ps1"
     ],

--- a/bucket/MicrosoftOffice365.ps1
+++ b/bucket/MicrosoftOffice365.ps1
@@ -182,101 +182,6 @@ Register-ArgumentCompleter -Native -CommandName $Cli -ScriptBlock {
         }
     }
     [Package]@{
-        # Issue #183. OneDrive.exe is a Windows OS component pre-installed
-        # per-machine under C:\Program Files\Microsoft OneDrive\ but is NOT
-        # on PATH and has no first-party PowerShell completer. We create a
-        # thin .cmd shim under ~\scoop\shims (already on PATH via scoop)
-        # so `onedrive` works from a terminal, and register a native
-        # argument completer for the curated set of top-level switches.
-        #
-        # Curated switches are sourced from long-standing community/MS
-        # support documentation of OneDrive client command-line flags.
-        # Microsoft does not publish a stable PowerShell completion
-        # grammar, so we deliberately keep this list short and obvious.
-        Name        = 'OneDrive CLI shim'
-        Installer   = 'custom'
-        CliCommands = @('onedrive')
-        Completion  = 'native'
-        Notes       = 'OneDrive.exe ships with Windows (per-machine install). This package only manages a launcher shim plus tab-completion -- it does not install OneDrive itself. Switches curated from MS support docs; no upstream PSCompletions catalog entry exists.'
-        ExpectedCompletions = @{
-            onedrive = @('/background','/reset','/shutdown','/restart','/addaccount','/configure_business','/silentconfig','/diag','/checkforupdates','/forcedeleteonedrive','/InternalAddBusiness')
-        }
-        CustomInstallScript = {
-            param($pkg)
-
-            $candidates = @(
-                'C:\Program Files\Microsoft OneDrive\OneDrive.exe',
-                'C:\Program Files (x86)\Microsoft OneDrive\OneDrive.exe'
-            )
-            $binary = $candidates | Where-Object { Test-Path -LiteralPath $_ } | Select-Object -First 1
-            if (-not $binary) {
-                throw "OneDrive.exe not found. Tried: $($candidates -join ', '). OneDrive ships with Windows; if it is missing, run 'winget install --id Microsoft.OneDrive' first."
-            }
-
-            $shimDir = Join-Path $env:USERPROFILE 'scoop\shims'
-            if (-not (Test-Path -LiteralPath $shimDir)) {
-                throw "Scoop shim directory '$shimDir' not found. Install scoop first (this bucket depends on it)."
-            }
-
-            $shimPath = Join-Path $shimDir 'onedrive.cmd'
-            # @start "" "<binary>" %* detaches the GUI from the terminal so
-            # the shell prompt returns immediately. The empty "" is the
-            # window-title arg required by cmd's start command when the path
-            # itself is quoted.
-            $content = "@echo off`r`n" +
-                       "@rem ScoopBucket:OneDriveShim -- managed by MicrosoftOffice365.ps1 (issue #183)`r`n" +
-                       "@start `"`" `"$binary`" %*`r`n"
-            Set-Content -LiteralPath $shimPath -Value $content -Encoding ASCII -NoNewline
-            Write-Host "  Created OneDrive shim: $shimPath -> $binary"
-        }
-        CustomUninstallScript = {
-            param($pkg)
-            $shimDir = Join-Path $env:USERPROFILE 'scoop\shims'
-            if (-not (Test-Path -LiteralPath $shimDir)) { return }
-            $shimPath = Join-Path $shimDir 'onedrive.cmd'
-            if (-not (Test-Path -LiteralPath $shimPath)) { return }
-            $raw = Get-Content -LiteralPath $shimPath -Raw -ErrorAction SilentlyContinue
-            if ($raw -and $raw -match 'ScoopBucket:OneDriveShim') {
-                Remove-Item -LiteralPath $shimPath -Force
-                Write-Host "  Removed OneDrive shim: $shimPath"
-            }
-        }
-        VerifyScript = {
-            $shimDir = Join-Path $env:USERPROFILE 'scoop\shims'
-            if (-not (Test-Path -LiteralPath $shimDir)) { return $false }
-            $shimPath = Join-Path $shimDir 'onedrive.cmd'
-            if (-not (Test-Path -LiteralPath $shimPath)) { return $false }
-            $raw = Get-Content -LiteralPath $shimPath -Raw -ErrorAction SilentlyContinue
-            if (-not $raw -or $raw -notmatch 'ScoopBucket:OneDriveShim') { return $false }
-            return $true
-        }
-        NativeCommandScript = {
-            param($Cli)
-
-            $switchMap = @{
-                onedrive = @(
-                    '/background','/reset','/shutdown','/restart','/addaccount',
-                    '/configure_business','/silentconfig','/diag','/checkforupdates',
-                    '/forcedeleteonedrive','/InternalAddBusiness'
-                )
-            }
-
-            $switches = $switchMap[$Cli]
-            if (-not $switches) { return '' }
-            $list = ($switches | ForEach-Object { "'$_'" }) -join ','
-@"
-Register-ArgumentCompleter -Native -CommandName $Cli -ScriptBlock {
-    param(`$wordToComplete, `$commandAst, `$cursorPosition)
-    @($list) |
-        Where-Object { `$_ -like "`$wordToComplete*" } |
-        ForEach-Object {
-            [System.Management.Automation.CompletionResult]::new(`$_, `$_, 'ParameterValue', `$_)
-        }
-}
-"@
-        }
-    }
-    [Package]@{
         Name        = 'Claude for Excel'
         Installer   = 'custom'
         DependsOn   = @('Microsoft 365 Apps for Enterprise')
@@ -341,6 +246,197 @@ Register-ArgumentCompleter -Native -CommandName $Cli -ScriptBlock {
                     }
                 } | Where-Object { $_ }
             return [bool]$hit
+        }
+    }
+    [Package]@{
+        # Windows ships OneDrive as a per-user install under
+        # %LOCALAPPDATA%\Microsoft\OneDrive. This entry replaces that with
+        # the machine-wide install (`OneDriveSetup.exe /allusers /silent`)
+        # so every user on the box shares one C:\Program Files\Microsoft
+        # OneDrive\OneDrive.exe binary -- mandatory for IT-managed
+        # tenant-redirect policy (see Set-OneDriveConfig below) and for
+        # the `onedrive` scoop shim to resolve to a stable path.
+        #
+        # Install nuances:
+        # 1. The per-user install (if any) is uninstalled first via
+        #    OneDriveSetup.exe /uninstall as a best-effort step.
+        # 2. /allusers /silent spawns OneDrive.Sync.Service.exe
+        #    /silentConfig as a background child. That child NEVER exits
+        #    on its own and pins Start-Process -Wait against the parent
+        #    job tree. We use Process.WaitForExit(timeout) on the parent
+        #    only, then explicitly Stop-Process the sync service.
+        # 3. OneDrive.exe is a GUI app with flat (not subcommand) switch
+        #    surface; the shim uses the same `@start "" "<exe>" %*`
+        #    detach pattern as the Office shims so the terminal returns
+        #    immediately after e.g. `onedrive /addaccount`.
+        Name        = 'Microsoft OneDrive (machine-wide)'
+        Installer   = 'custom'
+        CliCommands = @('onedrive')
+        Completion  = 'native'
+        Notes       = 'Replaces the Windows-default per-user OneDrive with a machine-wide install via OneDriveSetup.exe /allusers /silent. /allusers requires admin; the per-user uninstall is best-effort. Shim at ~\scoop\shims\onedrive.cmd resolves to C:\Program Files\Microsoft OneDrive\OneDrive.exe. Switches per support.microsoft.com OneDrive command-line reference (flat switches, no subcommands).'
+        ExpectedCompletions = @{
+            onedrive = @('/addaccount','/background','/reset','/resetauthstate','/shutdown','/signout','/configure_business:')
+        }
+        CustomInstallScript = {
+            param($pkg)
+
+            $machineExe = Join-Path $env:ProgramFiles 'Microsoft OneDrive\OneDrive.exe'
+            $perUserExe = Join-Path $env:LOCALAPPDATA 'Microsoft\OneDrive\OneDriveSetup.exe'
+            $sysWow64Exe = Join-Path $env:SystemRoot 'SysWOW64\OneDriveSetup.exe'
+            $system32Exe = Join-Path $env:SystemRoot 'System32\OneDriveSetup.exe'
+
+            Write-Host '  Stopping any running OneDrive instances...'
+            Get-Process OneDrive, OneDriveSetup, 'OneDrive.Sync.Service' -ErrorAction SilentlyContinue |
+                ForEach-Object { try { Stop-Process -Id $_.Id -Force -ErrorAction Stop } catch {} }
+
+            # Best-effort per-user uninstall. Failures are tolerated --
+            # /allusers will install alongside, but co-existence is messy.
+            $perUserUninstaller = @($perUserExe, $sysWow64Exe, $system32Exe) |
+                Where-Object { Test-Path -LiteralPath $_ } |
+                Select-Object -First 1
+            if ($perUserUninstaller) {
+                Write-Host "  Uninstalling per-user OneDrive via $perUserUninstaller /uninstall ..."
+                try {
+                    $p = Start-Process -FilePath $perUserUninstaller -ArgumentList '/uninstall' -PassThru -WindowStyle Hidden
+                    if (-not $p.WaitForExit(60000)) {
+                        Write-Warning "  Per-user OneDrive /uninstall did not exit in 60s; killing."
+                        try { $p.Kill() } catch {}
+                    }
+                } catch {
+                    Write-Warning "  Per-user OneDrive uninstall failed: $($_.Exception.Message)"
+                }
+            } else {
+                Write-Host '  No per-user OneDriveSetup.exe found; skipping per-user uninstall.'
+            }
+
+            # Download the latest OneDriveSetup.exe.
+            $installerPath = Join-Path $env:TEMP 'OneDriveSetup.exe'
+            $downloadUrl   = 'https://go.microsoft.com/fwlink/?linkid=844652'
+            Write-Host "  Downloading OneDriveSetup.exe from $downloadUrl ..."
+            $oldProgress = $ProgressPreference
+            $ProgressPreference = 'SilentlyContinue'
+            try {
+                Invoke-WebRequest -Uri $downloadUrl -OutFile $installerPath -UseBasicParsing
+            } finally {
+                $ProgressPreference = $oldProgress
+            }
+
+            Write-Host '  Installing OneDrive machine-wide (/allusers /silent)...'
+            $proc = Start-Process -FilePath $installerPath -ArgumentList '/allusers','/silent' -PassThru
+            if (-not $proc.WaitForExit(180000)) {
+                Write-Warning '  OneDriveSetup.exe did not exit within 180s; killing.'
+                try { $proc.Kill() } catch {}
+            }
+            if ($proc.HasExited -and $proc.ExitCode -ne 0) {
+                Remove-Item -LiteralPath $installerPath -Force -ErrorAction SilentlyContinue
+                throw "OneDriveSetup.exe exited with code $($proc.ExitCode)"
+            }
+
+            # /allusers spawns OneDrive.Sync.Service.exe /silentConfig
+            # which runs indefinitely and would block any caller using
+            # Start-Process -Wait. The binary install is already complete
+            # by the time the parent exits, so stopping the sync service
+            # is safe.
+            Get-CimInstance Win32_Process -Filter "Name='OneDrive.Sync.Service.exe'" -ErrorAction SilentlyContinue |
+                ForEach-Object {
+                    try {
+                        Stop-Process -Id $_.ProcessId -Force -ErrorAction Stop
+                        Write-Host "  Stopped post-install OneDrive.Sync.Service.exe (PID $($_.ProcessId))."
+                    } catch {}
+                }
+
+            Remove-Item -LiteralPath $installerPath -Force -ErrorAction SilentlyContinue
+
+            if (-not (Test-Path -LiteralPath $machineExe)) {
+                throw "OneDriveSetup.exe completed but expected binary '$machineExe' is missing."
+            }
+            $ver = (Get-Item -LiteralPath $machineExe).VersionInfo.FileVersion
+            Write-Host "  OneDrive installed: $machineExe (v$ver)"
+
+            # Scoop shim so `onedrive` resolves on PATH. Uses the same
+            # `@start "" "<exe>" %*` detach pattern as the Office shims so
+            # the terminal returns immediately after launching the GUI.
+            $shimDir = Join-Path $env:USERPROFILE 'scoop\shims'
+            if (-not (Test-Path -LiteralPath $shimDir)) {
+                throw "Scoop shim directory '$shimDir' not found. Install scoop first (this bucket depends on it)."
+            }
+            $shimPath = Join-Path $shimDir 'onedrive.cmd'
+            $content  = "@echo off`r`n" +
+                        "@rem ScoopBucket:OneDriveShim:onedrive -- managed by MicrosoftOffice365.ps1`r`n" +
+                        "@start `"`" `"$machineExe`" %*`r`n"
+            Set-Content -LiteralPath $shimPath -Value $content -Encoding ASCII -NoNewline
+            Write-Host "  Created OneDrive shim: $shimPath -> $machineExe"
+        }
+        CustomUninstallScript = {
+            param($pkg)
+
+            # Stop OneDrive cleanly then remove the shim and uninstall
+            # the machine-wide binary. Restoring the per-user install is
+            # left to Windows -- nothing to do here for that.
+            Get-Process OneDrive, 'OneDrive.Sync.Service' -ErrorAction SilentlyContinue |
+                ForEach-Object { try { Stop-Process -Id $_.Id -Force -ErrorAction Stop } catch {} }
+
+            $shimDir  = Join-Path $env:USERPROFILE 'scoop\shims'
+            $shimPath = Join-Path $shimDir 'onedrive.cmd'
+            if (Test-Path -LiteralPath $shimPath) {
+                $raw = Get-Content -LiteralPath $shimPath -Raw -ErrorAction SilentlyContinue
+                if ($raw -and $raw -match 'ScoopBucket:OneDriveShim:') {
+                    Remove-Item -LiteralPath $shimPath -Force
+                    Write-Host "  Removed OneDrive shim: $shimPath"
+                }
+            }
+
+            $machineSetup = Join-Path $env:ProgramFiles 'Microsoft OneDrive\OneDriveSetup.exe'
+            if (Test-Path -LiteralPath $machineSetup) {
+                Write-Host "  Uninstalling machine-wide OneDrive via $machineSetup /uninstall /allusers ..."
+                try {
+                    $p = Start-Process -FilePath $machineSetup -ArgumentList '/uninstall','/allusers' -PassThru -WindowStyle Hidden
+                    if (-not $p.WaitForExit(120000)) {
+                        Write-Warning '  OneDrive /uninstall did not exit in 120s; killing.'
+                        try { $p.Kill() } catch {}
+                    }
+                } catch {
+                    Write-Warning "  OneDrive uninstall failed: $($_.Exception.Message)"
+                }
+            }
+        }
+        VerifyScript = {
+            $machineExe = Join-Path $env:ProgramFiles 'Microsoft OneDrive\OneDrive.exe'
+            if (-not (Test-Path -LiteralPath $machineExe)) { return $false }
+            $shimPath = Join-Path $env:USERPROFILE 'scoop\shims\onedrive.cmd'
+            if (-not (Test-Path -LiteralPath $shimPath)) { return $false }
+            $raw = Get-Content -LiteralPath $shimPath -Raw -ErrorAction SilentlyContinue
+            if (-not $raw -or $raw -notmatch 'ScoopBucket:OneDriveShim:') { return $false }
+            return $true
+        }
+        NativeCommandScript = {
+            param($Cli)
+
+            if ($Cli -ne 'onedrive') { return '' }
+
+            # OneDrive.exe accepts flat switches (no subcommand tree).
+            # Sources: Microsoft Learn OneDrive admin docs and the
+            # OneDrive client itself. Switches are stable across versions.
+            $switches = @(
+                '/addaccount'
+                '/background'
+                '/reset'
+                '/resetauthstate'
+                '/shutdown'
+                '/signout'
+                '/configure_business:'
+            )
+            $list = ($switches | ForEach-Object { "'$_'" }) -join ','
+@"
+Register-ArgumentCompleter -Native -CommandName $Cli -ScriptBlock {
+    param(`$wordToComplete, `$commandAst, `$cursorPosition)
+    @($list) |
+        Where-Object { `$_ -like "`$wordToComplete*" } |
+        ForEach-Object {
+            [System.Management.Automation.CompletionResult]::new(`$_, `$_, 'ParameterValue', `$_)
+        }
+}
+"@
         }
     }
 )


### PR DESCRIPTION
Closes #188.

## Summary

Replaces the legacy `'OneDrive CLI shim'` package (#183, which only managed a launcher shim against the pre-existing per-user OneDrive) with a new `'Microsoft OneDrive (machine-wide)'` package that:

1. **Downloads OneDriveSetup.exe** from `https://go.microsoft.com/fwlink/?linkid=844652`.
2. **Best-effort uninstalls** any existing per-user OneDrive (`%LOCALAPPDATA%\Microsoft\OneDrive\OneDriveSetup.exe /uninstall`).
3. **Runs `OneDriveSetup.exe /allusers /silent`** with a 180s `Process.WaitForExit` timeout.
4. **Stops the orphaned `OneDrive.Sync.Service.exe /silentConfig`** child after install (the documented hang where `/silentConfig` never exits and pins `Start-Process -Wait` on the job tree).
5. **Creates a scoop shim** at `~\scoop\shims\onedrive.cmd` that detaches via `@start "" "<exe>" %*` so `onedrive /addaccount` returns control immediately.
6. **Registers native completion** for the post-install user-facing switches: `/addaccount`, `/signout`, `/configure_business:`, `/reset`, `/resetauthstate`, `/background`, `/shutdown`.

A symmetric `CustomUninstallScript` runs `OneDriveSetup.exe /uninstall /allusers` and removes the shim.

## Why remove the legacy package?

Both packages declared `CliCommands = @('onedrive')` in the same bundle. The bundle loader would write `onedrive.cmd` twice (last-writer-wins) and register the native completer twice. New regression test `no two packages within a bundle declare the same CliCommands entry` pins this invariant for the future.

## Behavior-first tests (`bucket/Bundles.Tests.ps1`)

| Test | Why |
|---|---|
| `Microsoft OneDrive (machine-wide) is owned by the MicrosoftOffice365 bundle` | Replaces the legacy `OneDrive CLI shim` ownership assertion. Also asserts the legacy name is **not** in the bundle. |
| `advertises the install-time switches the user actually needs post-/allusers` | Pins `/addaccount`, `/signout`, `/configure_business:` in `ExpectedCompletions[onedrive]` -- the post-/allusers user workflow that the legacy shim package omitted. |
| `no two packages within a bundle declare the same CliCommands entry` | Bundle-loader regression guard. Fails for the exact collision this PR fixes. |

Each test was verified RED before the fix (legacy package still present) and GREEN after. The "no two packages" test fails for a behavioral reason (collision detected in ``) when the legacy package is restored.

## Manifest

Bumped to `1.12.000` to track the .ps1 surface change.

## Test results

Light suite locally:

`./bucket/Invoke-Tests.ps1 -Tag Light` -> **938 passed, 0 failed**

## Notes

- `Start-Process -Wait` was deliberately avoided in the install script per the documented OneDrive `/silentConfig` job-tree hang. `Process.WaitForExit(timeout)` + explicit `Stop-Process` on the sync service is the documented workaround.
- The shim file format / detection regex match the existing Office shim pattern.
- The OneDrive download URL (`fwlink 844652`) is the canonical Microsoft redirect for the current OneDriveSetup.exe.