### PR TITLE
feat(MarkMichaelisOneDriveConfiguration): harden RootDir ACL to match home dir

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,7 +173,9 @@ Current members:
   sign-ins land in the right place, and rewrites KFM bindings (Known
   Folder Move: Documents / Pictures / Desktop) to follow the canonical
   Work account when its folder moves. Supports `-WhatIf` for dry-run
-  preview before a real migration.
+  preview before a real migration. On creation, the `RootDir` ACL is
+  hardened to match home-directory permissions so sync roots on
+  alternate volumes are not readable by other local accounts.
 
   For Business tenants with large cloud-only datasets (where a
   cross-volume robocopy migration would hydrate every Files-On-Demand

--- a/bucket/MarkMichaelisOneDriveConfiguration.Tests.ps1
+++ b/bucket/MarkMichaelisOneDriveConfiguration.Tests.ps1
@@ -249,6 +249,60 @@ Describe 'Get-OneDriveAccountList (zombie slot filter)' -Tag 'Light' {
     }
 }
 
+Describe 'Set-RootDirAclFromHome' -Tag 'Light' {
+    It 'does not call Set-Acl when -WhatIf is supplied' {
+        Mock -CommandName Set-Acl -MockWith {}
+        Mock -CommandName Get-Acl -MockWith {
+            [pscustomobject]@{ Sddl = 'O:S-1-5-21-fake' }
+        }
+
+        Set-RootDirAclFromHome -Path 'TestDrive:\nope' -ReferencePath 'TestDrive:\home' -WhatIf
+
+        Should -Invoke -CommandName Set-Acl -Times 0 -Exactly
+    }
+
+    It 'calls Set-Acl with the reference ACL when not in WhatIf' {
+        $synthetic = [pscustomobject]@{ Sddl = 'O:S-1-5-21-synthetic' }
+        Mock -CommandName Set-Acl -MockWith {}
+
+        Set-RootDirAclFromHome -Path 'TestDrive:\target' -ReferenceAcl $synthetic
+
+        Should -Invoke -CommandName Set-Acl -Times 1 -Exactly -ParameterFilter {
+            $LiteralPath -eq 'TestDrive:\target' -and $AclObject -eq $synthetic
+        }
+    }
+
+    It 'reads the reference ACL via Get-Acl on $ReferencePath when -ReferenceAcl is not supplied' {
+        $synthetic = [pscustomobject]@{ Sddl = 'O:S-1-5-21-fromhome' }
+        Mock -CommandName Get-Acl -MockWith { $synthetic } -ParameterFilter {
+            $LiteralPath -eq 'TestDrive:\home'
+        }
+        Mock -CommandName Set-Acl -MockWith {}
+
+        Set-RootDirAclFromHome -Path 'TestDrive:\target' -ReferencePath 'TestDrive:\home'
+
+        Should -Invoke -CommandName Get-Acl -Times 1 -Exactly -ParameterFilter {
+            $LiteralPath -eq 'TestDrive:\home'
+        }
+        Should -Invoke -CommandName Set-Acl -Times 1 -Exactly -ParameterFilter {
+            $AclObject -eq $synthetic
+        }
+    }
+
+    It 'still calls Set-Acl on the target even when the target path does not exist (mock-only)' {
+        # The helper is a pure transform: it doesn't probe the target.
+        # The orchestrator is responsible for sequencing Create-then-ACL.
+        $synthetic = [pscustomobject]@{ Sddl = 'O:S-1-5-21-x' }
+        Mock -CommandName Set-Acl -MockWith {}
+
+        Set-RootDirAclFromHome -Path 'TestDrive:\does-not-exist' -ReferenceAcl $synthetic
+
+        Should -Invoke -CommandName Set-Acl -Times 1 -Exactly -ParameterFilter {
+            $LiteralPath -eq 'TestDrive:\does-not-exist'
+        }
+    }
+}
+
 Describe 'Resolve-FreshSyncAccounts' -Tag 'Light' {
     BeforeAll {
         $script:b1 = [pscustomobject]@{

--- a/bucket/MarkMichaelisOneDriveConfiguration.json
+++ b/bucket/MarkMichaelisOneDriveConfiguration.json
@@ -1,6 +1,6 @@
 {
     "$schema": "https://raw.githubusercontent.com/lukesampson/scoop/master/schema.json",
-    "version": "1.03.000",
+    "version": "1.04.000",
     "description": "Personal post-install customization bundle (member of the MarkMichaelis* run-last family). Pins OneDrive sync roots under a single parent, applies tenant-redirection policy, and rewrites KFM bindings to follow the canonical Work account. Runs AFTER all install bundles; reshapes state rather than installing software.",
     "url": [
         "https://raw.githubusercontent.com/MarkMichaelis/ScoopBucket/master/bucket/MarkMichaelisOneDriveConfiguration.ps1"

--- a/bucket/MarkMichaelisOneDriveConfiguration.ps1
+++ b/bucket/MarkMichaelisOneDriveConfiguration.ps1
@@ -107,6 +107,40 @@ function Get-OneDriveTargetPath {
     return ([System.IO.Path]::Combine($RootDir, ("OneDrive - {0}" -f $name)))
 }
 
+function Set-RootDirAclFromHome {
+    <#
+    .SYNOPSIS
+        Copy the ACL from the user's home directory onto $Path.
+    .DESCRIPTION
+        When $RootDir is created on a volume other than the system
+        drive (e.g. D:\OneDrive), it inherits the volume-root ACL,
+        which on a default Windows install grants Read+Execute to
+        BUILTIN\Users. That makes the OneDrive sync root readable
+        by every local account on the box.
+
+        This helper copies the explicit ACL from the user's home
+        directory (which Windows provisions as user-only) onto the
+        target path so the sync root is hardened to match home-dir
+        permissions. Gated by $PSCmdlet.ShouldProcess so -WhatIf
+        previews the intended Set-Acl call.
+
+        Accepts an optional -ReferenceAcl so unit tests can supply
+        a synthetic ACL without touching the real filesystem.
+    #>
+    [CmdletBinding(SupportsShouldProcess)]
+    param(
+        [Parameter(Mandatory)][string] $Path,
+        [string] $ReferencePath = $env:USERPROFILE,
+        [object] $ReferenceAcl
+    )
+    if (-not $ReferenceAcl) {
+        $ReferenceAcl = Get-Acl -LiteralPath $ReferencePath
+    }
+    if ($PSCmdlet.ShouldProcess($Path, "Apply ACL from '$ReferencePath'")) {
+        Set-Acl -LiteralPath $Path -AclObject $ReferenceAcl
+    }
+}
+
 function Test-IsSameVolume {
     <#
     .SYNOPSIS
@@ -621,10 +655,23 @@ function Invoke-MarkMichaelisOneDriveConfiguration {
         Write-Host "  FreshSync requested: $($FreshSync -join ', ')"
     }
 
-    # 1. Pre-create $RootDir.
+    # 1. Pre-create $RootDir and harden its ACL to match $env:USERPROFILE.
+    #    On alternate volumes (e.g. D:\OneDrive), a freshly-created
+    #    directory inherits the volume-root ACL which grants Read+Execute
+    #    to BUILTIN\Users. Copy the home-dir ACL so the sync root is
+    #    user-only, matching what Windows provisions for C:\Users\<me>.
     if (-not (Test-Path $RootDir)) {
         if ($PSCmdlet.ShouldProcess($RootDir, 'Create directory')) {
             New-Item -ItemType Directory -Path $RootDir -Force | Out-Null
+        }
+        Write-Verbose "Applying home-directory ACL ($env:USERPROFILE) to '$RootDir'..."
+        Set-RootDirAclFromHome -Path $RootDir
+    }
+    else {
+        $homeAcl = Get-Acl -LiteralPath $env:USERPROFILE
+        $rootAcl = Get-Acl -LiteralPath $RootDir
+        if ($homeAcl.Sddl -ne $rootAcl.Sddl) {
+            Write-Warning "$RootDir already exists; ACL differs from $env:USERPROFILE. Leaving ACL unchanged. Run icacls or re-create the directory to harden it."
         }
     }
 


### PR DESCRIPTION
## Summary

Closes #196.

When `$RootDir` is created on an alternate volume (e.g. `D:\OneDrive`), the freshly-created directory inherits the volume-root ACL, which on a default Windows install grants Read+Execute to `BUILTIN\Users`. That makes the OneDrive sync root readable by every local account on the box.

This PR adds a `Set-RootDirAclFromHome` helper that copies the ACL from `$env:USERPROFILE` onto the target directory via `Get-Acl` / `Set-Acl`, gated by `ShouldProcess` so `-WhatIf` previews the intended `Set-Acl` call. The helper accepts an optional `-ReferenceAcl` so unit tests can supply a synthetic ACL without touching the real filesystem.

## Changes

- `bucket/MarkMichaelisOneDriveConfiguration.ps1`
  - Add `Set-RootDirAclFromHome` (pure-ish: optional `-ReferenceAcl` for tests).
  - Integrate after the `New-Item -ItemType Directory -Path $RootDir` block:
    - Fresh create: apply home-dir ACL (verbose log line on entry).
    - Pre-existing: compare ACL Sddl; if it differs, `Write-Warning` and leave it alone.
- `bucket/MarkMichaelisOneDriveConfiguration.Tests.ps1`
  - Add 4 Pester tests under `Describe 'Set-RootDirAclFromHome'`:
    - `-WhatIf` suppresses the `Set-Acl` call.
    - Non-`-WhatIf` invokes `Set-Acl` with the supplied reference ACL.
    - `-ReferenceAcl` omitted -> `Get-Acl` is called on `-ReferencePath`.
    - Target path independence (mock-only): helper is a pure transform, does not probe the target.
- `bucket/MarkMichaelisOneDriveConfiguration.json` -- bump `1.03.000` -> `1.04.000`.
- `README.md` -- one-sentence note under the bundle section.

## Verification

```
Invoke-Pester -Path .\bucket\MarkMichaelisOneDriveConfiguration.Tests.ps1 -Output Detailed
Invoke-Pester -Path .\bucket\Bundles.Tests.ps1 -Output Minimal
.\Test-ManifestVersionBumps.ps1
.\bucket\MarkMichaelisOneDriveConfiguration.ps1 -WhatIf -Verbose -RootDir D:\OneDrive
```

All checks green locally: 28/28 in the bundle file, 792/793 bundle tests pass (1 pre-existing skip), 35/35 manifest version bumps current.

The `-WhatIf` smoke run now emits the new line:

```
VERBOSE: Applying home-directory ACL (C:\Users\Mark) to 'D:\OneDrive'...
What if: Performing the operation "Apply ACL from 'C:\Users\Mark'" on target "D:\OneDrive".
```