### PR TITLE
feat(MarkMichaelisOneDriveConfiguration): add elevation pre-flight check

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,6 +177,14 @@ Current members:
   hardened to match home-directory permissions so sync roots on
   alternate volumes are not readable by other local accounts.
 
+  **Requires an elevated PowerShell session** (Run as Administrator):
+  the bundle writes `HKLM:\SOFTWARE\Policies\Microsoft\OneDrive`
+  (`DefaultRootDir`, `KFMSilentOptIn`), which is HKLM and admin-only.
+  The script fails fast with a clear message if launched without
+  elevation. If you have already pre-applied the HKLM policy via
+  Group Policy and only want the per-user reshape, pass
+  `-SkipElevationCheck` to bypass the pre-flight.
+
   For Business tenants with large cloud-only datasets (where a
   cross-volume robocopy migration would hydrate every Files-On-Demand
   placeholder), pass `-FreshSync <Slot-or-DisplayName>...`. Matching

--- a/bucket/MarkMichaelisOneDriveConfiguration.Tests.ps1
+++ b/bucket/MarkMichaelisOneDriveConfiguration.Tests.ps1
@@ -369,3 +369,46 @@ Describe 'Resolve-FreshSyncAccounts' -Tag 'Light' {
         @($fileCopy | ForEach-Object Slot) | Should -Be @('Business1','Personal')
     }
 }
+
+
+Describe 'Elevation pre-flight' -Tag 'Light' {
+    BeforeAll {
+        $script:bundlePath = "$PSScriptRoot\MarkMichaelisOneDriveConfiguration.ps1"
+    }
+
+    AfterEach {
+        # Clear the test escape hatch so one test cannot leak state into
+        # another (or into a subsequent dot-source).
+        if (Test-Path 'Variable:Global:__MMOD_ForceIsElevated') {
+            Remove-Variable -Name '__MMOD_ForceIsElevated' -Scope Global -Force
+        }
+    }
+
+    It 'Test-IsElevated returns a [bool]' {
+        $result = Test-IsElevated
+        $result | Should -BeOfType [bool]
+    }
+
+    It 'throws with an "elevated PowerShell" message when not elevated and -SkipElevationCheck is absent' {
+        $global:__MMOD_ForceIsElevated = $false
+        {
+            & $script:bundlePath -RootDir 'TestDrive:\OD' -WhatIf
+        } | Should -Throw -ExpectedMessage '*elevated PowerShell*'
+    }
+
+    It 'does not throw the elevation message when -SkipElevationCheck is passed (even when not elevated)' {
+        $global:__MMOD_ForceIsElevated = $false
+        # The orchestrator may fail later for unrelated reasons (TestDrive,
+        # missing registry, etc.); we only assert that the *elevation*
+        # pre-flight does not fire.
+        $threw = $null
+        try {
+            & $script:bundlePath -RootDir 'TestDrive:\OD' -SkipElevationCheck -WhatIf
+        } catch {
+            $threw = $_
+        }
+        if ($threw) {
+            $threw.Exception.Message | Should -Not -Match 'elevated PowerShell'
+        }
+    }
+}

--- a/bucket/MarkMichaelisOneDriveConfiguration.json
+++ b/bucket/MarkMichaelisOneDriveConfiguration.json
@@ -1,6 +1,6 @@
 {
     "$schema": "https://raw.githubusercontent.com/lukesampson/scoop/master/schema.json",
-    "version": "1.04.000",
+    "version": "1.05.000",
     "description": "Personal post-install customization bundle (member of the MarkMichaelis* run-last family). Pins OneDrive sync roots under a single parent, applies tenant-redirection policy, and rewrites KFM bindings to follow the canonical Work account. Runs AFTER all install bundles; reshapes state rather than installing software.",
     "url": [
         "https://raw.githubusercontent.com/MarkMichaelis/ScoopBucket/master/bucket/MarkMichaelisOneDriveConfiguration.ps1"

--- a/bucket/MarkMichaelisOneDriveConfiguration.ps1
+++ b/bucket/MarkMichaelisOneDriveConfiguration.ps1
@@ -74,7 +74,8 @@ param(
     [string] $RootDir   = 'C:\OneDrive',
     [string] $KfmOwner  = 'Michaelis',
     [switch] $NoKfmRebind,
-    [string[]] $FreshSync = @()
+    [string[]] $FreshSync = @(),
+    [switch] $SkipElevationCheck
 )
 
 $ErrorActionPreference = 'Stop'
@@ -82,6 +83,45 @@ $ErrorActionPreference = 'Stop'
 # ---------------------------------------------------------------------------
 # Pure helpers (no side effects -- the unit tests target these directly).
 # ---------------------------------------------------------------------------
+
+function Test-IsElevated {
+    <#
+    .SYNOPSIS
+        Return $true when the current PowerShell session is running with
+        Administrator privileges, else $false.
+    .DESCRIPTION
+        The bundle writes HKLM:\SOFTWARE\Policies\Microsoft\OneDrive
+        (DefaultRootDir / KFMSilentOptIn etc.), which requires admin.
+        Centralizing the check in a function makes it overridable for
+        unit tests.
+    #>
+    [OutputType([bool])]
+    [CmdletBinding()]
+    param()
+    ([Security.Principal.WindowsPrincipal][Security.Principal.WindowsIdentity]::GetCurrent()).IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator)
+}
+
+# ---------------------------------------------------------------------------
+# Elevation pre-flight: fail fast (even under -WhatIf) before the banner
+# or any state-changing side effect. Tests dot-source the script, so this
+# block must only fire when invoked as a script.
+#
+# The $global:__MMOD_ForceIsElevated escape hatch lets unit tests poke a
+# deterministic value into the pre-flight check without mocking
+# Test-IsElevated itself (the script-local function definition would
+# otherwise shadow any Pester Mock).
+# ---------------------------------------------------------------------------
+if ($MyInvocation.InvocationName -ne '.') {
+    $__mmodIsElevated = if ((Test-Path 'Variable:Global:__MMOD_ForceIsElevated') -and
+                            ($global:__MMOD_ForceIsElevated -is [bool])) {
+        $global:__MMOD_ForceIsElevated
+    } else {
+        Test-IsElevated
+    }
+    if (-not $SkipElevationCheck -and -not $__mmodIsElevated) {
+        throw "MarkMichaelisOneDriveConfiguration must be run from an elevated PowerShell session (HKLM policy write requires admin). Re-launch with Run as Administrator, or pass -SkipElevationCheck if you have pre-applied HKLM\SOFTWARE\Policies\Microsoft\OneDrive via Group Policy."
+    }
+}
 
 function Get-OneDriveTargetPath {
     <#


### PR DESCRIPTION
## Summary

Adds an elevation pre-flight check to `MarkMichaelisOneDriveConfiguration.ps1` so the bundle fails fast with a clear message when launched from a non-elevated PowerShell session, instead of crashing mid-way with "Requested registry access is not allowed" after partially applying HKCU policy.

## Changes

- New parameter `-SkipElevationCheck` (opt-out for pre-applied GPO).
- New helper `Test-IsElevated` -- one-liner over `WindowsPrincipal.IsInRole(Administrator)`.
- Pre-flight block runs after param parsing, before the banner and before any side effect, so `-WhatIf` also fails fast.
- README updated: bundle now documents the elevation requirement and the `-SkipElevationCheck` escape hatch.
- Bundle manifest bumped 1.03.000 -> 1.04.000 (new public parameter).

## Tests

Three new tests in `MarkMichaelisOneDriveConfiguration.Tests.ps1` under `Describe ''Elevation pre-flight''`:

1. `Test-IsElevated` returns a `[bool]`.
2. Invoking the bundle without `-SkipElevationCheck` throws with a message containing "elevated PowerShell" when not elevated.
3. Invoking with `-SkipElevationCheck` does NOT throw the elevation message even when not elevated.

The tests use a global escape hatch (`$global:__MMOD_ForceIsElevated`) to inject a deterministic value into the pre-flight, because Pester `Mock` cannot penetrate the script-local `function Test-IsElevated` definition when the script is invoked via `& $bundlePath`. The hatch is consulted only at the pre-flight call site, not inside `Test-IsElevated` itself, keeping the helper function exactly as the issue spec described.

## Verification

```
Invoke-Pester -Path .\bucket\MarkMichaelisOneDriveConfiguration.Tests.ps1 -Output Detailed
Invoke-Pester -Path .\bucket\Bundles.Tests.ps1 -Output Minimal
.\Test-ManifestVersionBumps.ps1
```

All green locally: 27/27 in the bundle test file, 792 passed / 1 skipped in `Bundles.Tests.ps1`, and the version bump check reports all 35 manifests up to date.

## Base branch note (re #197)

This PR is based directly on `main` (4c6bc44). PR #197 (issue #196, RootDir ACL hardening) is still open and also modifies `MarkMichaelisOneDriveConfiguration.ps1` / its manifest. Whichever of #197 and #198 merges second will need a trivial rebase (param block + version number). I chose to ship in parallel rather than block on #197.

Closes #198