### PR TITLE
fix(MarkMichaelisOneDriveConfiguration): skip zombie Business slots

### DIFF
--- a/bucket/MarkMichaelisOneDriveConfiguration.Tests.ps1
+++ b/bucket/MarkMichaelisOneDriveConfiguration.Tests.ps1
@@ -177,3 +177,74 @@ Describe 'Resolve-KfmRebindAction' -Tag 'Light' {
         $result.Action | Should -Be 'OwnerNotSignedIn'
     }
 }
+
+Describe 'Get-OneDriveAccountList (zombie slot filter)' -Tag 'Light' {
+    # Regression for issue #192: a Business slot left over from a failed
+    # sign-in has no DisplayName / UserFolder / UserEmail and must be
+    # skipped, else Get-OneDriveTargetPath throws downstream.
+
+    BeforeAll {
+        function New-FakeSlot {
+            param([string]$Name, [hashtable]$Props)
+            [pscustomobject]@{
+                PSChildName = $Name
+                PSPath      = "TestRegistry::OneDrive\Accounts\$Name"
+                _Props      = [pscustomobject]$Props
+            }
+        }
+    }
+
+    It 'skips a Business slot with empty DisplayName and UserFolder' {
+        $real = New-FakeSlot 'Business1' @{
+            DisplayName        = 'IntelliTect'
+            ConfiguredTenantId = 'tid-1'
+            UserEmail          = 'a@example.com'
+            UserFolder         = 'C:\Users\me\OneDrive - IntelliTect'
+        }
+        $zombie = New-FakeSlot 'Business2' @{
+            DisplayName        = $null
+            ConfiguredTenantId = $null
+            UserEmail          = $null
+            UserFolder         = $null
+        }
+
+        Mock -CommandName Test-Path -ParameterFilter {
+            $Path -eq 'HKCU:\Software\Microsoft\OneDrive\Accounts'
+        } -MockWith { $true }
+
+        Mock -CommandName Get-ChildItem -ParameterFilter {
+            $Path -eq 'HKCU:\Software\Microsoft\OneDrive\Accounts'
+        } -MockWith { @($real, $zombie) }
+
+        Mock -CommandName Get-ItemProperty -MockWith {
+            param($Path)
+            ($real, $zombie | Where-Object { $_.PSPath -eq $Path } | Select-Object -First 1)._Props
+        }
+
+        $accounts = Get-OneDriveAccountList
+        $accounts | Should -HaveCount 1
+        $accounts[0].Slot | Should -Be 'Business1'
+        $accounts[0].DisplayName | Should -Be 'IntelliTect'
+    }
+
+    It 'skips a Business slot with DisplayName but no UserFolder' {
+        $halfZombie = New-FakeSlot 'Business1' @{
+            DisplayName        = 'Foo'
+            ConfiguredTenantId = 'tid-1'
+            UserEmail          = 'a@example.com'
+            UserFolder         = $null
+        }
+
+        Mock -CommandName Test-Path -ParameterFilter {
+            $Path -eq 'HKCU:\Software\Microsoft\OneDrive\Accounts'
+        } -MockWith { $true }
+
+        Mock -CommandName Get-ChildItem -ParameterFilter {
+            $Path -eq 'HKCU:\Software\Microsoft\OneDrive\Accounts'
+        } -MockWith { @($halfZombie) }
+
+        Mock -CommandName Get-ItemProperty -MockWith { $halfZombie._Props }
+
+        Get-OneDriveAccountList | Should -BeNullOrEmpty
+    }
+}

--- a/bucket/MarkMichaelisOneDriveConfiguration.json
+++ b/bucket/MarkMichaelisOneDriveConfiguration.json
@@ -1,6 +1,6 @@
 {
     "$schema": "https://raw.githubusercontent.com/lukesampson/scoop/master/schema.json",
-    "version": "1.01.000",
+    "version": "1.02.000",
     "description": "Personal post-install customization bundle (member of the MarkMichaelis* run-last family). Pins OneDrive sync roots under a single parent, applies tenant-redirection policy, and rewrites KFM bindings to follow the canonical Work account. Runs AFTER all install bundles; reshapes state rather than installing software.",
     "url": [
         "https://raw.githubusercontent.com/MarkMichaelis/ScoopBucket/master/bucket/MarkMichaelisOneDriveConfiguration.ps1"

--- a/bucket/MarkMichaelisOneDriveConfiguration.ps1
+++ b/bucket/MarkMichaelisOneDriveConfiguration.ps1
@@ -222,6 +222,14 @@ function Get-OneDriveAccountList {
         # Personal slot is only meaningful when populated (UserFolder set).
         if ($isPersonal -and -not $props.UserFolder) { continue }
 
+        # Business slot may be a zombie left over from a failed sign-in:
+        # no DisplayName, no UserFolder, no UserEmail. Skip it -- there is
+        # nothing to compute a target path from and nothing to migrate.
+        if ($isBusiness -and (-not $props.DisplayName -or -not $props.UserFolder)) {
+            Write-Verbose "Skipping empty/zombie Business slot '$name' (no DisplayName or UserFolder)."
+            continue
+        }
+
         $tenantId = $props.ConfiguredTenantId
         if (-not $tenantId) { $tenantId = $props.cid }
 


### PR DESCRIPTION
## Summary

Fixes [#192](https://github.com/MarkMichaelis/ScoopBucket/issues/192).

A half-initialized OneDrive Business slot left over from a failed sign-in
has empty DisplayName, UserFolder, and UserEmail. `Get-OneDriveAccountList`
recorded it anyway, causing `Get-OneDriveTargetPath` to throw on the
pre-create-directory pass on the user's machine.

Filter zombie Business slots in `Get-OneDriveAccountList`, mirroring
the existing Personal-slot filter (`if -not UserFolder; continue`).

## Verification

- 16 / 16 pure-function tests pass (2 new regression tests):
  - skips a Business slot with empty DisplayName and UserFolder
  - skips a Business slot with DisplayName but no UserFolder
- 792 / 793 Bundles.Tests pass (1 pre-existing skip)
- Test-ManifestVersionBumps clean (1.01.000 -> 1.02.000)
- `-WhatIf` on author's machine now discovers 3 real accounts (Michaelis Work, IntelliTect Work, Personal) and skips the zombie Business slot. Full migration plan generates correctly.

Closes #192