### PR TITLE
feat(bundles): add MarkMichaelisOneDriveConfiguration personal post-install bundle

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,6 +141,40 @@ the small config-only bundles (`GitConfigVisualStudio`,
 `SetPowerConfiguration`, `McAfeeUninstall`) remain imperative for now;
 the discovery and validation tools handle both forms transparently.
 
+### Personal post-install customization (`MarkMichaelis*` bundles)
+
+A separate category of bundle whose name is prefixed with
+`MarkMichaelis*`. These bundles do **not** install software; they
+reshape state on the machine (sync roots, Known Folder Move bindings,
+per-app settings) to match the author's personal layout. Members of
+this family are designed to run **after** all install bundles --
+ordering matters because they reference the accounts and folders
+those installs created.
+
+Intended run order:
+
+```powershell
+# 1. Install bundles first (in any order).
+scoop install MarkMichaelis/OSBasePackages
+scoop install MarkMichaelis/DeveloperBasePackages
+scoop install MarkMichaelis/ClientBasePackages
+scoop install MarkMichaelis/MicrosoftOffice365
+scoop install MarkMichaelis/AIAgents
+
+# 2. Personal post-install customization LAST.
+scoop install MarkMichaelis/MarkMichaelisOneDriveConfiguration
+```
+
+Current members:
+
+- **`MarkMichaelisOneDriveConfiguration`** -- pins every signed-in
+  OneDrive account's sync root under a single configurable parent
+  (default `C:\OneDrive`), applies tenant-redirection policy so future
+  sign-ins land in the right place, and rewrites KFM bindings (Known
+  Folder Move: Documents / Pictures / Desktop) to follow the canonical
+  Work account when its folder moves. Supports `-WhatIf` for dry-run
+  preview before a real migration.
+
 ## Authoring guidelines
 
 ### Manifest versioning

--- a/bucket/MarkMichaelisOneDriveConfiguration.Tests.ps1
+++ b/bucket/MarkMichaelisOneDriveConfiguration.Tests.ps1
@@ -1,0 +1,179 @@
+#requires -Version 7.0
+#requires -Modules @{ ModuleName = 'Pester'; ModuleVersion = '5.0.0' }
+
+<#
+.SYNOPSIS
+    Pure-function tests for MarkMichaelisOneDriveConfiguration.ps1.
+
+.DESCRIPTION
+    The migration script itself is mostly registry + filesystem
+    plumbing (covered by -WhatIf smoke tests during user verification),
+    but its decision helpers are pure and easily testable:
+
+      - Get-OneDriveTargetPath: account record + RootDir -> target folder
+      - Test-IsSameVolume:      same-volume vs cross-volume detection
+      - Resolve-KfmRebindAction: KFM rebind decision (track / rebind /
+        warn / owner-not-signed-in)
+
+    Pester 5 quirk (see bucket/Bundles.Tests.ps1 for the long-form
+    note): -ForEach test cases must be populated at DISCOVERY time, not
+    inside BeforeAll. We dot-source the bundle script at discovery so
+    the helper functions are visible to It blocks too -- BeforeAll
+    re-dot-sources for clean state.
+#>
+
+# Discovery-time: dot-source the bundle so its helpers are in scope
+# when -ForEach evaluates. The bundle's main orchestration is gated by
+# $MyInvocation.InvocationName -eq '.', so dot-sourcing only loads
+# helpers without running the migration.
+. "$PSScriptRoot\MarkMichaelisOneDriveConfiguration.ps1"
+
+BeforeAll {
+    . "$PSScriptRoot\MarkMichaelisOneDriveConfiguration.ps1"
+}
+
+Describe 'Get-OneDriveTargetPath' -Tag 'Light' {
+    It 'computes Work tenant path as "<RootDir>\OneDrive - <DisplayName>"' {
+        $acct = [pscustomobject]@{
+            AccountType = 'Business'
+            DisplayName = 'IntelliTect'
+            UserFolder  = 'C:\Users\me\OneDrive - IntelliTect'
+        }
+        Get-OneDriveTargetPath -Account $acct -RootDir 'C:\OneDrive' |
+            Should -Be 'C:\OneDrive\OneDrive - IntelliTect'
+    }
+
+    It 'computes Personal path as "<RootDir>\OneDrive - Personal"' {
+        $acct = [pscustomobject]@{
+            AccountType = 'Personal'
+            DisplayName = $null
+            UserFolder  = 'C:\Users\me\OneDrive'
+        }
+        Get-OneDriveTargetPath -Account $acct -RootDir 'C:\OneDrive' |
+            Should -Be 'C:\OneDrive\OneDrive - Personal'
+    }
+
+    It 'honors a non-default RootDir' {
+        $acct = [pscustomobject]@{
+            AccountType = 'Business'
+            DisplayName = 'Michaelis'
+            UserFolder  = 'D:\Mark\OneDrive - Michaelis'
+        }
+        Get-OneDriveTargetPath -Account $acct -RootDir 'E:\Cloud' |
+            Should -Be 'E:\Cloud\OneDrive - Michaelis'
+    }
+
+    It 'throws when Work account is missing DisplayName' {
+        $acct = [pscustomobject]@{
+            AccountType = 'Business'
+            DisplayName = $null
+            UserFolder  = 'C:\foo'
+        }
+        { Get-OneDriveTargetPath -Account $acct -RootDir 'C:\OneDrive' } |
+            Should -Throw -ExpectedMessage '*DisplayName*'
+    }
+}
+
+Describe 'Test-IsSameVolume' -Tag 'Light' {
+    It 'returns $true for two paths on the same drive root' {
+        Test-IsSameVolume -Source 'C:\Users\me\OneDrive - X' -Destination 'C:\OneDrive\OneDrive - X' |
+            Should -BeTrue
+    }
+
+    It 'returns $false for paths on different drive roots' {
+        Test-IsSameVolume -Source 'C:\Users\me\OneDrive - X' -Destination 'D:\OneDrive\OneDrive - X' |
+            Should -BeFalse
+    }
+
+    It 'is case-insensitive on the drive letter' {
+        Test-IsSameVolume -Source 'c:\foo' -Destination 'C:\bar' | Should -BeTrue
+    }
+}
+
+Describe 'Resolve-KfmRebindAction' -Tag 'Light' {
+    BeforeAll {
+        $script:owner = [pscustomobject]@{
+            Slot        = 'Business1'
+            AccountType = 'Business'
+            DisplayName = 'Michaelis Consulting'
+            UserFolder  = 'C:\OneDrive\OneDrive - Michaelis Consulting'
+        }
+        $script:other = [pscustomobject]@{
+            Slot        = 'Business2'
+            AccountType = 'Business'
+            DisplayName = 'IntelliTect'
+            UserFolder  = 'C:\OneDrive\OneDrive - IntelliTect'
+        }
+        $script:personal = [pscustomobject]@{
+            Slot        = 'Personal'
+            AccountType = 'Personal'
+            DisplayName = $null
+            UserFolder  = 'C:\OneDrive\OneDrive - Personal'
+        }
+    }
+
+    It "returns Action='Track' when KFM is bound under the owner's UserFolder" {
+        $result = Resolve-KfmRebindAction `
+            -Accounts @($script:owner, $script:other) `
+            -KfmCurrentPath 'C:\OneDrive\OneDrive - Michaelis Consulting\Documents' `
+            -KfmOwner 'Michaelis'
+        $result.Action | Should -Be 'Track'
+        $result.OwnerAccount.Slot | Should -Be 'Business1'
+    }
+
+    It "returns Action='Rebind' when KFM is bound under a different account" {
+        $result = Resolve-KfmRebindAction `
+            -Accounts @($script:owner, $script:other) `
+            -KfmCurrentPath 'C:\OneDrive\OneDrive - IntelliTect\Documents' `
+            -KfmOwner 'Michaelis'
+        $result.Action | Should -Be 'Rebind'
+        $result.OwnerAccount.Slot | Should -Be 'Business1'
+    }
+
+    It "returns Action='WarnOnly' when -NoKfmRebind is supplied with a mismatched binding" {
+        $result = Resolve-KfmRebindAction `
+            -Accounts @($script:owner, $script:other) `
+            -KfmCurrentPath 'C:\OneDrive\OneDrive - IntelliTect\Documents' `
+            -KfmOwner 'Michaelis' -NoKfmRebind
+        $result.Action | Should -Be 'WarnOnly'
+    }
+
+    It "returns Action='None' when KFM is not currently active" {
+        $result = Resolve-KfmRebindAction `
+            -Accounts @($script:owner) `
+            -KfmCurrentPath $null `
+            -KfmOwner 'Michaelis'
+        $result.Action | Should -Be 'None'
+    }
+
+    It "returns Action='OwnerNotSignedIn' when no Business account has a matching DisplayName" {
+        $result = Resolve-KfmRebindAction `
+            -Accounts @($script:other, $script:personal) `
+            -KfmCurrentPath 'C:\OneDrive\OneDrive - IntelliTect\Documents' `
+            -KfmOwner 'Michaelis'
+        $result.Action | Should -Be 'OwnerNotSignedIn'
+        $result.OwnerAccount | Should -BeNullOrEmpty
+    }
+
+    It "never matches the Personal slot even if its DisplayName contains the owner keyword" {
+        $personalNamedMichaelis = [pscustomobject]@{
+            Slot        = 'Personal'
+            AccountType = 'Personal'
+            DisplayName = 'Mark Michaelis'
+            UserFolder  = 'C:\foo'
+        }
+        $result = Resolve-KfmRebindAction `
+            -Accounts @($personalNamedMichaelis, $script:other) `
+            -KfmCurrentPath 'C:\OneDrive\OneDrive - IntelliTect\Documents' `
+            -KfmOwner 'Michaelis'
+        $result.Action | Should -Be 'OwnerNotSignedIn'
+    }
+
+    It 'returns an empty-accounts result as OwnerNotSignedIn' {
+        $result = Resolve-KfmRebindAction `
+            -Accounts @() `
+            -KfmCurrentPath $null `
+            -KfmOwner 'Michaelis'
+        $result.Action | Should -Be 'OwnerNotSignedIn'
+    }
+}

--- a/bucket/MarkMichaelisOneDriveConfiguration.json
+++ b/bucket/MarkMichaelisOneDriveConfiguration.json
@@ -1,0 +1,11 @@
+{
+    "$schema": "https://raw.githubusercontent.com/lukesampson/scoop/master/schema.json",
+    "version": "1.00.000",
+    "description": "Personal post-install customization bundle (member of the MarkMichaelis* run-last family). Pins OneDrive sync roots under a single parent, applies tenant-redirection policy, and rewrites KFM bindings to follow the canonical Work account. Runs AFTER all install bundles; reshapes state rather than installing software.",
+    "url": [
+        "https://raw.githubusercontent.com/MarkMichaelis/ScoopBucket/master/bucket/MarkMichaelisOneDriveConfiguration.ps1"
+    ],
+    "installer": {
+        "script": "& \"$dir\\MarkMichaelisOneDriveConfiguration.ps1\""
+    }
+}

--- a/bucket/MarkMichaelisOneDriveConfiguration.json
+++ b/bucket/MarkMichaelisOneDriveConfiguration.json
@@ -1,6 +1,6 @@
 {
     "$schema": "https://raw.githubusercontent.com/lukesampson/scoop/master/schema.json",
-    "version": "1.00.000",
+    "version": "1.01.000",
     "description": "Personal post-install customization bundle (member of the MarkMichaelis* run-last family). Pins OneDrive sync roots under a single parent, applies tenant-redirection policy, and rewrites KFM bindings to follow the canonical Work account. Runs AFTER all install bundles; reshapes state rather than installing software.",
     "url": [
         "https://raw.githubusercontent.com/MarkMichaelis/ScoopBucket/master/bucket/MarkMichaelisOneDriveConfiguration.ps1"

--- a/bucket/MarkMichaelisOneDriveConfiguration.ps1
+++ b/bucket/MarkMichaelisOneDriveConfiguration.ps1
@@ -85,13 +85,13 @@ function Get-OneDriveTargetPath {
         [Parameter(Mandatory)][string]$RootDir
     )
     if ($Account.AccountType -eq 'Personal') {
-        return (Join-Path $RootDir 'OneDrive - Personal')
+        return ([System.IO.Path]::Combine($RootDir, 'OneDrive - Personal'))
     }
     $name = $Account.DisplayName
     if ([string]::IsNullOrWhiteSpace($name)) {
         throw "Account has no DisplayName; cannot compute target path."
     }
-    return (Join-Path $RootDir ("OneDrive - {0}" -f $name))
+    return ([System.IO.Path]::Combine($RootDir, ("OneDrive - {0}" -f $name)))
 }
 
 function Test-IsSameVolume {

--- a/bucket/MarkMichaelisOneDriveConfiguration.ps1
+++ b/bucket/MarkMichaelisOneDriveConfiguration.ps1
@@ -1,0 +1,625 @@
+<#
+.SYNOPSIS
+    Personal post-install OneDrive customization (run-last, member of the
+    MarkMichaelis* personal-customization bundle category).
+
+.DESCRIPTION
+    Reshapes OneDrive state on this machine to match the author's
+    personal layout: all sync roots under a single configurable parent
+    directory (default C:\OneDrive), tenant-redirection policy applied
+    so future sign-ins land in the right place, and Known Folder Move
+    (KFM) bindings rewritten to follow the OneDrive folder when it
+    moves.
+
+    Pattern follows GitConfigure.ps1 / SetPowerConfiguration.ps1: a
+    free-form configuration script, NOT a [Package[]] declarative
+    bundle. The MarkMichaelis* family runs AFTER all install bundles to
+    reshape state.
+
+    Behavior:
+      - Idempotent: re-running is a no-op once state matches the
+        convention.
+      - Supports -WhatIf / -Confirm via $PSCmdlet.ShouldProcess on every
+        state-changing operation.
+      - Auto-migrates any account whose UserFolder doesn't match the
+        target convention. Same-volume migrations use Move-Item (NTFS
+        rename, preserves Cloud Files reparse + ACLs). Cross-volume
+        migrations use robocopy /MIR /COPYALL /DCOPY:DAT /B and warn
+        about Files-On-Demand placeholders.
+      - Rewrites KFM bindings (User Shell Folders / Shell Folders /
+        KNOWNFOLDERID GUIDs) when the owning account moves.
+      - Extensible per-app fix-up hook ($AppFixUps) ships empty;
+        Snagit is deliberately NOT included because its
+        CatalogFolder / ExternalOutputDir use the logical Documents
+        path and follow KFM transparently.
+
+.PARAMETER RootDir
+    Parent directory for all OneDrive sync roots. Default: C:\OneDrive.
+
+.PARAMETER KfmOwner
+    Account whose DisplayName identifies the canonical KFM owner.
+    Default: 'Michaelis'. Resolved via a substring/equality match
+    against the DisplayName of Business* registry slots.
+
+.PARAMETER NoKfmRebind
+    Suppress the warning + automatic rebind that fires when KFM is
+    currently bound to a different account than -KfmOwner.
+
+.EXAMPLE
+    .\MarkMichaelisOneDriveConfiguration.ps1 -WhatIf
+
+    Shows every move + registry write the script would perform without
+    changing any state.
+
+.EXAMPLE
+    .\MarkMichaelisOneDriveConfiguration.ps1
+
+    Run for real: pre-create $RootDir, apply policy, migrate any
+    mis-located accounts, rewrite KFM, restart OneDrive.
+#>
+[CmdletBinding(SupportsShouldProcess)]
+param(
+    [string] $RootDir   = 'C:\OneDrive',
+    [string] $KfmOwner  = 'Michaelis',
+    [switch] $NoKfmRebind
+)
+
+$ErrorActionPreference = 'Stop'
+
+# ---------------------------------------------------------------------------
+# Pure helpers (no side effects -- the unit tests target these directly).
+# ---------------------------------------------------------------------------
+
+function Get-OneDriveTargetPath {
+    <#
+    .SYNOPSIS
+        Compute the convention-correct local folder for an account.
+    .DESCRIPTION
+        Work tenants -> "$RootDir\OneDrive - <DisplayName>".
+        Personal      -> "$RootDir\OneDrive - Personal".
+    #>
+    [OutputType([string])]
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)][pscustomobject]$Account,
+        [Parameter(Mandatory)][string]$RootDir
+    )
+    if ($Account.AccountType -eq 'Personal') {
+        return (Join-Path $RootDir 'OneDrive - Personal')
+    }
+    $name = $Account.DisplayName
+    if ([string]::IsNullOrWhiteSpace($name)) {
+        throw "Account has no DisplayName; cannot compute target path."
+    }
+    return (Join-Path $RootDir ("OneDrive - {0}" -f $name))
+}
+
+function Test-IsSameVolume {
+    <#
+    .SYNOPSIS
+        True if two paths live on the same Windows volume (drive root).
+    .DESCRIPTION
+        Same-volume migrations can use Move-Item (NTFS rename, preserves
+        Cloud Files reparse points + ACLs). Cross-volume needs robocopy
+        with /COPYALL /DCOPY:DAT /B.
+    #>
+    [OutputType([bool])]
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)][string]$Source,
+        [Parameter(Mandatory)][string]$Destination
+    )
+    $srcRoot = [System.IO.Path]::GetPathRoot([System.IO.Path]::GetFullPath($Source))
+    $dstRoot = [System.IO.Path]::GetPathRoot([System.IO.Path]::GetFullPath($Destination))
+    return ($srcRoot -and $dstRoot -and
+            [string]::Equals($srcRoot, $dstRoot, [System.StringComparison]::OrdinalIgnoreCase))
+}
+
+function Resolve-KfmRebindAction {
+    <#
+    .SYNOPSIS
+        Decide what to do with the current KFM binding.
+    .DESCRIPTION
+        Inputs:
+          - $Accounts: list of discovered account records (with DisplayName,
+            UserFolder, AccountType).
+          - $KfmCurrentPath: current resolved Documents/Pictures path (or
+            $null if KFM is not active).
+          - $KfmOwner: the DisplayName substring of the desired owner.
+          - $NoKfmRebind: switch -- if set, suppress rebind.
+
+        Outputs an object with:
+          - Action: 'None' | 'Track' | 'Rebind' | 'WarnOnly' | 'OwnerNotSignedIn'
+          - OwnerAccount: the resolved account record, or $null
+          - Reason: human-readable explanation
+    #>
+    [OutputType([pscustomobject])]
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)][AllowEmptyCollection()][object[]]$Accounts,
+        [AllowNull()][string]$KfmCurrentPath,
+        [Parameter(Mandatory)][string]$KfmOwner,
+        [switch]$NoKfmRebind
+    )
+
+    $ownerAcct = $Accounts |
+        Where-Object { $_.AccountType -ne 'Personal' -and $_.DisplayName -and ($_.DisplayName -match [regex]::Escape($KfmOwner)) } |
+        Select-Object -First 1
+
+    if (-not $ownerAcct) {
+        return [pscustomobject]@{
+            Action       = 'OwnerNotSignedIn'
+            OwnerAccount = $null
+            Reason       = "KfmOwner '$KfmOwner' is not signed in to OneDrive (no Business* slot has matching DisplayName)."
+        }
+    }
+
+    if (-not $KfmCurrentPath) {
+        return [pscustomobject]@{
+            Action       = 'None'
+            OwnerAccount = $ownerAcct
+            Reason       = "KFM is not currently active; nothing to track."
+        }
+    }
+
+    $ownerFolder = $ownerAcct.UserFolder
+    if ($ownerFolder -and $KfmCurrentPath.StartsWith($ownerFolder, [System.StringComparison]::OrdinalIgnoreCase)) {
+        return [pscustomobject]@{
+            Action       = 'Track'
+            OwnerAccount = $ownerAcct
+            Reason       = "KFM is bound to the owner account ($($ownerAcct.DisplayName)); follow it when it moves."
+        }
+    }
+
+    if ($NoKfmRebind) {
+        return [pscustomobject]@{
+            Action       = 'WarnOnly'
+            OwnerAccount = $ownerAcct
+            Reason       = "KFM is bound to a non-owner account ('$KfmCurrentPath') but -NoKfmRebind was supplied; leaving it alone."
+        }
+    }
+
+    return [pscustomobject]@{
+        Action       = 'Rebind'
+        OwnerAccount = $ownerAcct
+        Reason       = "KFM is bound to a non-owner path ('$KfmCurrentPath'); rebind to $($ownerAcct.DisplayName)."
+    }
+}
+
+# ---------------------------------------------------------------------------
+# Side-effectful helpers (registry + filesystem). Each wraps every
+# state-changing call in $PSCmdlet.ShouldProcess so -WhatIf works.
+# ---------------------------------------------------------------------------
+
+$KnownFolderGuids = @(
+    '{F42EE2D3-909F-4907-8871-4C22FC0BF756}',  # Documents
+    '{0DDD015D-B06C-45D5-8C4C-F59713854639}',  # Pictures
+    '{B4BFCC3A-DB2C-424C-B029-7FE99A87C641}'   # Desktop
+)
+
+function Get-OneDriveAccountList {
+    <#
+    .SYNOPSIS
+        Enumerate OneDrive Business* + Personal accounts from HKCU.
+    #>
+    [OutputType([object[]])]
+    [CmdletBinding()]
+    param()
+
+    $results = New-Object System.Collections.Generic.List[object]
+    $root = 'HKCU:\Software\Microsoft\OneDrive\Accounts'
+    if (-not (Test-Path $root)) { return @() }
+
+    foreach ($slot in Get-ChildItem -Path $root -ErrorAction SilentlyContinue) {
+        $name = $slot.PSChildName
+        $isBusiness = $name -like 'Business*'
+        $isPersonal = $name -eq 'Personal'
+        if (-not ($isBusiness -or $isPersonal)) { continue }
+
+        $props = Get-ItemProperty -Path $slot.PSPath -ErrorAction SilentlyContinue
+        if (-not $props) { continue }
+
+        # Personal slot is only meaningful when populated (UserFolder set).
+        if ($isPersonal -and -not $props.UserFolder) { continue }
+
+        $tenantId = $props.ConfiguredTenantId
+        if (-not $tenantId) { $tenantId = $props.cid }
+
+        $results.Add([pscustomobject]@{
+            Slot              = $name
+            AccountType       = if ($isPersonal) { 'Personal' } else { 'Business' }
+            DisplayName       = $props.DisplayName
+            TenantId          = $tenantId
+            UserEmail         = $props.UserEmail
+            UserFolder        = $props.UserFolder
+            RegistryPath      = $slot.PSPath
+        }) | Out-Null
+    }
+    return $results.ToArray()
+}
+
+function Get-CurrentKfmPath {
+    <#
+    .SYNOPSIS
+        Read the resolved Documents path from Shell Folders, or $null.
+    #>
+    [OutputType([string])]
+    [CmdletBinding()]
+    param()
+    $shellFolders = 'HKCU:\Software\Microsoft\Windows\CurrentVersion\Explorer\Shell Folders'
+    if (-not (Test-Path $shellFolders)) { return $null }
+    $props = Get-ItemProperty -Path $shellFolders -ErrorAction SilentlyContinue
+    if (-not $props) { return $null }
+    return $props.Personal  # the "Personal" value here = Documents
+}
+
+function Set-OneDrivePolicy {
+    <#
+    .SYNOPSIS
+        Apply tenant-redirection policy (DefaultRootDir per Work tenant)
+        and the GPOSetUpdateRing policy in HKLM.
+    #>
+    [CmdletBinding(SupportsShouldProcess)]
+    param(
+        [Parameter(Mandatory)][object[]]$Accounts,
+        [Parameter(Mandatory)][string]$RootDir
+    )
+
+    $hkcuPolicy = 'HKCU:\SOFTWARE\Policies\Microsoft\OneDrive'
+    $hkcuDefRoot = "$hkcuPolicy\DefaultRootDir"
+    foreach ($key in @($hkcuPolicy, $hkcuDefRoot)) {
+        if (-not (Test-Path $key)) {
+            if ($PSCmdlet.ShouldProcess($key, 'Create registry key')) {
+                New-Item -Path $key -Force | Out-Null
+            }
+        }
+    }
+
+    foreach ($acct in $Accounts) {
+        if ($acct.AccountType -ne 'Business') { continue }
+        if (-not $acct.TenantId)              { continue }
+        if (-not $acct.DisplayName)           { continue }
+        $target = Join-Path $RootDir ("OneDrive - {0}" -f $acct.DisplayName)
+        $existing = (Get-ItemProperty -Path $hkcuDefRoot -Name $acct.TenantId -ErrorAction SilentlyContinue).$($acct.TenantId)
+        if ($existing -eq $target) { continue }
+        if ($PSCmdlet.ShouldProcess("$hkcuDefRoot\$($acct.TenantId)", "Set DefaultRootDir -> $target")) {
+            Set-ItemProperty -Path $hkcuDefRoot -Name $acct.TenantId -Value $target -Type String
+        }
+    }
+
+    $hklmPolicy = 'HKLM:\SOFTWARE\Policies\Microsoft\OneDrive'
+    if (-not (Test-Path $hklmPolicy)) {
+        if ($PSCmdlet.ShouldProcess($hklmPolicy, 'Create registry key')) {
+            try { New-Item -Path $hklmPolicy -Force | Out-Null } catch {
+                Write-Warning "Could not create $hklmPolicy (requires elevation): $($_.Exception.Message)"
+                return
+            }
+        }
+    }
+    $existingRing = (Get-ItemProperty -Path $hklmPolicy -Name 'GPOSetUpdateRing' -ErrorAction SilentlyContinue).GPOSetUpdateRing
+    if ($existingRing -ne 4) {
+        if ($PSCmdlet.ShouldProcess("$hklmPolicy\GPOSetUpdateRing", 'Set DWord = 4 (Deferred ring)')) {
+            try {
+                Set-ItemProperty -Path $hklmPolicy -Name 'GPOSetUpdateRing' -Value 4 -Type DWord
+            } catch {
+                Write-Warning "Could not set GPOSetUpdateRing (requires elevation): $($_.Exception.Message)"
+            }
+        }
+    }
+}
+
+function Stop-OneDriveExe {
+    [CmdletBinding(SupportsShouldProcess)]
+    param()
+    $exe = Join-Path $env:LOCALAPPDATA 'Microsoft\OneDrive\OneDrive.exe'
+    if (-not (Test-Path $exe)) { $exe = 'OneDrive.exe' }
+    if ($PSCmdlet.ShouldProcess('OneDrive.exe', '/shutdown')) {
+        try { & $exe /shutdown 2>$null } catch { }
+        # Best-effort wait: poll for process exit up to 10s.
+        for ($i = 0; $i -lt 20; $i++) {
+            if (-not (Get-Process -Name 'OneDrive' -ErrorAction SilentlyContinue)) { break }
+            Start-Sleep -Milliseconds 500
+        }
+    }
+}
+
+function Start-OneDriveExe {
+    [CmdletBinding(SupportsShouldProcess)]
+    param()
+    $exe = Join-Path $env:LOCALAPPDATA 'Microsoft\OneDrive\OneDrive.exe'
+    if (-not (Test-Path $exe)) { $exe = 'OneDrive.exe' }
+    if ($PSCmdlet.ShouldProcess('OneDrive.exe', 'start (background)')) {
+        try { Start-Process -FilePath $exe -ArgumentList '/background' -WindowStyle Hidden | Out-Null } catch {
+            Write-Warning "Failed to start OneDrive: $($_.Exception.Message)"
+        }
+    }
+}
+
+function Move-OneDriveFolder {
+    <#
+    .SYNOPSIS
+        Move an account's UserFolder from $Source to $Destination,
+        using NTFS rename when possible and robocopy /MIR /COPYALL
+        otherwise. Throws on failure (leaves source in place).
+    #>
+    [CmdletBinding(SupportsShouldProcess)]
+    param(
+        [Parameter(Mandatory)][string]$Source,
+        [Parameter(Mandatory)][string]$Destination
+    )
+
+    if (-not (Test-Path $Source)) {
+        Write-Verbose "Source '$Source' does not exist; treating as new account folder."
+        return
+    }
+    if ((Test-Path $Destination) -and ((Get-Item $Destination).FullName -ieq (Get-Item $Source).FullName)) {
+        return
+    }
+    if (Test-Path $Destination) {
+        throw "Refusing to merge: destination '$Destination' already exists. Resolve manually."
+    }
+
+    $parent = Split-Path -Parent $Destination
+    if (-not (Test-Path $parent)) {
+        if ($PSCmdlet.ShouldProcess($parent, 'Create parent directory')) {
+            New-Item -ItemType Directory -Path $parent -Force | Out-Null
+        }
+    }
+
+    if (Test-IsSameVolume -Source $Source -Destination $Destination) {
+        if ($PSCmdlet.ShouldProcess($Source, "Move-Item -> $Destination (same volume)")) {
+            Move-Item -LiteralPath $Source -Destination $Destination
+        }
+    } else {
+        Write-Warning "Cross-volume migration: Files-On-Demand placeholders will be materialized by robocopy. To force-hydrate cloud-only files first, run: attrib -O '$Source\*' /S /D"
+        if ($PSCmdlet.ShouldProcess($Source, "robocopy /MIR /COPYALL -> $Destination (cross volume)")) {
+            $args = @($Source, $Destination, '/MIR','/COPYALL','/DCOPY:DAT','/B','/R:1','/W:1','/XJ','/NFL','/NDL')
+            & robocopy @args | Out-Null
+            $rc = $LASTEXITCODE
+            # robocopy success: 0-7. >=8 is failure.
+            if ($rc -ge 8) {
+                throw "robocopy failed (exit $rc) -- leaving source '$Source' in place."
+            }
+            if ($PSCmdlet.ShouldProcess($Source, 'Remove-Item -Recurse (after successful robocopy)')) {
+                Remove-Item -LiteralPath $Source -Recurse -Force
+            }
+        }
+    }
+}
+
+function Update-OneDriveAccountRegistry {
+    <#
+    .SYNOPSIS
+        Update OneDrive's per-account registry so it knows where the
+        UserFolder lives after a move.
+    #>
+    [CmdletBinding(SupportsShouldProcess)]
+    param(
+        [Parameter(Mandatory)][pscustomobject]$Account,
+        [Parameter(Mandatory)][string]$NewPath
+    )
+    $regPath = $Account.RegistryPath
+    if ($PSCmdlet.ShouldProcess("$regPath\UserFolder", "Set -> $NewPath")) {
+        Set-ItemProperty -Path $regPath -Name 'UserFolder' -Value $NewPath -Type String
+    }
+    foreach ($valueName in 'ScopeIdToMountPointPathCache','ScopeIdToMountPointPathCacheRoot') {
+        $cacheKey = Join-Path $regPath $valueName
+        if (-not (Test-Path $cacheKey)) { continue }
+        $props = Get-ItemProperty -Path $cacheKey -ErrorAction SilentlyContinue
+        if (-not $props) { continue }
+        foreach ($pName in $props.PSObject.Properties.Name) {
+            if ($pName -like 'PS*') { continue }
+            $cur = $props.$pName
+            if ($cur -is [string] -and $Account.UserFolder -and
+                $cur.StartsWith($Account.UserFolder, [System.StringComparison]::OrdinalIgnoreCase)) {
+                $new = $NewPath + $cur.Substring($Account.UserFolder.Length)
+                if ($PSCmdlet.ShouldProcess("$cacheKey\$pName", "Rewrite '$cur' -> '$new'")) {
+                    Set-ItemProperty -Path $cacheKey -Name $pName -Value $new
+                }
+            }
+        }
+    }
+}
+
+function Update-KfmBindings {
+    <#
+    .SYNOPSIS
+        Rewrite User Shell Folders / Shell Folders / KNOWNFOLDERID GUID
+        entries that point under $OldRoot so they now point under
+        $NewRoot.
+    #>
+    [CmdletBinding(SupportsShouldProcess)]
+    param(
+        [Parameter(Mandatory)][string]$OldRoot,
+        [Parameter(Mandatory)][string]$NewRoot
+    )
+
+    foreach ($leaf in 'User Shell Folders','Shell Folders') {
+        $key = "HKCU:\Software\Microsoft\Windows\CurrentVersion\Explorer\$leaf"
+        if (-not (Test-Path $key)) { continue }
+        $props = Get-ItemProperty -Path $key -ErrorAction SilentlyContinue
+        if (-not $props) { continue }
+        foreach ($pName in $props.PSObject.Properties.Name) {
+            if ($pName -like 'PS*') { continue }
+            $cur = [string]$props.$pName
+            if ($cur.StartsWith($OldRoot, [System.StringComparison]::OrdinalIgnoreCase)) {
+                $new = $NewRoot + $cur.Substring($OldRoot.Length)
+                if ($PSCmdlet.ShouldProcess("$key\$pName", "Rewrite '$cur' -> '$new'")) {
+                    # User Shell Folders uses ExpandString templates; Shell
+                    # Folders is plain String. Preserve whichever type the
+                    # value already had.
+                    $kind = (Get-Item -LiteralPath $key).GetValueKind($pName)
+                    Set-ItemProperty -Path $key -Name $pName -Value $new -Type $kind
+                }
+            }
+        }
+    }
+
+    foreach ($guid in $KnownFolderGuids) {
+        $key = "HKCU:\Software\Microsoft\Windows\CurrentVersion\Explorer\FolderDescriptions\$guid"
+        if (-not (Test-Path $key)) { continue }
+        $props = Get-ItemProperty -Path $key -ErrorAction SilentlyContinue
+        if (-not $props) { continue }
+        foreach ($pName in 'RelativePath','ParsingName') {
+            $cur = [string]$props.$pName
+            if ($cur -and $cur.StartsWith($OldRoot, [System.StringComparison]::OrdinalIgnoreCase)) {
+                $new = $NewRoot + $cur.Substring($OldRoot.Length)
+                if ($PSCmdlet.ShouldProcess("$key\$pName", "Rewrite '$cur' -> '$new'")) {
+                    Set-ItemProperty -Path $key -Name $pName -Value $new
+                }
+            }
+        }
+    }
+}
+
+# ---------------------------------------------------------------------------
+# Extensible per-app fix-up hook.
+#
+# Snagit is deliberately NOT included: its CatalogFolder /
+# ExternalOutputDir use the logical Documents path
+# (%USERPROFILE%\Documents or the KFM-redirected Documents target), so
+# it follows KFM transparently without needing a registry rewrite.
+# ---------------------------------------------------------------------------
+
+$AppFixUps = @{
+    # Example shape (left empty by design):
+    #
+    # 'HKCU:\Software\SomeVendor\SomeApp' = @{
+    #     'SomeValueName' = { param($old, $new) $current = (Get-ItemProperty $key $name).$name; ... }
+    # }
+}
+
+function Invoke-AppFixUps {
+    [CmdletBinding(SupportsShouldProcess)]
+    param(
+        [Parameter(Mandatory)][string]$OldRoot,
+        [Parameter(Mandatory)][string]$NewRoot
+    )
+    foreach ($regPath in $AppFixUps.Keys) {
+        if (-not (Test-Path $regPath)) { continue }
+        foreach ($valueName in $AppFixUps[$regPath].Keys) {
+            $sb = $AppFixUps[$regPath][$valueName]
+            if ($PSCmdlet.ShouldProcess("$regPath\$valueName", 'Run app fix-up scriptblock')) {
+                & $sb $OldRoot $NewRoot
+            }
+        }
+    }
+}
+
+# ---------------------------------------------------------------------------
+# Main orchestration. Skipped when the script is dot-sourced (so unit
+# tests can pull in just the helper functions above).
+# ---------------------------------------------------------------------------
+
+function Invoke-MarkMichaelisOneDriveConfiguration {
+    [CmdletBinding(SupportsShouldProcess)]
+    param(
+        [Parameter(Mandatory)][string]$RootDir,
+        [Parameter(Mandatory)][string]$KfmOwner,
+        [switch]$NoKfmRebind
+    )
+
+    Write-Host "MarkMichaelisOneDriveConfiguration: RootDir=$RootDir, KfmOwner=$KfmOwner"
+
+    # 1. Pre-create $RootDir.
+    if (-not (Test-Path $RootDir)) {
+        if ($PSCmdlet.ShouldProcess($RootDir, 'Create directory')) {
+            New-Item -ItemType Directory -Path $RootDir -Force | Out-Null
+        }
+    }
+
+    # 2. Discover accounts.
+    $accounts = Get-OneDriveAccountList
+    Write-Host "  Discovered $($accounts.Count) account(s):"
+    foreach ($a in $accounts) {
+        Write-Host ("    [{0}] {1} <{2}> -> {3}" -f $a.AccountType, $a.DisplayName, $a.UserEmail, $a.UserFolder)
+    }
+
+    # 3. Pre-create per-account target directories under $RootDir.
+    foreach ($a in $accounts) {
+        $target = Get-OneDriveTargetPath -Account $a -RootDir $RootDir
+        if (-not (Test-Path $target)) {
+            if ($PSCmdlet.ShouldProcess($target, 'Create directory')) {
+                New-Item -ItemType Directory -Path $target -Force | Out-Null
+            }
+        }
+    }
+
+    # 4. KFM decision (computed before any moves so we know who to track).
+    $kfmCurrent = Get-CurrentKfmPath
+    $kfmDecision = Resolve-KfmRebindAction -Accounts $accounts -KfmCurrentPath $kfmCurrent `
+        -KfmOwner $KfmOwner -NoKfmRebind:$NoKfmRebind
+    Write-Host "  KFM: [$($kfmDecision.Action)] $($kfmDecision.Reason)"
+    if ($kfmDecision.Action -eq 'OwnerNotSignedIn') {
+        throw "KFM owner '$KfmOwner' is not signed in. Sign in to the matching Work account in OneDrive and re-run."
+    }
+
+    # 5. Apply policy.
+    Set-OneDrivePolicy -Accounts $accounts -RootDir $RootDir
+
+    # 6. Compute migration plan (account -> target) and execute.
+    $stoppedOneDrive = $false
+    $migrations = @()
+    foreach ($a in $accounts) {
+        $target = Get-OneDriveTargetPath -Account $a -RootDir $RootDir
+        if ($a.UserFolder -and (Test-Path $a.UserFolder) -and
+            ($a.UserFolder.TrimEnd('\') -ine $target.TrimEnd('\'))) {
+            $migrations += [pscustomobject]@{ Account = $a; OldPath = $a.UserFolder; NewPath = $target }
+        }
+    }
+
+    if ($migrations.Count -gt 0) {
+        Stop-OneDriveExe
+        $stoppedOneDrive = $true
+        foreach ($m in $migrations) {
+            try {
+                Write-Host "  Migrating $($m.Account.DisplayName): $($m.OldPath) -> $($m.NewPath)"
+                Move-OneDriveFolder -Source $m.OldPath -Destination $m.NewPath
+                Update-OneDriveAccountRegistry -Account $m.Account -NewPath $m.NewPath
+
+                # Rewrite KFM if this account is the (tracked) owner.
+                if ($kfmDecision.Action -eq 'Track' -and
+                    $kfmDecision.OwnerAccount -and
+                    $kfmDecision.OwnerAccount.Slot -eq $m.Account.Slot) {
+                    Update-KfmBindings -OldRoot $m.OldPath -NewRoot $m.NewPath
+                }
+                Invoke-AppFixUps -OldRoot $m.OldPath -NewRoot $m.NewPath
+            } catch {
+                Write-Error "Migration failed for $($m.Account.DisplayName): $($_.Exception.Message). Source left in place; OneDrive NOT restarted."
+                throw
+            }
+        }
+    }
+
+    # 7. Handle Rebind / WarnOnly cases.
+    if ($kfmDecision.Action -eq 'Rebind' -and $kfmDecision.OwnerAccount) {
+        $ownerTarget = Get-OneDriveTargetPath -Account $kfmDecision.OwnerAccount -RootDir $RootDir
+        $kfmRoot = $kfmCurrent
+        # Trim to drive root if it doesn't match a known account folder.
+        if ($PSCmdlet.ShouldProcess("KFM root '$kfmRoot' -> '$ownerTarget'", "Rebind KFM")) {
+            Update-KfmBindings -OldRoot $kfmRoot -NewRoot $ownerTarget
+        }
+    } elseif ($kfmDecision.Action -eq 'WarnOnly') {
+        Write-Warning $kfmDecision.Reason
+    }
+
+    if ($stoppedOneDrive) {
+        Start-OneDriveExe
+    }
+
+    # 8. Banner.
+    Write-Host ""
+    Write-Host "MarkMichaelisOneDriveConfiguration complete:"
+    Write-Host "  Accounts found:   $($accounts.Count)"
+    Write-Host "  Migrations:       $($migrations.Count)"
+    Write-Host "  KFM action:       $($kfmDecision.Action)"
+    Write-Host ""
+    Write-Warning "MRU staleness: Office recent docs / Snagit Recent File List / VS recent files may reference old OneDrive paths; reopen as needed."
+}
+
+# Only run when invoked as a script (Scoop's installer does
+# `& "$dir\MarkMichaelisOneDriveConfiguration.ps1"`). When dot-sourced
+# (Pester tests), expose the helpers without running migration.
+if ($MyInvocation.InvocationName -ne '.') {
+    Invoke-MarkMichaelisOneDriveConfiguration -RootDir $RootDir -KfmOwner $KfmOwner -NoKfmRebind:$NoKfmRebind
+}

--- a/bucket/MicrosoftOffice365.json
+++ b/bucket/MicrosoftOffice365.json
@@ -1,6 +1,6 @@
 {
     "$schema": "https://raw.githubusercontent.com/lukesampson/scoop/master/schema.json",
-    "version": "1.12.000",
+    "version": "1.13.000",
     "url": [
         "https://raw.githubusercontent.com/MarkMichaelis/ScoopBucket/master/bucket/MicrosoftOffice365.ps1"
     ],

--- a/bucket/MicrosoftOffice365.ps1
+++ b/bucket/MicrosoftOffice365.ps1
@@ -443,36 +443,8 @@ Register-ArgumentCompleter -Native -CommandName $Cli -ScriptBlock {
 
 Invoke-PackageInstall -Packages $Packages -Bundle 'MicrosoftOffice365'
 
-# OneDrive tenant-redirection policy. Tied to Office, not a package, so it
-# runs after the package pass instead of being modelled as a Package entry.
-Function Get-Office365TenantId {
-    [OutputType([string])]
-    [CmdletBinding()]
-    param(
-        [Parameter(Mandatory,ValueFromPipeline)][string]$TenantName
-    )
-    Invoke-RestMethod -Uri "https://login.windows.net/$TenantName.onmicrosoft.com/.well-known/openid-configuration" -UseBasicParsing | `
-        Select-Object 'token_endpoint' | Where-Object {
-            $_ -match 'https://login.windows.net/(?<TenantId>.+)/oauth2/token'
-        } | ForEach-Object { [PSCustomObject]$matches } | Select-Object TenantId
-}
-
-Function Set-OneDriveConfig {
-    if (-not (Test-Path 'HKCU:\SOFTWARE\Policies\Microsoft\OneDrive')) {
-        New-Item -Path 'HKCU:\SOFTWARE\Policies\Microsoft\OneDrive' | Out-Null
-    }
-    if (-not (Test-Path 'HKCU:\SOFTWARE\Policies\Microsoft\OneDrive\DefaultRootDir')) {
-        New-Item -Path 'HKCU:\SOFTWARE\Policies\Microsoft\OneDrive\DefaultRootDir' | Out-Null
-    }
-    Set-ItemProperty -Path 'HKCU:\SOFTWARE\Policies\Microsoft\OneDrive\DefaultRootDir' `
-        -Name "$(Get-Office365TenantId 'IntelliTectSP')" -Value 'C:\OneDrive\IntelliTect'
-    Set-ItemProperty -Path 'HKCU:\SOFTWARE\Policies\Microsoft\OneDrive\DefaultRootDir' `
-        -Name "$(Get-Office365TenantId 'Michaelises')"  -Value 'C:\OneDrive\Michaelises'
-
-    Set-ItemProperty -Path 'HKLM:\SOFTWARE\Policies\Microsoft\OneDrive' `
-        -Name 'GPOSetUpdateRing' -Value 'dword:00000004'
-}
-
-try { Set-OneDriveConfig } catch {
-    Write-Warning "Set-OneDriveConfig failed: $($_.Exception.Message)"
-}
+# OneDrive tenant-redirection policy and KFM rewriting moved to the
+# personal post-install customization bundle
+# MarkMichaelisOneDriveConfiguration. That bundle runs AFTER all install
+# bundles to reshape state (sync roots, KFM, per-app settings) and is
+# the first member of the MarkMichaelis* run-last category.


### PR DESCRIPTION
## Summary

Adds a new `MarkMichaelis*` personal post-install customization bundle category. These bundles run AFTER all install bundles to reshape state (sync roots, KFM, per-app settings) rather than installing software.

First member: `MarkMichaelisOneDriveConfiguration`.

## What ships

**New bundle: `bucket/MarkMichaelisOneDriveConfiguration.ps1` + `.json` (v1.00.000)**

- Free-form config bundle (pattern: `GitConfigure.ps1` / `SetPowerConfiguration.ps1`), not a `[Package[]]` array.
- Signature: `-RootDir 'C:\OneDrive' -KfmOwner 'Michaelis' -NoKfmRebind`.
- Idempotent, `-WhatIf` safe (every state change wrapped in `ShouldProcess`).
- Discovers Business* + populated Personal slots from `HKCU:\Software\Microsoft\OneDrive\Accounts`.
- Sets policy idempotently: per-tenant `DefaultRootDir` under HKCU; `GPOSetUpdateRing` as a real `DWord 4` in HKLM (not the buggy `'dword:00000004'` string the old code wrote).
- Computes convention paths: Work -> `OneDrive - <DisplayName>`, Personal -> `OneDrive - Personal`.
- Auto-migrates mismatched accounts: same-volume uses `Move-Item` (NTFS rename, preserves Cloud Files reparse + ACLs); cross-volume uses `robocopy /MIR /COPYALL /DCOPY:DAT /B /R:1 /W:1 /XJ` with a Files-On-Demand hydration warning.
- Updates OneDrive registry: `UserFolder` plus `ScopeIdToMountPointPathCache` / `ScopeIdToMountPointPathCacheRoot`.
- Rewrites KFM bindings: `User Shell Folders` (preserves ExpandString type), `Shell Folders`, and `KNOWNFOLDERID` GUIDs for Documents / Pictures / Desktop.
- KFM owner logic: `Resolve-KfmRebindAction` returns Track / Rebind / WarnOnly / None / OwnerNotSignedIn based on owner DisplayName match against Business* slots.
- Extensible `` hook (ships empty). Snagit deliberately NOT included (its `CatalogFolder` / `ExternalOutputDir` follow the logical Documents path transparently).
- On any migration failure: source left in place, OneDrive NOT restarted, throws.

**Tests: `bucket/MarkMichaelisOneDriveConfiguration.Tests.ps1` (14 tests)**

- `Get-OneDriveTargetPath`: Work/Personal/custom-root/missing-DisplayName.
- `Test-IsSameVolume`: same-drive / cross-drive / case-insensitive.
- `Resolve-KfmRebindAction`: Track / Rebind / WarnOnly / None / OwnerNotSignedIn (including the Personal-slot exclusion edge case).

**Refactor: `bucket/MicrosoftOffice365.ps1`**

- Deletes `Get-Office365TenantId`, `Set-OneDriveConfig`, and the trailing `try { Set-OneDriveConfig } catch` block. The new bundle supersedes it with correct behavior (real `DWord`, account discovery from registry instead of hard-coded tenant names, KFM rewriting, folder migration).
- `MicrosoftOffice365.json`: `1.12.000` -> `1.13.000`.

**Docs: `README.md`**

- New section "Personal post-install customization (`MarkMichaelis*` bundles)" explaining the run-last category and intended ordering.

## Verification

```powershell
Invoke-Pester -Path .\bucket\Bundles.Tests.ps1,.\bucket\MarkMichaelisOneDriveConfiguration.Tests.ps1
# 806 passed, 1 skipped (unchanged from main: PSCompletionsCatalog probe), 0 failed

.\Test-ManifestVersionBumps.ps1
# All 35 manifest(s) have up-to-date version bumps.
```

## Notes

- Implementation only; the migration was NOT executed on this machine. User will smoke-test with `-WhatIf` then a real run after merge.
- `-WhatIf` works end-to-end: every registry write, file move, `OneDrive.exe /shutdown`, and `OneDrive.exe /background` is gated by `ShouldProcess`.

Closes #187