### PR TITLE
Safety-critical correctness overhaul for MarkMichaelisOneDriveConfiguration

### DIFF
--- a/bucket/MarkMichaelisOneDriveConfiguration.Tests.ps1
+++ b/bucket/MarkMichaelisOneDriveConfiguration.Tests.ps1
@@ -299,6 +299,31 @@ Describe 'Get-OneDrivePlaceholderCount' -Tag 'Light' {
     }
 }
 
+Describe 'Export-OneDriveRegistryBackup' -Tag 'Light' {
+    It 'exports each required registry subtree into the combined backup file' {
+        Mock -CommandName Test-Path -MockWith { $false }
+        Mock -CommandName New-Item
+        Mock -CommandName Set-Content
+        Mock -CommandName Add-Content
+        Mock -CommandName Remove-Item
+        Mock -CommandName Get-Content -MockWith { "Windows Registry Editor Version 5.00`r`n[HKEY_CURRENT_USER\\Software]" }
+        Mock -CommandName Invoke-RegExportCommand
+
+        Export-OneDriveRegistryBackup -OutputPath 'C:\Users\Mark\AppData\Local\MarkMichaelis\OneDriveMigration\backup-20240102-030405.reg' | Out-Null
+
+        foreach ($subKey in @(
+            'HKCU\Software\Microsoft\OneDrive\Accounts',
+            'HKCU\Software\Microsoft\Windows\CurrentVersion\Explorer\User Shell Folders',
+            'HKCU\Software\Microsoft\Windows\CurrentVersion\Explorer\Shell Folders',
+            'HKCU\Software\Microsoft\Windows\CurrentVersion\Explorer\FolderDescriptions',
+            'HKCU\SOFTWARE\Policies\Microsoft\OneDrive',
+            'HKLM\SOFTWARE\Policies\Microsoft\OneDrive'
+        )) {
+            Should -Invoke Invoke-RegExportCommand -Times 1 -ParameterFilter { $SubKey -eq $subKey }
+        }
+    }
+}
+
 Describe 'Get-OneDriveAccountList (zombie slot filter)' -Tag 'Light' {
     # Regression for issue #192: a Business slot left over from a failed
     # sign-in has no DisplayName / UserFolder / UserEmail and must be
@@ -556,6 +581,7 @@ Describe 'Invoke-MarkMichaelisOneDriveConfiguration pre-create behavior' -Tag 'L
         }
         Mock -CommandName Set-OneDriveTenantDefaultRootDirPolicy
         Mock -CommandName Set-OneDriveUpdateRingPolicy
+        Mock -CommandName Export-OneDriveRegistryBackup -MockWith { 'C:\\backup.reg' }
         Mock -CommandName Stop-OneDriveExe
         Mock -CommandName Move-OneDriveFolder
         Mock -CommandName Update-OneDriveAccountRegistry
@@ -599,6 +625,7 @@ Describe 'Invoke-MarkMichaelisOneDriveConfiguration running state' -Tag 'Light' 
         }
         Mock -CommandName Set-OneDriveTenantDefaultRootDirPolicy
         Mock -CommandName Set-OneDriveUpdateRingPolicy
+        Mock -CommandName Export-OneDriveRegistryBackup -MockWith { 'C:\\backup.reg' }
         Mock -CommandName Stop-OneDriveExe
         Mock -CommandName Move-OneDriveFolder
         Mock -CommandName Update-OneDriveAccountRegistry
@@ -655,6 +682,7 @@ Describe 'Invoke-MarkMichaelisOneDriveConfiguration rollback' -Tag 'Light' {
         }
         Mock -CommandName Set-OneDriveTenantDefaultRootDirPolicy
         Mock -CommandName Set-OneDriveUpdateRingPolicy
+        Mock -CommandName Export-OneDriveRegistryBackup -MockWith { 'C:\\backup.reg' }
         Mock -CommandName Stop-OneDriveExe
         Mock -CommandName Move-OneDriveFolder -MockWith { $script:afterMove = $true }
         Mock -CommandName Get-OneDriveAccountRegistrySnapshot -MockWith { [pscustomobject]@{ UserFolder = $oldPath; CacheValues = @{} } }
@@ -712,6 +740,7 @@ Describe 'Invoke-MarkMichaelisOneDriveConfiguration KFM rebind' -Tag 'Light' {
         Mock -CommandName Get-CurrentKfmPath -MockWith { $kfmCurrent }
         Mock -CommandName Set-OneDriveTenantDefaultRootDirPolicy
         Mock -CommandName Set-OneDriveUpdateRingPolicy
+        Mock -CommandName Export-OneDriveRegistryBackup -MockWith { 'C:\\backup.reg' }
         Mock -CommandName Stop-OneDriveExe
         Mock -CommandName Move-OneDriveFolder
         Mock -CommandName Update-OneDriveAccountRegistry
@@ -745,6 +774,7 @@ Describe 'Invoke-MarkMichaelisOneDriveConfiguration KFM rebind' -Tag 'Light' {
         Mock -CommandName Get-CurrentKfmPath -MockWith { 'D:\Elsewhere\Documents' }
         Mock -CommandName Set-OneDriveTenantDefaultRootDirPolicy
         Mock -CommandName Set-OneDriveUpdateRingPolicy
+        Mock -CommandName Export-OneDriveRegistryBackup -MockWith { 'C:\\backup.reg' }
         Mock -CommandName Stop-OneDriveExe
         Mock -CommandName Move-OneDriveFolder
         Mock -CommandName Update-OneDriveAccountRegistry
@@ -1000,3 +1030,4 @@ Describe 'Resolve-FreshSyncAccounts' -Tag 'Light' {
         @($fileCopy | ForEach-Object Slot) | Should -Be @('Business1','Personal')
     }
 }
+

--- a/bucket/MarkMichaelisOneDriveConfiguration.Tests.ps1
+++ b/bucket/MarkMichaelisOneDriveConfiguration.Tests.ps1
@@ -964,6 +964,39 @@ Describe 'Plan-then-execute architecture' -Tag 'Light' {
     }
 }
 
+Describe 'Get-OneDriveMigrationSummaryLines' -Tag 'Light' {
+    It 'renders the detailed summary sections in a stable grouped structure' {
+        $accounts = @(
+            [pscustomobject]@{ AccountType = 'Business'; DisplayName = 'IntelliTect'; UserFolder = 'C:\Users\me\OneDrive - IntelliTect' }
+        )
+        $sharePointSites = @(
+            [pscustomobject]@{ CurrentPath = 'C:\Users\Mark\IntelliTect - Engineering'; DesiredPath = 'C:\OneDrive\IntelliTect\IntelliTect - Engineering' }
+        )
+        $plan = @(
+            [pscustomobject]@{ Type='RegistryBackup'; Target='C:\Backup.reg'; CurrentValue=$null; DesiredValue=$null; Status='Done'; SkipReason=$null; FailureReason=$null },
+            [pscustomobject]@{ Type='WritePolicy'; Target='HKCU:\SOFTWARE\Policies\Microsoft\OneDrive\DefaultRootDir\tid-1'; CurrentValue='old'; DesiredValue='new'; Status='Done'; SkipReason=$null; FailureReason=$null },
+            [pscustomobject]@{ Type='MoveAccount'; Target='C:\OneDrive\OneDrive - IntelliTect'; CurrentValue='C:\Users\me\OneDrive - IntelliTect'; DesiredValue='C:\OneDrive\OneDrive - IntelliTect'; Status='Skipped'; SkipReason='Current path already matches the canonical target.'; FailureReason=$null },
+            [pscustomobject]@{ Type='RewriteSPCache'; Target='C:\OneDrive\IntelliTect\IntelliTect - Engineering'; CurrentValue='C:\Users\Mark\IntelliTect - Engineering'; DesiredValue='C:\OneDrive\IntelliTect\IntelliTect - Engineering'; Status='Done'; SkipReason=$null; FailureReason=$null },
+            [pscustomobject]@{ Type='RewriteKfm'; Target='KFM'; CurrentValue='C:\Old\Documents'; DesiredValue='C:\New\Documents'; Status='Failed'; SkipReason=$null; FailureReason='boom' },
+            [pscustomobject]@{ Type='Verify'; Target='C:\OneDrive\OneDrive - IntelliTect'; CurrentValue='old'; DesiredValue='new'; Status='Done'; SkipReason=$null; FailureReason=$null }
+        )
+
+        $summary = (Get-OneDriveMigrationSummaryLines -Accounts $accounts -SharePointSites $sharePointSites -Plan $plan -DeferredCleanupPaths @('C:\Old.migrated-123')) -join "`n"
+
+        $summary | Should -Match 'Discovered Accounts:'
+        $summary | Should -Match 'Discovered SharePoint Sites:'
+        $summary | Should -Match 'Policy Writes:'
+        $summary | Should -Match 'Moves:'
+        $summary | Should -Match 'KFM Rewrites:'
+        $summary | Should -Match 'SharePoint Cache Rewrites:'
+        $summary | Should -Match 'Verification Results:'
+        $summary | Should -Match 'Backup Location:'
+        $summary | Should -Match 'MRU Warning:'
+        $summary | Should -Match '\.migrated-\* directories awaiting cleanup:'
+        $summary | Should -Match 'Failed: boom \| KFM'
+    }
+}
+
 Describe 'Resolve-FreshSyncAccounts' -Tag 'Light' {
     BeforeAll {
         $script:b1 = [pscustomobject]@{

--- a/bucket/MarkMichaelisOneDriveConfiguration.Tests.ps1
+++ b/bucket/MarkMichaelisOneDriveConfiguration.Tests.ps1
@@ -116,7 +116,7 @@ Describe 'Resolve-KfmRebindAction' -Tag 'Light' {
         $result = Resolve-KfmRebindAction `
             -Accounts @($script:owner, $script:other) `
             -KfmCurrentPath 'C:\OneDrive\OneDrive - Michaelis Consulting\Documents' `
-            -KfmOwner 'Michaelis'
+            -KfmOwner 'Michaelis Consulting'
         $result.Action | Should -Be 'Track'
         $result.OwnerAccount.Slot | Should -Be 'Business1'
     }
@@ -125,7 +125,7 @@ Describe 'Resolve-KfmRebindAction' -Tag 'Light' {
         $result = Resolve-KfmRebindAction `
             -Accounts @($script:owner, $script:other) `
             -KfmCurrentPath 'C:\OneDrive\OneDrive - IntelliTect\Documents' `
-            -KfmOwner 'Michaelis'
+            -KfmOwner 'Michaelis Consulting'
         $result.Action | Should -Be 'Rebind'
         $result.OwnerAccount.Slot | Should -Be 'Business1'
     }
@@ -134,7 +134,7 @@ Describe 'Resolve-KfmRebindAction' -Tag 'Light' {
         $result = Resolve-KfmRebindAction `
             -Accounts @($script:owner, $script:other) `
             -KfmCurrentPath 'C:\OneDrive\OneDrive - IntelliTect\Documents' `
-            -KfmOwner 'Michaelis' -NoKfmRebind
+            -KfmOwner 'Michaelis Consulting' -NoKfmRebind
         $result.Action | Should -Be 'WarnOnly'
     }
 
@@ -142,7 +142,7 @@ Describe 'Resolve-KfmRebindAction' -Tag 'Light' {
         $result = Resolve-KfmRebindAction `
             -Accounts @($script:owner) `
             -KfmCurrentPath $null `
-            -KfmOwner 'Michaelis'
+            -KfmOwner 'Michaelis Consulting'
         $result.Action | Should -Be 'None'
     }
 
@@ -150,7 +150,7 @@ Describe 'Resolve-KfmRebindAction' -Tag 'Light' {
         $result = Resolve-KfmRebindAction `
             -Accounts @($script:other, $script:personal) `
             -KfmCurrentPath 'C:\OneDrive\OneDrive - IntelliTect\Documents' `
-            -KfmOwner 'Michaelis'
+            -KfmOwner 'Michaelis Consulting'
         $result.Action | Should -Be 'OwnerNotSignedIn'
         $result.OwnerAccount | Should -BeNullOrEmpty
     }
@@ -165,7 +165,7 @@ Describe 'Resolve-KfmRebindAction' -Tag 'Light' {
         $result = Resolve-KfmRebindAction `
             -Accounts @($personalNamedMichaelis, $script:other) `
             -KfmCurrentPath 'C:\OneDrive\OneDrive - IntelliTect\Documents' `
-            -KfmOwner 'Michaelis'
+            -KfmOwner 'Mark Michaelis'
         $result.Action | Should -Be 'OwnerNotSignedIn'
     }
 
@@ -173,16 +173,34 @@ Describe 'Resolve-KfmRebindAction' -Tag 'Light' {
         $result = Resolve-KfmRebindAction `
             -Accounts @($script:other, $script:personal) `
             -KfmCurrentPath $null `
-            -KfmOwner 'Michaelis'
+            -KfmOwner 'Michaelis Consulting'
         $result.Action | Should -Be 'None'
         $result.OwnerAccount | Should -BeNullOrEmpty
+    }
+
+    It 'matches KfmOwner by case-insensitive equality by default' {
+        $result = Resolve-KfmRebindAction `
+            -Accounts @($script:owner, $script:other) `
+            -KfmCurrentPath 'C:\OneDrive\OneDrive - IntelliTect\Documents' `
+            -KfmOwner 'michaelis consulting'
+        $result.Action | Should -Be 'Rebind'
+        $result.OwnerAccount.Slot | Should -Be 'Business1'
+    }
+
+    It 'supports opt-in substring owner matching with -KfmOwnerContains' {
+        $result = Resolve-KfmRebindAction `
+            -Accounts @($script:owner, $script:other) `
+            -KfmCurrentPath 'C:\OneDrive\OneDrive - IntelliTect\Documents' `
+            -KfmOwner 'Michaelis' -KfmOwnerContains
+        $result.Action | Should -Be 'Rebind'
+        $result.OwnerAccount.Slot | Should -Be 'Business1'
     }
 
     It 'returns an empty-accounts result as None when KFM is inactive' {
         $result = Resolve-KfmRebindAction `
             -Accounts @() `
             -KfmCurrentPath $null `
-            -KfmOwner 'Michaelis'
+            -KfmOwner 'Michaelis Consulting'
         $result.Action | Should -Be 'None'
     }
 }
@@ -273,6 +291,57 @@ Describe 'Update-OneDriveSharePointCache' -Tag 'Light' {
             $Name -eq 'Site' -and
             $Value -eq $Expected
         }
+    }
+}
+
+Describe 'Invoke-RobocopyMirror' -Tag 'Light' {
+    It 'uses /ZB so cross-volume copies stay restartable and can fall back to backup mode' {
+        $script:capturedRobocopyArgs = $null
+        function global:robocopy {
+            param([Parameter(ValueFromRemainingArguments = $true)] $Args)
+            $script:capturedRobocopyArgs = @($Args)
+            $global:LASTEXITCODE = 3
+        }
+
+        try {
+            Invoke-RobocopyMirror -Source 'C:\Source' -Destination 'D:\Dest' | Should -Be 3
+            $script:capturedRobocopyArgs | Should -Contain '/ZB'
+            $script:capturedRobocopyArgs | Should -Not -Contain '/B'
+        }
+        finally {
+            Remove-Item function:\global:robocopy -ErrorAction SilentlyContinue
+        }
+    }
+}
+
+Describe 'Update-KfmBindings' -Tag 'Light' {
+    It 'rewrites extended known-folder GUID entries including Downloads and Screenshots' {
+        $oldRoot = 'C:\Users\me\OneDrive - IntelliTect'
+        $newRoot = 'C:\OneDrive\OneDrive - IntelliTect'
+        $downloadsGuid = '{374DE290-123F-4565-9164-39C4925E467B}'
+        $screenshotsGuid = '{B7BEDE81-DF94-4682-A7D8-57A52620B86F}'
+        $folderKeys = @(
+            "HKCU:\Software\Microsoft\Windows\CurrentVersion\Explorer\FolderDescriptions\$downloadsGuid",
+            "HKCU:\Software\Microsoft\Windows\CurrentVersion\Explorer\FolderDescriptions\$screenshotsGuid"
+        )
+
+        Mock -CommandName Test-Path -MockWith { param($Path) $Path -in $folderKeys }
+        Mock -CommandName Get-ItemProperty -MockWith {
+            param($Path)
+            switch ($Path) {
+                $folderKeys[0] { [pscustomobject]@{ RelativePath = "$oldRoot\Downloads"; ParsingName = "$oldRoot\Downloads" } ; break }
+                $folderKeys[1] { [pscustomobject]@{ RelativePath = "$oldRoot\Pictures\Screenshots"; ParsingName = "$oldRoot\Pictures\Screenshots" } ; break }
+                default { [pscustomobject]@{} }
+            }
+        }
+        Mock -CommandName Set-ItemProperty
+
+        Update-KfmBindings -OldRoot $oldRoot -NewRoot $newRoot -Confirm:$false
+
+        Should -Invoke Set-ItemProperty -Times 1 -ParameterFilter { $Path -eq $folderKeys[0] -and $Name -eq 'RelativePath' -and $Value -eq "$newRoot\Downloads" }
+        Should -Invoke Set-ItemProperty -Times 1 -ParameterFilter { $Path -eq $folderKeys[0] -and $Name -eq 'ParsingName' -and $Value -eq "$newRoot\Downloads" }
+        Should -Invoke Set-ItemProperty -Times 1 -ParameterFilter { $Path -eq $folderKeys[1] -and $Name -eq 'RelativePath' -and $Value -eq "$newRoot\Pictures\Screenshots" }
+        Should -Invoke Set-ItemProperty -Times 1 -ParameterFilter { $Path -eq $folderKeys[1] -and $Name -eq 'ParsingName' -and $Value -eq "$newRoot\Pictures\Screenshots" }
     }
 }
 
@@ -750,7 +819,7 @@ Describe 'Invoke-MarkMichaelisOneDriveConfiguration KFM rebind' -Tag 'Heavy' {
         Mock -CommandName Get-Process -MockWith { $null }
         Mock -CommandName Update-KfmBindings
 
-        Invoke-MarkMichaelisOneDriveConfiguration -RootDir $rootDir -KfmOwner 'Michaelis' -FreshSync @() -Confirm:$false
+        Invoke-MarkMichaelisOneDriveConfiguration -RootDir $rootDir -KfmOwner 'Michaelis Consulting' -FreshSync @() -Confirm:$false
 
         Should -Invoke Update-KfmBindings -Times 1 -ParameterFilter {
             $OldRoot -eq 'C:\OneDrive\OneDrive - IntelliTect' -and
@@ -785,7 +854,7 @@ Describe 'Invoke-MarkMichaelisOneDriveConfiguration KFM rebind' -Tag 'Heavy' {
         Mock -CommandName Update-KfmBindings
         Mock -CommandName Write-Warning
 
-        Invoke-MarkMichaelisOneDriveConfiguration -RootDir 'C:\OneDrive' -KfmOwner 'Michaelis' -FreshSync @() -Confirm:$false
+        Invoke-MarkMichaelisOneDriveConfiguration -RootDir 'C:\OneDrive' -KfmOwner 'Michaelis Consulting' -FreshSync @() -Confirm:$false
 
         Should -Invoke Update-KfmBindings -Times 0
         Should -Invoke Write-Warning -Times 1 -ParameterFilter { $Message -like '*not under any discovered OneDrive account UserFolder*' }

--- a/bucket/MarkMichaelisOneDriveConfiguration.Tests.ps1
+++ b/bucket/MarkMichaelisOneDriveConfiguration.Tests.ps1
@@ -216,6 +216,66 @@ Describe 'Resolve-KfmCurrentOwnerRoot' -Tag 'Light' {
     }
 }
 
+Describe 'Get-OneDriveSharePointSiteList' -Tag 'Light' {
+    It 'discovers nested and sibling SharePoint mount points and computes canonical tenant-sibling targets' {
+        $account = [pscustomobject]@{
+            Slot = 'Business1'; AccountType = 'Business'; DisplayName = 'IntelliTect'; TenantId = 'tenant-1'
+            UserFolder = 'C:\OneDrive\OneDrive - IntelliTect'; RegistryPath = 'HKCU:\Software\Microsoft\OneDrive\Accounts\Business1'
+        }
+
+        Mock -CommandName Get-OneDriveRegistryStringValuesUnderPath -MockWith {
+            param($Path)
+            switch ($Path) {
+                'HKCU:\Software\Microsoft\OneDrive\Accounts\Business1\Tenants\tenant-1' {
+                    @(
+                        [pscustomobject]@{ KeyPath = $Path; ValueName = 'Nested'; Value = 'C:\OneDrive\OneDrive - IntelliTect\Projects' },
+                        [pscustomobject]@{ KeyPath = $Path; ValueName = 'Sibling'; Value = 'C:\Users\Mark\IntelliTect - Engineering' }
+                    )
+                    break
+                }
+                'HKCU:\Software\Microsoft\OneDrive\Accounts\Business1\ScopeIdToMountPointPathCache' {
+                    @([pscustomobject]@{ KeyPath = $Path; ValueName = 'Cache'; Value = 'C:\Users\Mark\IntelliTect - Engineering' })
+                    break
+                }
+                default { @() }
+            }
+        }
+
+        $sites = Get-OneDriveSharePointSiteList -Accounts @($account) -RootDir 'C:\OneDrive'
+
+        @($sites).Count | Should -Be 2
+        ($sites | ForEach-Object CurrentPath) | Should -Contain 'C:\OneDrive\OneDrive - IntelliTect\Projects'
+        ($sites | ForEach-Object CurrentPath) | Should -Contain 'C:\Users\Mark\IntelliTect - Engineering'
+        ($sites | Where-Object CurrentPath -eq 'C:\OneDrive\OneDrive - IntelliTect\Projects').DesiredPath | Should -Be 'C:\OneDrive\IntelliTect\Projects'
+        ($sites | Where-Object CurrentPath -eq 'C:\Users\Mark\IntelliTect - Engineering').DesiredPath | Should -Be 'C:\OneDrive\IntelliTect\IntelliTect - Engineering'
+    }
+}
+
+Describe 'Update-OneDriveSharePointCache' -Tag 'Light' {
+    It 'prefix-rewrites nested and sibling SharePoint cache paths for <OldPath>' -ForEach @(
+        @{ OldPath = 'C:\OneDrive\OneDrive - IntelliTect\Projects'; NewPath = 'C:\OneDrive\IntelliTect\Projects'; Current = 'C:\OneDrive\OneDrive - IntelliTect\Projects\Docs'; Expected = 'C:\OneDrive\IntelliTect\Projects\Docs' }
+        @{ OldPath = 'C:\Users\Mark\IntelliTect - Engineering'; NewPath = 'C:\OneDrive\IntelliTect\IntelliTect - Engineering'; Current = 'C:\Users\Mark\IntelliTect - Engineering\Sub'; Expected = 'C:\OneDrive\IntelliTect\IntelliTect - Engineering\Sub' }
+    ) {
+        $account = [pscustomobject]@{
+            Slot = 'Business1'; AccountType = 'Business'; DisplayName = 'IntelliTect'; TenantId = 'tenant-1'
+            UserFolder = 'C:\OneDrive\OneDrive - IntelliTect'; RegistryPath = 'HKCU:\Software\Microsoft\OneDrive\Accounts\Business1'
+        }
+
+        Mock -CommandName Get-OneDriveRegistryStringValuesUnderPath -MockWith {
+            @([pscustomobject]@{ KeyPath = 'HKCU:\Software\Microsoft\OneDrive\Accounts\Business1\ScopeIdToMountPointPathCache'; ValueName = 'Site'; Value = $Current })
+        }
+        Mock -CommandName Set-ItemProperty
+
+        Update-OneDriveSharePointCache -Account $account -OldPath $OldPath -NewPath $NewPath -Confirm:$false
+
+        Should -Invoke Set-ItemProperty -Times 1 -ParameterFilter {
+            $Path -eq 'HKCU:\Software\Microsoft\OneDrive\Accounts\Business1\ScopeIdToMountPointPathCache' -and
+            $Name -eq 'Site' -and
+            $Value -eq $Expected
+        }
+    }
+}
+
 Describe 'Get-OneDriveAccountList (zombie slot filter)' -Tag 'Light' {
     # Regression for issue #192: a Business slot left over from a failed
     # sign-in has no DisplayName / UserFolder / UserEmail and must be
@@ -466,6 +526,7 @@ Describe 'Invoke-MarkMichaelisOneDriveConfiguration pre-create behavior' -Tag 'L
         }
         Mock -CommandName Get-OneDriveAccountList -MockWith { @($acct) }
         Mock -CommandName Resolve-FreshSyncAccounts -MockWith { @() }
+        Mock -CommandName Get-OneDriveSharePointSiteList -MockWith { @() }
         Mock -CommandName Get-CurrentKfmPath -MockWith { $null }
         Mock -CommandName Resolve-KfmRebindAction -MockWith {
             [pscustomobject]@{ Action = 'None'; OwnerAccount = $acct; Reason = 'KFM inactive' }
@@ -508,6 +569,7 @@ Describe 'Invoke-MarkMichaelisOneDriveConfiguration running state' -Tag 'Light' 
         }
         Mock -CommandName Get-OneDriveAccountList -MockWith { @($script:acct) }
         Mock -CommandName Resolve-FreshSyncAccounts -MockWith { @() }
+        Mock -CommandName Get-OneDriveSharePointSiteList -MockWith { @() }
         Mock -CommandName Get-CurrentKfmPath -MockWith { $null }
         Mock -CommandName Resolve-KfmRebindAction -MockWith {
             [pscustomobject]@{ Action = 'None'; OwnerAccount = $null; Reason = 'KFM inactive' }
@@ -563,6 +625,7 @@ Describe 'Invoke-MarkMichaelisOneDriveConfiguration rollback' -Tag 'Light' {
         }
         Mock -CommandName Get-OneDriveAccountList -MockWith { @($acct) }
         Mock -CommandName Resolve-FreshSyncAccounts -MockWith { @() }
+        Mock -CommandName Get-OneDriveSharePointSiteList -MockWith { @() }
         Mock -CommandName Get-CurrentKfmPath -MockWith { $null }
         Mock -CommandName Resolve-KfmRebindAction -MockWith {
             [pscustomobject]@{ Action = 'None'; OwnerAccount = $null; Reason = 'KFM inactive' }
@@ -622,6 +685,7 @@ Describe 'Invoke-MarkMichaelisOneDriveConfiguration KFM rebind' -Tag 'Light' {
         }
         Mock -CommandName Get-OneDriveAccountList -MockWith { @($owner, $other) }
         Mock -CommandName Resolve-FreshSyncAccounts -MockWith { @() }
+        Mock -CommandName Get-OneDriveSharePointSiteList -MockWith { @() }
         Mock -CommandName Get-CurrentKfmPath -MockWith { $kfmCurrent }
         Mock -CommandName Set-OneDriveTenantDefaultRootDirPolicy
         Mock -CommandName Set-OneDriveUpdateRingPolicy
@@ -654,6 +718,7 @@ Describe 'Invoke-MarkMichaelisOneDriveConfiguration KFM rebind' -Tag 'Light' {
         }
         Mock -CommandName Get-OneDriveAccountList -MockWith { @($owner) }
         Mock -CommandName Resolve-FreshSyncAccounts -MockWith { @() }
+        Mock -CommandName Get-OneDriveSharePointSiteList -MockWith { @() }
         Mock -CommandName Get-CurrentKfmPath -MockWith { 'D:\Elsewhere\Documents' }
         Mock -CommandName Set-OneDriveTenantDefaultRootDirPolicy
         Mock -CommandName Set-OneDriveUpdateRingPolicy
@@ -692,6 +757,7 @@ Describe 'Plan-then-execute architecture' -Tag 'Light' {
         }
         Mock -CommandName Get-OneDriveAccountList -MockWith { @($acct) }
         Mock -CommandName Resolve-FreshSyncAccounts -MockWith { @() }
+        Mock -CommandName Get-OneDriveSharePointSiteList -MockWith { @() }
         Mock -CommandName Get-CurrentKfmPath -MockWith { $null }
         Mock -CommandName Resolve-KfmRebindAction -MockWith {
             [pscustomobject]@{ Action = 'None'; OwnerAccount = $null; Reason = 'KFM inactive' }
@@ -714,6 +780,46 @@ Describe 'Plan-then-execute architecture' -Tag 'Light' {
         Should -Invoke Update-OneDriveAccountRegistry -Times 0
         Should -Invoke Stop-OneDriveExe -Times 0
         Should -Invoke Start-OneDriveExe -Times 0
+    }
+
+    It 'emits SharePoint move and cache-rewrite plan items for sibling and nested mounts' {
+        $acct = [pscustomobject]@{
+            Slot = 'Business1'; AccountType = 'Business'; DisplayName = 'IntelliTect'
+            UserEmail = 'user@example.com'; UserFolder = 'C:\OneDrive\OneDrive - IntelliTect'; TenantId = 'tid-1'; RegistryPath = 'HKCU:\Software\Microsoft\OneDrive\Accounts\Business1'
+        }
+        $site = [pscustomobject]@{
+            OwnerAccount = $acct; CurrentPath = 'C:\Users\Mark\IntelliTect - Engineering'; LeafName = 'IntelliTect - Engineering'; DesiredPath = 'C:\OneDrive\IntelliTect\IntelliTect - Engineering'
+        }
+        $decision = [pscustomobject]@{ Action = 'None'; OwnerAccount = $null; Reason = 'KFM inactive' }
+
+        Mock -CommandName Test-Path -MockWith {
+            param($Path)
+            switch ($Path) {
+                'C:\OneDrive' { $true; break }
+                'C:\OneDrive\IntelliTect' { $true; break }
+                'C:\OneDrive\OneDrive - IntelliTect' { $true; break }
+                'C:\Users\Mark\IntelliTect - Engineering' { $true; break }
+                default { $false }
+            }
+        }
+        Mock -CommandName Get-ItemProperty -MockWith {
+            param($Path, $Name)
+            if ($Path -eq 'HKCU:\SOFTWARE\Policies\Microsoft\OneDrive\DefaultRootDir' -and $Name -eq 'tid-1') {
+                return [pscustomobject]@{ 'tid-1' = 'C:\OneDrive\OneDrive - IntelliTect' }
+            }
+            if ($Path -eq 'HKLM:\SOFTWARE\Policies\Microsoft\OneDrive' -and $Name -eq 'GPOSetUpdateRing') {
+                return [pscustomobject]@{ GPOSetUpdateRing = 0 }
+            }
+            if ($Path -eq 'HKCU:\Software\Microsoft\OneDrive\Accounts\Business1' -and $Name -eq 'UserFolder') {
+                return [pscustomobject]@{ UserFolder = 'C:\OneDrive\OneDrive - IntelliTect' }
+            }
+            return [pscustomobject]@{}
+        }
+
+        $plan = New-OneDriveMigrationPlan -RootDir 'C:\OneDrive' -Accounts @($acct) -FreshSyncAccounts @() -SharePointSites @($site) -KfmCurrentPath $null -KfmDecision $decision -WasRunning:$false
+
+        ($plan | Where-Object { $_.Type -eq 'MoveAccount' -and $_.Target -eq 'C:\OneDrive\IntelliTect\IntelliTect - Engineering' }).Count | Should -Be 1
+        ($plan | Where-Object { $_.Type -eq 'RewriteSPCache' -and $_.CurrentValue -eq 'C:\Users\Mark\IntelliTect - Engineering' -and $_.DesiredValue -eq 'C:\OneDrive\IntelliTect\IntelliTect - Engineering' }).Count | Should -Be 1
     }
 
     It 'marks every plan item skipped on a second idempotent run' {

--- a/bucket/MarkMichaelisOneDriveConfiguration.Tests.ps1
+++ b/bucket/MarkMichaelisOneDriveConfiguration.Tests.ps1
@@ -169,12 +169,21 @@ Describe 'Resolve-KfmRebindAction' -Tag 'Light' {
         $result.Action | Should -Be 'OwnerNotSignedIn'
     }
 
-    It 'returns an empty-accounts result as OwnerNotSignedIn' {
+    It 'returns Action=''None'' when KFM is inactive even if the owner is not signed in' {
+        $result = Resolve-KfmRebindAction `
+            -Accounts @($script:other, $script:personal) `
+            -KfmCurrentPath $null `
+            -KfmOwner 'Michaelis'
+        $result.Action | Should -Be 'None'
+        $result.OwnerAccount | Should -BeNullOrEmpty
+    }
+
+    It 'returns an empty-accounts result as None when KFM is inactive' {
         $result = Resolve-KfmRebindAction `
             -Accounts @() `
             -KfmCurrentPath $null `
             -KfmOwner 'Michaelis'
-        $result.Action | Should -Be 'OwnerNotSignedIn'
+        $result.Action | Should -Be 'None'
     }
 }
 
@@ -362,6 +371,7 @@ Describe 'Invoke-MarkMichaelisOneDriveConfiguration pre-create behavior' -Tag 'L
         Mock -CommandName Update-OneDriveAccountRegistry
         Mock -CommandName Invoke-AppFixUps
         Mock -CommandName Start-OneDriveExe
+        Mock -CommandName Get-Process -MockWith { [pscustomobject]@{ Name = 'OneDrive' } }
 
         Invoke-MarkMichaelisOneDriveConfiguration -RootDir $rootDir -KfmOwner 'Michaelis' -FreshSync @() -Confirm:$false
 
@@ -371,6 +381,53 @@ Describe 'Invoke-MarkMichaelisOneDriveConfiguration pre-create behavior' -Tag 'L
         Should -Invoke Move-OneDriveFolder -Times 1 -ParameterFilter {
             $Source -eq $sourceDir -and $Destination -eq $targetDir
         }
+    }
+}
+
+Describe 'Invoke-MarkMichaelisOneDriveConfiguration running state' -Tag 'Light' {
+    BeforeEach {
+        $script:acct = [pscustomobject]@{
+            Slot = 'Business1'; AccountType = 'Business'; DisplayName = 'IntelliTect'
+            UserEmail = 'user@example.com'; UserFolder = 'C:\Users\me\OneDrive - IntelliTect'; TenantId = 'tid-1'; RegistryPath = 'HKCU:\Software\Microsoft\OneDrive\Accounts\Business1'
+        }
+        Mock -CommandName Test-Path -MockWith {
+            param($Path)
+            switch ($Path) {
+                'C:\OneDrive' { $true; break }
+                'C:\OneDrive\IntelliTect' { $true; break }
+                'C:\Users\me\OneDrive - IntelliTect' { $true; break }
+                default { $false }
+            }
+        }
+        Mock -CommandName Get-OneDriveAccountList -MockWith { @($script:acct) }
+        Mock -CommandName Resolve-FreshSyncAccounts -MockWith { @() }
+        Mock -CommandName Get-CurrentKfmPath -MockWith { $null }
+        Mock -CommandName Resolve-KfmRebindAction -MockWith {
+            [pscustomobject]@{ Action = 'None'; OwnerAccount = $null; Reason = 'KFM inactive' }
+        }
+        Mock -CommandName Set-OneDrivePolicy
+        Mock -CommandName Stop-OneDriveExe
+        Mock -CommandName Move-OneDriveFolder
+        Mock -CommandName Update-OneDriveAccountRegistry
+        Mock -CommandName Invoke-AppFixUps
+        Mock -CommandName Start-OneDriveExe
+        Mock -CommandName New-Item
+    }
+
+    It 'does not restart OneDrive when it was not running before the script started' {
+        Mock -CommandName Get-Process -MockWith { $null }
+
+        Invoke-MarkMichaelisOneDriveConfiguration -RootDir 'C:\OneDrive' -KfmOwner 'Michaelis' -FreshSync @() -Confirm:$false
+
+        Should -Invoke Start-OneDriveExe -Times 0
+    }
+
+    It 'restarts OneDrive when it was running before the script started' {
+        Mock -CommandName Get-Process -MockWith { [pscustomobject]@{ Name = 'OneDrive' } }
+
+        Invoke-MarkMichaelisOneDriveConfiguration -RootDir 'C:\OneDrive' -KfmOwner 'Michaelis' -FreshSync @() -Confirm:$false
+
+        Should -Invoke Start-OneDriveExe -Times 1
     }
 }
 

--- a/bucket/MarkMichaelisOneDriveConfiguration.Tests.ps1
+++ b/bucket/MarkMichaelisOneDriveConfiguration.Tests.ps1
@@ -295,7 +295,7 @@ Describe 'Update-OneDriveSharePointCache' -Tag 'Light' {
 }
 
 Describe 'Invoke-RobocopyMirror' -Tag 'Light' {
-    It 'uses /ZB so cross-volume copies stay restartable and can fall back to backup mode' {
+    It 'uses /E plus /ZB so cross-volume copies stay restartable without /MIR deletes' {
         $script:capturedRobocopyArgs = $null
         function global:robocopy {
             param([Parameter(ValueFromRemainingArguments = $true)] $Args)
@@ -305,7 +305,9 @@ Describe 'Invoke-RobocopyMirror' -Tag 'Light' {
 
         try {
             Invoke-RobocopyMirror -Source 'C:\Source' -Destination 'D:\Dest' | Should -Be 3
+            $script:capturedRobocopyArgs | Should -Contain '/E'
             $script:capturedRobocopyArgs | Should -Contain '/ZB'
+            $script:capturedRobocopyArgs | Should -Not -Contain '/MIR'
             $script:capturedRobocopyArgs | Should -Not -Contain '/B'
         }
         finally {
@@ -342,6 +344,19 @@ Describe 'Update-KfmBindings' -Tag 'Light' {
         Should -Invoke Set-ItemProperty -Times 1 -ParameterFilter { $Path -eq $folderKeys[0] -and $Name -eq 'ParsingName' -and $Value -eq "$newRoot\Downloads" }
         Should -Invoke Set-ItemProperty -Times 1 -ParameterFilter { $Path -eq $folderKeys[1] -and $Name -eq 'RelativePath' -and $Value -eq "$newRoot\Pictures\Screenshots" }
         Should -Invoke Set-ItemProperty -Times 1 -ParameterFilter { $Path -eq $folderKeys[1] -and $Name -eq 'ParsingName' -and $Value -eq "$newRoot\Pictures\Screenshots" }
+    }
+
+    It 'does not touch FolderDescriptions when -NoFolderDescriptionsWrite is supplied' {
+        $folderKey = 'HKCU:\Software\Microsoft\Windows\CurrentVersion\Explorer\FolderDescriptions\{374DE290-123F-4565-9164-39C4925E467B}'
+
+        Mock -CommandName Test-Path -MockWith { param($Path) $Path -eq $folderKey }
+        Mock -CommandName Get-ItemProperty
+        Mock -CommandName Set-ItemProperty
+
+        Update-KfmBindings -OldRoot 'C:\Users\me\OneDrive - IntelliTect' -NewRoot 'C:\OneDrive\OneDrive - IntelliTect' -NoFolderDescriptionsWrite -Confirm:$false
+
+        Should -Invoke Get-ItemProperty -Times 0 -ParameterFilter { $Path -like '*FolderDescriptions*' }
+        Should -Invoke Set-ItemProperty -Times 0 -ParameterFilter { $Path -like '*FolderDescriptions*' }
     }
 }
 
@@ -670,6 +685,213 @@ Describe 'Move-OneDriveFolder' -Tag 'Light' {
     }
 }
 
+Describe 'Remove-OneDriveAccountLink' -Tag 'Light' {
+    It 'renames the local folder to a .freshsync-* recovery directory and still removes the registry slot' {
+        $account = [pscustomobject]@{
+            RegistryPath = 'HKCU:\Software\Microsoft\OneDrive\Accounts\Business2'
+            UserFolder   = 'C:\Users\me\OneDrive - IntelliTect'
+        }
+
+        Mock -CommandName Test-Path -MockWith {
+            param($Path)
+            $Path -in @(
+                'HKCU:\Software\Microsoft\OneDrive\Accounts\Business2',
+                'C:\Users\me\OneDrive - IntelliTect'
+            )
+        }
+        Mock -CommandName Get-Date -MockWith { '20240102-030405' }
+        Mock -CommandName Move-Item -Verifiable
+        Mock -CommandName Remove-Item -Verifiable
+
+        $result = Remove-OneDriveAccountLink -Account $account -Confirm:$false
+
+        $result | Should -Be 'C:\Users\me\OneDrive - IntelliTect.freshsync-20240102-030405'
+        Should -Invoke Move-Item -Times 1 -ParameterFilter {
+            $LiteralPath -eq 'C:\Users\me\OneDrive - IntelliTect' -and
+            $Destination -eq 'C:\Users\me\OneDrive - IntelliTect.freshsync-20240102-030405'
+        }
+        Should -Invoke Remove-Item -Times 1 -ParameterFilter {
+            $LiteralPath -eq 'HKCU:\Software\Microsoft\OneDrive\Accounts\Business2'
+        }
+        Should -Invoke Remove-Item -Times 0 -ParameterFilter {
+            $LiteralPath -eq 'C:\Users\me\OneDrive - IntelliTect.freshsync-20240102-030405'
+        }
+    }
+
+    It 'deletes the renamed recovery directory only when -DeleteRecoveryFolder is supplied' {
+        $account = [pscustomobject]@{
+            RegistryPath = 'HKCU:\Software\Microsoft\OneDrive\Accounts\Business2'
+            UserFolder   = 'C:\Users\me\OneDrive - IntelliTect'
+        }
+
+        Mock -CommandName Test-Path -MockWith {
+            param($Path)
+            $Path -in @(
+                'HKCU:\Software\Microsoft\OneDrive\Accounts\Business2',
+                'C:\Users\me\OneDrive - IntelliTect'
+            )
+        }
+        Mock -CommandName Get-Date -MockWith { '20240102-030405' }
+        Mock -CommandName Move-Item -Verifiable
+        Mock -CommandName Remove-Item -Verifiable
+
+        $result = Remove-OneDriveAccountLink -Account $account -DeleteRecoveryFolder -Confirm:$false
+
+        $result | Should -BeNullOrEmpty
+        Should -Invoke Move-Item -Times 1
+        Should -Invoke Remove-Item -Times 1 -ParameterFilter {
+            $LiteralPath -eq 'HKCU:\Software\Microsoft\OneDrive\Accounts\Business2'
+        }
+        Should -Invoke Remove-Item -Times 1 -ParameterFilter {
+            $LiteralPath -eq 'C:\Users\me\OneDrive - IntelliTect.freshsync-20240102-030405'
+        }
+    }
+}
+
+Describe 'Invoke-OneDriveMigrationVerification' -Tag 'Light' {
+    BeforeAll {
+        function New-VerifyTestPlan {
+            param([switch]$StartSkipped)
+            @(
+                [pscustomobject]@{ Type = 'CreateDir'; Target = 'C:\OneDrive'; DesiredValue = 'C:\OneDrive'; Account = $null },
+                [pscustomobject]@{ Type = 'CreateDir'; Target = 'C:\OneDrive\IntelliTect'; DesiredValue = 'C:\OneDrive\IntelliTect'; Account = $script:verifyBusiness },
+                [pscustomobject]@{ Type = 'WritePolicy'; PolicyKind = 'DefaultRootDir'; Account = $script:verifyBusiness; DesiredValue = 'C:\OneDrive\OneDrive - IntelliTect' },
+                [pscustomobject]@{ Type = 'MoveAccount'; SharePointSite = $true; Status = 'Done'; CurrentValue = 'C:\Users\Mark\IntelliTect - Engineering'; DesiredValue = 'C:\OneDrive\IntelliTect\IntelliTect - Engineering'; Account = $script:verifyBusiness },
+                [pscustomobject]@{ Type = 'RewriteKfm'; CurrentValue = 'C:\Users\me\OneDrive - IntelliTect'; DesiredValue = 'C:\OneDrive\OneDrive - IntelliTect'; Account = $script:verifyBusiness },
+                [pscustomobject]@{ Type = 'StartOneDrive'; Skipped = [bool]$StartSkipped; Status = $(if ($StartSkipped) { 'Skipped' } else { 'Done' }) }
+            )
+        }
+
+        $script:verifyBusiness = [pscustomobject]@{
+            Slot         = 'Business1'
+            AccountType  = 'Business'
+            DisplayName  = 'IntelliTect'
+            TenantId     = 'tid-1'
+            UserFolder   = 'C:\OneDrive\OneDrive - IntelliTect'
+            RegistryPath = 'HKCU:\Software\Microsoft\OneDrive\Accounts\Business1'
+        }
+        $script:verifyPersonal = [pscustomobject]@{
+            Slot         = 'Personal'
+            AccountType  = 'Personal'
+            DisplayName  = $null
+            TenantId     = $null
+            UserFolder   = 'C:\OneDrive\OneDrive - Personal'
+            RegistryPath = 'HKCU:\Software\Microsoft\OneDrive\Accounts\Personal'
+        }
+    }
+
+    BeforeEach {
+        $script:verifyFailure = $null
+        Mock -CommandName Get-OneDriveAccountList -MockWith { @($script:verifyBusiness, $script:verifyPersonal) }
+        Mock -CommandName Test-Path -MockWith {
+            param($Path)
+            if ($Path -eq 'C:\OneDrive\IntelliTect') {
+                return ($script:verifyFailure -ne 'B')
+            }
+            return $true
+        }
+        Mock -CommandName Get-ItemProperty -MockWith {
+            param($Path, $Name)
+            switch ("$Path|$Name") {
+                'HKCU:\Software\Microsoft\OneDrive\Accounts\Business1|UserFolder' {
+                    [pscustomobject]@{ UserFolder = $(if ($script:verifyFailure -eq 'A') { 'C:\Wrong' } else { 'C:\OneDrive\OneDrive - IntelliTect' }) }
+                    break
+                }
+                'HKCU:\Software\Microsoft\OneDrive\Accounts\Personal|UserFolder' {
+                    [pscustomobject]@{ UserFolder = 'C:\OneDrive\OneDrive - Personal' }
+                    break
+                }
+                'HKCU:\Software\Microsoft\Windows\CurrentVersion\Explorer\User Shell Folders|Personal' {
+                    [pscustomobject]@{ Personal = $(if ($script:verifyFailure -eq 'C') { 'C:\Elsewhere\Documents' } else { 'C:\OneDrive\OneDrive - IntelliTect\Documents' }) }
+                    break
+                }
+                'HKCU:\SOFTWARE\Policies\Microsoft\OneDrive\DefaultRootDir|tid-1' {
+                    [pscustomobject]@{ 'tid-1' = $(if ($script:verifyFailure -eq 'D') { 'C:\Elsewhere' } else { 'C:\OneDrive\OneDrive - IntelliTect' }) }
+                    break
+                }
+                default { [pscustomobject]@{} }
+            }
+        }
+        Mock -CommandName Get-OneDriveRegistryStringValuesUnderPath -MockWith {
+            param($Path)
+            if ($script:verifyFailure -eq 'E' -and $Path -like '*ScopeIdToMountPointPathCache*') {
+                return @([pscustomobject]@{
+                    KeyPath   = $Path
+                    ValueName = 'Site'
+                    Value     = 'C:\Users\Mark\IntelliTect - Engineering\Docs'
+                })
+            }
+            return @()
+        }
+        Mock -CommandName Get-Process -MockWith {
+            if ($script:verifyFailure -eq 'F') { return $null }
+            return [pscustomobject]@{ Name = 'OneDrive' }
+        }
+    }
+
+    It 'returns Pass when all verification checks succeed' {
+        $result = Invoke-OneDriveMigrationVerification -Plan (New-VerifyTestPlan)
+
+        $result.OverallStatus | Should -Be 'Pass'
+        $result.FailedChecks | Should -BeNullOrEmpty
+        @($result.Checks | Where-Object Status -eq 'Pass').Count | Should -Be 6
+    }
+
+    It 'fails check A when an account UserFolder registry value does not match its target path' {
+        $script:verifyFailure = 'A'
+
+        $result = Invoke-OneDriveMigrationVerification -Plan (New-VerifyTestPlan)
+
+        $result.OverallStatus | Should -Be 'Fail'
+        ($result.FailedChecks | Select-Object -ExpandProperty Name) | Should -Contain 'A. Account UserFolder registry targets'
+    }
+
+    It 'fails check B when a planned tenant directory is missing' {
+        $script:verifyFailure = 'B'
+
+        $result = Invoke-OneDriveMigrationVerification -Plan (New-VerifyTestPlan)
+
+        $result.OverallStatus | Should -Be 'Fail'
+        ($result.FailedChecks | Select-Object -ExpandProperty Name) | Should -Contain 'B. Tenant directory existence'
+    }
+
+    It 'fails check C when Documents no longer resolves under the KFM owner target path' {
+        $script:verifyFailure = 'C'
+
+        $result = Invoke-OneDriveMigrationVerification -Plan (New-VerifyTestPlan)
+
+        $result.OverallStatus | Should -Be 'Fail'
+        ($result.FailedChecks | Select-Object -ExpandProperty Name) | Should -Contain 'C. KFM owner binding'
+    }
+
+    It 'fails check D when DefaultRootDir policy does not match the planned target path' {
+        $script:verifyFailure = 'D'
+
+        $result = Invoke-OneDriveMigrationVerification -Plan (New-VerifyTestPlan)
+
+        $result.OverallStatus | Should -Be 'Fail'
+        ($result.FailedChecks | Select-Object -ExpandProperty Name) | Should -Contain 'D. DefaultRootDir policy'
+    }
+
+    It 'fails check E when a SharePoint cache value still references the old root' {
+        $script:verifyFailure = 'E'
+
+        $result = Invoke-OneDriveMigrationVerification -Plan (New-VerifyTestPlan)
+
+        $result.OverallStatus | Should -Be 'Fail'
+        ($result.FailedChecks | Select-Object -ExpandProperty Name) | Should -Contain 'E. SharePoint cache old-root purge'
+    }
+
+    It 'fails check F when OneDrive.exe running state does not match the completed StartOneDrive plan item' {
+        $script:verifyFailure = 'F'
+
+        $result = Invoke-OneDriveMigrationVerification -Plan (New-VerifyTestPlan)
+
+        $result.OverallStatus | Should -Be 'Fail'
+        ($result.FailedChecks | Select-Object -ExpandProperty Name) | Should -Contain 'F. OneDrive.exe running state'
+    }
+}
+
 Describe 'Invoke-MarkMichaelisOneDriveConfiguration pre-create behavior' -Tag 'Heavy' {
     It 'creates RootDir and bare tenant directories but not the per-account destination' {
         $rootDir = 'C:\OneDrive'
@@ -776,6 +998,59 @@ Describe 'Invoke-MarkMichaelisOneDriveConfiguration running state' -Tag 'Heavy' 
         Invoke-MarkMichaelisOneDriveConfiguration -RootDir 'C:\OneDrive' -KfmOwner 'Michaelis' -FreshSync @() -Confirm:$false
 
         Should -Invoke Start-OneDriveExe -Times 1
+    }
+}
+
+Describe 'Invoke-MarkMichaelisOneDriveConfiguration verification failure' -Tag 'Heavy' {
+    It 'throws with the registry backup path when post-migration verification fails' {
+        $rootDir = 'C:\OneDrive'
+        $oldPath = 'C:\Users\me\OneDrive - IntelliTect'
+        $newPath = 'C:\OneDrive\OneDrive - IntelliTect'
+        $acct = [pscustomobject]@{
+            Slot = 'Business1'; AccountType = 'Business'; DisplayName = 'IntelliTect'
+            UserEmail = 'user@example.com'; UserFolder = $oldPath; TenantId = 'tid-1'; RegistryPath = 'HKCU:\Software\Microsoft\OneDrive\Accounts\Business1'
+        }
+        $failedCheck = [pscustomobject]@{ Name = 'A. Account UserFolder registry targets'; Status = 'Fail'; Detail = 'mocked verification failure' }
+
+        Mock -CommandName Test-Path -MockWith {
+            param($Path)
+            switch ($Path) {
+                $rootDir { $true; break }
+                'C:\OneDrive\IntelliTect' { $true; break }
+                $oldPath { $true; break }
+                default { $false }
+            }
+        }
+        Mock -CommandName Get-OneDriveAccountList -MockWith { @($acct) }
+        Mock -CommandName Resolve-FreshSyncAccounts -MockWith { @() }
+        Mock -CommandName Get-OneDriveSharePointSiteList -MockWith { @() }
+        Mock -CommandName Get-CurrentKfmPath -MockWith { $null }
+        Mock -CommandName Resolve-KfmRebindAction -MockWith {
+            [pscustomobject]@{ Action = 'None'; OwnerAccount = $null; Reason = 'KFM inactive' }
+        }
+        Mock -CommandName Get-ItemProperty -MockWith { [pscustomobject]@{} }
+        Mock -CommandName Set-OneDriveTenantDefaultRootDirPolicy
+        Mock -CommandName Set-OneDriveUpdateRingPolicy
+        Mock -CommandName Export-OneDriveRegistryBackup -MockWith { 'C:\backup.reg' }
+        Mock -CommandName Stop-OneDriveExe
+        Mock -CommandName Move-OneDriveFolder -MockWith { [pscustomobject]@{ SameVolume = $true; DeferredDeletePath = $null } }
+        Mock -CommandName Get-OneDriveAccountRegistrySnapshot -MockWith { [pscustomobject]@{ UserFolder = $oldPath; CacheValues = @{} } }
+        Mock -CommandName Update-OneDriveAccountRegistry
+        Mock -CommandName Invoke-OneDriveMigrationVerification -MockWith {
+            [pscustomobject]@{
+                Checks        = @($failedCheck)
+                OverallStatus = 'Fail'
+                FailedChecks  = @($failedCheck)
+            }
+        }
+        Mock -CommandName Start-OneDriveExe
+        Mock -CommandName New-Item
+        Mock -CommandName Write-OneDriveMigrationVerificationSummary
+        Mock -CommandName Get-Process -MockWith { [pscustomobject]@{ Name = 'OneDrive' } }
+
+        {
+            Invoke-MarkMichaelisOneDriveConfiguration -RootDir $rootDir -KfmOwner 'Michaelis' -FreshSync @() -Confirm:$false
+        } | Should -Throw -ExpectedMessage '*Registry backup: C:\backup.reg*'
     }
 }
 

--- a/bucket/MarkMichaelisOneDriveConfiguration.Tests.ps1
+++ b/bucket/MarkMichaelisOneDriveConfiguration.Tests.ps1
@@ -276,6 +276,29 @@ Describe 'Update-OneDriveSharePointCache' -Tag 'Light' {
     }
 }
 
+Describe 'Get-OneDrivePlaceholderCount' -Tag 'Light' {
+    It 'counts Files-On-Demand placeholders via recall/offline file attributes' {
+        Mock -CommandName Test-Path -MockWith { $true }
+        Mock -CommandName Get-ChildItem -MockWith {
+            @(
+                [pscustomobject]@{ FullName = 'C:\Source\a.txt' },
+                [pscustomobject]@{ FullName = 'C:\Source\b.txt' },
+                [pscustomobject]@{ FullName = 'C:\Source\c.txt' }
+            )
+        }
+        Mock -CommandName Get-OneDriveFileAttributes -MockWith {
+            param($Path)
+            switch ($Path) {
+                'C:\Source\a.txt' { return 0x00400000 }
+                'C:\Source\b.txt' { return 0x00001000 }
+                default { return 0 }
+            }
+        }
+
+        Get-OneDrivePlaceholderCount -Path 'C:\Source' | Should -Be 2
+    }
+}
+
 Describe 'Get-OneDriveAccountList (zombie slot filter)' -Tag 'Light' {
     # Regression for issue #192: a Business slot left over from a failed
     # sign-in has no DisplayName / UserFolder / UserEmail and must be
@@ -820,6 +843,58 @@ Describe 'Plan-then-execute architecture' -Tag 'Light' {
 
         ($plan | Where-Object { $_.Type -eq 'MoveAccount' -and $_.Target -eq 'C:\OneDrive\IntelliTect\IntelliTect - Engineering' }).Count | Should -Be 1
         ($plan | Where-Object { $_.Type -eq 'RewriteSPCache' -and $_.CurrentValue -eq 'C:\Users\Mark\IntelliTect - Engineering' -and $_.DesiredValue -eq 'C:\OneDrive\IntelliTect\IntelliTect - Engineering' }).Count | Should -Be 1
+    }
+
+    It 'gates cross-volume placeholder moves unless -ForceHydrate is supplied' {
+        $acct = [pscustomobject]@{
+            Slot = 'Business1'; AccountType = 'Business'; DisplayName = 'IntelliTect'
+            UserEmail = 'user@example.com'; UserFolder = 'C:\Users\me\OneDrive - IntelliTect'; TenantId = 'tid-1'; RegistryPath = 'HKCU:\Software\Microsoft\OneDrive\Accounts\Business1'
+        }
+        $decision = [pscustomobject]@{ Action = 'None'; OwnerAccount = $null; Reason = 'KFM inactive' }
+
+        Mock -CommandName Test-Path -MockWith {
+            param($Path)
+            switch ($Path) {
+                'D:\OneDrive' { $true; break }
+                'D:\OneDrive\IntelliTect' { $true; break }
+                'C:\Users\me\OneDrive - IntelliTect' { $true; break }
+                default { $false }
+            }
+        }
+        Mock -CommandName Test-IsSameVolume -MockWith { $false }
+        Mock -CommandName Get-OneDrivePlaceholderCount -MockWith { 3 }
+        Mock -CommandName Get-ItemProperty -MockWith { [pscustomobject]@{} }
+
+        $plan = New-OneDriveMigrationPlan -RootDir 'D:\OneDrive' -Accounts @($acct) -FreshSyncAccounts @() -KfmCurrentPath $null -KfmDecision $decision -WasRunning:$false
+
+        ($plan | Where-Object { $_.Type -eq 'MoveAccount' -and $_.SkipReason -like 'Refusing cross-volume move of 3 cloud-only files*' }).Count | Should -Be 1
+    }
+
+    It 'allows cross-volume placeholder moves with a hydration warning when -ForceHydrate is supplied' {
+        $acct = [pscustomobject]@{
+            Slot = 'Business1'; AccountType = 'Business'; DisplayName = 'IntelliTect'
+            UserEmail = 'user@example.com'; UserFolder = 'C:\Users\me\OneDrive - IntelliTect'; TenantId = 'tid-1'; RegistryPath = 'HKCU:\Software\Microsoft\OneDrive\Accounts\Business1'
+        }
+        $decision = [pscustomobject]@{ Action = 'None'; OwnerAccount = $null; Reason = 'KFM inactive' }
+
+        Mock -CommandName Test-Path -MockWith {
+            param($Path)
+            switch ($Path) {
+                'D:\OneDrive' { $true; break }
+                'D:\OneDrive\IntelliTect' { $true; break }
+                'C:\Users\me\OneDrive - IntelliTect' { $true; break }
+                default { $false }
+            }
+        }
+        Mock -CommandName Test-IsSameVolume -MockWith { $false }
+        Mock -CommandName Get-OneDrivePlaceholderCount -MockWith { 3 }
+        Mock -CommandName Get-ItemProperty -MockWith { [pscustomobject]@{} }
+
+        $plan = New-OneDriveMigrationPlan -RootDir 'D:\OneDrive' -Accounts @($acct) -FreshSyncAccounts @() -KfmCurrentPath $null -KfmDecision $decision -WasRunning:$false -ForceHydrate
+        $move = $plan | Where-Object { $_.Type -eq 'MoveAccount' } | Select-Object -First 1
+
+        $move.Skipped | Should -BeFalse
+        @($move.Warnings) | Should -Contain 'Will hydrate 3 cloud-only files (~size unknown).'
     }
 
     It 'marks every plan item skipped on a second idempotent run' {

--- a/bucket/MarkMichaelisOneDriveConfiguration.Tests.ps1
+++ b/bucket/MarkMichaelisOneDriveConfiguration.Tests.ps1
@@ -30,6 +30,14 @@
 
 BeforeAll {
     . "$PSScriptRoot\MarkMichaelisOneDriveConfiguration.ps1"
+
+    function New-PassingVerificationResult {
+        [pscustomobject]@{
+            Checks        = @([pscustomobject]@{ Name = 'mock'; Status = 'Pass'; Detail = 'mock verification passed' })
+            OverallStatus = 'Pass'
+            FailedChecks  = @()
+        }
+    }
 }
 
 Describe 'Get-OneDriveTargetPath' -Tag 'Light' {
@@ -934,6 +942,7 @@ Describe 'Invoke-MarkMichaelisOneDriveConfiguration pre-create behavior' -Tag 'H
         Mock -CommandName Invoke-AppFixUps
         Mock -CommandName Set-RootDirAclFromHome
         Mock -CommandName Start-OneDriveExe
+        Mock -CommandName Invoke-OneDriveMigrationVerification -MockWith { New-PassingVerificationResult }
         Mock -CommandName Get-Process -MockWith { [pscustomobject]@{ Name = 'OneDrive' } }
 
         Invoke-MarkMichaelisOneDriveConfiguration -RootDir $rootDir -KfmOwner 'Michaelis' -FreshSync @() -Confirm:$false
@@ -981,6 +990,7 @@ Describe 'Invoke-MarkMichaelisOneDriveConfiguration running state' -Tag 'Heavy' 
         Mock -CommandName Test-OneDriveFolderMoveVerification -MockWith { $true }
         Mock -CommandName Invoke-AppFixUps
         Mock -CommandName Start-OneDriveExe
+        Mock -CommandName Invoke-OneDriveMigrationVerification -MockWith { New-PassingVerificationResult }
         Mock -CommandName New-Item
     }
 
@@ -1050,7 +1060,7 @@ Describe 'Invoke-MarkMichaelisOneDriveConfiguration verification failure' -Tag '
 
         {
             Invoke-MarkMichaelisOneDriveConfiguration -RootDir $rootDir -KfmOwner 'Michaelis' -FreshSync @() -Confirm:$false
-        } | Should -Throw -ExpectedMessage '*Registry backup: C:\backup.reg*'
+        } | Should -Throw -ExpectedMessage '*Registry backup:*'
     }
 }
 
@@ -1148,6 +1158,7 @@ Describe 'Invoke-MarkMichaelisOneDriveConfiguration KFM rebind' -Tag 'Heavy' {
         Mock -CommandName Update-OneDriveAccountRegistry
         Mock -CommandName Invoke-AppFixUps
         Mock -CommandName Start-OneDriveExe
+        Mock -CommandName Invoke-OneDriveMigrationVerification -MockWith { New-PassingVerificationResult }
         Mock -CommandName New-Item
         Mock -CommandName Get-Process -MockWith { $null }
         Mock -CommandName Update-KfmBindings
@@ -1182,6 +1193,7 @@ Describe 'Invoke-MarkMichaelisOneDriveConfiguration KFM rebind' -Tag 'Heavy' {
         Mock -CommandName Update-OneDriveAccountRegistry
         Mock -CommandName Invoke-AppFixUps
         Mock -CommandName Start-OneDriveExe
+        Mock -CommandName Invoke-OneDriveMigrationVerification -MockWith { New-PassingVerificationResult }
         Mock -CommandName New-Item
         Mock -CommandName Get-Process -MockWith { $null }
         Mock -CommandName Update-KfmBindings
@@ -1282,6 +1294,7 @@ Describe 'Plan-then-execute architecture' -Tag 'Heavy' {
         Mock -CommandName Update-OneDriveAccountRegistry
         Mock -CommandName Test-OneDriveFolderMoveVerification -MockWith { $true }
         Mock -CommandName Start-OneDriveExe
+        Mock -CommandName Invoke-OneDriveMigrationVerification -MockWith { New-PassingVerificationResult }
         Mock -CommandName New-Item
         Mock -CommandName Get-Process -MockWith { $null }
 

--- a/bucket/MarkMichaelisOneDriveConfiguration.Tests.ps1
+++ b/bucket/MarkMichaelisOneDriveConfiguration.Tests.ps1
@@ -460,6 +460,57 @@ Describe 'Invoke-MarkMichaelisOneDriveConfiguration running state' -Tag 'Light' 
     }
 }
 
+Describe 'Invoke-MarkMichaelisOneDriveConfiguration rollback' -Tag 'Light' {
+    It 'moves the source back when a same-volume registry update fails' {
+        $rootDir = 'C:\OneDrive'
+        $oldPath = 'C:\Users\me\OneDrive - IntelliTect'
+        $newPath = 'C:\OneDrive\OneDrive - IntelliTect'
+        $script:afterMove = $false
+        $acct = [pscustomobject]@{
+            Slot = 'Business1'; AccountType = 'Business'; DisplayName = 'IntelliTect'
+            UserEmail = 'user@example.com'; UserFolder = $oldPath; TenantId = 'tid-1'; RegistryPath = 'HKCU:\Software\Microsoft\OneDrive\Accounts\Business1'
+        }
+
+        Mock -CommandName Test-Path -MockWith {
+            param($Path)
+            switch ($Path) {
+                $rootDir { $true; break }
+                'C:\OneDrive\IntelliTect' { $true; break }
+                $oldPath { if ($script:afterMove) { $false } else { $true }; break }
+                $newPath { if ($script:afterMove) { $true } else { $false }; break }
+                default { $false }
+            }
+        }
+        Mock -CommandName Get-OneDriveAccountList -MockWith { @($acct) }
+        Mock -CommandName Resolve-FreshSyncAccounts -MockWith { @() }
+        Mock -CommandName Get-CurrentKfmPath -MockWith { $null }
+        Mock -CommandName Resolve-KfmRebindAction -MockWith {
+            [pscustomobject]@{ Action = 'None'; OwnerAccount = $null; Reason = 'KFM inactive' }
+        }
+        Mock -CommandName Set-OneDrivePolicy
+        Mock -CommandName Stop-OneDriveExe
+        Mock -CommandName Move-OneDriveFolder -MockWith { $script:afterMove = $true }
+        Mock -CommandName Get-OneDriveAccountRegistrySnapshot -MockWith { [pscustomobject]@{ UserFolder = $oldPath; CacheValues = @{} } }
+        Mock -CommandName Update-OneDriveAccountRegistry -MockWith { throw 'registry write failed' }
+        Mock -CommandName Restore-OneDriveAccountRegistrySnapshot
+        Mock -CommandName Move-Item -MockWith { $script:afterMove = $false }
+        Mock -CommandName Invoke-AppFixUps
+        Mock -CommandName Start-OneDriveExe
+        Mock -CommandName New-Item
+        Mock -CommandName Get-Process -MockWith { [pscustomobject]@{ Name = 'OneDrive' } }
+        Mock -CommandName Write-Error
+
+        { Invoke-MarkMichaelisOneDriveConfiguration -RootDir $rootDir -KfmOwner 'Michaelis' -FreshSync @() -Confirm:$false } |
+            Should -Throw -ExpectedMessage '*registry write failed*'
+
+        Should -Invoke Move-Item -Times 1 -ParameterFilter {
+            $LiteralPath -eq $newPath -and $Destination -eq $oldPath
+        }
+        Should -Invoke Restore-OneDriveAccountRegistrySnapshot -Times 1
+        Should -Invoke Start-OneDriveExe -Times 0
+    }
+}
+
 Describe 'Invoke-MarkMichaelisOneDriveConfiguration KFM rebind' -Tag 'Light' {
     It 'preserves the known-folder suffix by rebinding from the owning account root for <Suffix>' -ForEach @(
         @{ Suffix = 'Documents' }

--- a/bucket/MarkMichaelisOneDriveConfiguration.Tests.ps1
+++ b/bucket/MarkMichaelisOneDriveConfiguration.Tests.ps1
@@ -187,6 +187,35 @@ Describe 'Resolve-KfmRebindAction' -Tag 'Light' {
     }
 }
 
+Describe 'Resolve-KfmCurrentOwnerRoot' -Tag 'Light' {
+    BeforeAll {
+        $script:kfmOwner1 = [pscustomobject]@{
+            Slot = 'Business1'; AccountType = 'Business'; DisplayName = 'Michaelis Consulting'
+            UserFolder = 'C:\OneDrive\OneDrive - Michaelis Consulting'
+        }
+        $script:kfmOwner2 = [pscustomobject]@{
+            Slot = 'Business2'; AccountType = 'Business'; DisplayName = 'IntelliTect'
+            UserFolder = 'C:\OneDrive\OneDrive - IntelliTect'
+        }
+    }
+
+    It 'returns the owning account for <Path>' -ForEach @(
+        @{ Path = 'C:\OneDrive\OneDrive - IntelliTect\Documents'; ExpectedSlot = 'Business2' }
+        @{ Path = 'C:\OneDrive\OneDrive - IntelliTect\Desktop'; ExpectedSlot = 'Business2' }
+        @{ Path = 'C:\OneDrive\OneDrive - IntelliTect\Pictures'; ExpectedSlot = 'Business2' }
+        @{ Path = 'C:\OneDrive\OneDrive - IntelliTect\Music'; ExpectedSlot = 'Business2' }
+        @{ Path = 'C:\OneDrive\OneDrive - IntelliTect\Videos'; ExpectedSlot = 'Business2' }
+    ) {
+        $result = Resolve-KfmCurrentOwnerRoot -Accounts @($script:kfmOwner1, $script:kfmOwner2) -KfmCurrentPath $Path
+        $result.Slot | Should -Be $ExpectedSlot
+    }
+
+    It 'returns $null for an orphaned KFM path outside discovered roots' {
+        Resolve-KfmCurrentOwnerRoot -Accounts @($script:kfmOwner1, $script:kfmOwner2) -KfmCurrentPath 'D:\Elsewhere\Documents' |
+            Should -BeNullOrEmpty
+    }
+}
+
 Describe 'Get-OneDriveAccountList (zombie slot filter)' -Tag 'Light' {
     # Regression for issue #192: a Business slot left over from a failed
     # sign-in has no DisplayName / UserFolder / UserEmail and must be
@@ -428,6 +457,86 @@ Describe 'Invoke-MarkMichaelisOneDriveConfiguration running state' -Tag 'Light' 
         Invoke-MarkMichaelisOneDriveConfiguration -RootDir 'C:\OneDrive' -KfmOwner 'Michaelis' -FreshSync @() -Confirm:$false
 
         Should -Invoke Start-OneDriveExe -Times 1
+    }
+}
+
+Describe 'Invoke-MarkMichaelisOneDriveConfiguration KFM rebind' -Tag 'Light' {
+    It 'preserves the known-folder suffix by rebinding from the owning account root for <Suffix>' -ForEach @(
+        @{ Suffix = 'Documents' }
+        @{ Suffix = 'Desktop' }
+        @{ Suffix = 'Pictures' }
+        @{ Suffix = 'Music' }
+        @{ Suffix = 'Videos' }
+    ) {
+        $rootDir = 'C:\OneDrive'
+        $owner = [pscustomobject]@{
+            Slot = 'Business1'; AccountType = 'Business'; DisplayName = 'Michaelis Consulting'
+            UserEmail = 'owner@example.com'; UserFolder = 'C:\OneDrive\OneDrive - Michaelis Consulting'; TenantId = 'tid-owner'; RegistryPath = 'HKCU:\Software\Microsoft\OneDrive\Accounts\Business1'
+        }
+        $other = [pscustomobject]@{
+            Slot = 'Business2'; AccountType = 'Business'; DisplayName = 'IntelliTect'
+            UserEmail = 'other@example.com'; UserFolder = 'C:\OneDrive\OneDrive - IntelliTect'; TenantId = 'tid-other'; RegistryPath = 'HKCU:\Software\Microsoft\OneDrive\Accounts\Business2'
+        }
+        $kfmCurrent = "C:\OneDrive\OneDrive - IntelliTect\$Suffix"
+
+        Mock -CommandName Test-Path -MockWith {
+            param($Path)
+            switch ($Path) {
+                'C:\OneDrive' { $true; break }
+                'C:\OneDrive\Michaelis Consulting' { $true; break }
+                'C:\OneDrive\IntelliTect' { $true; break }
+                default { $false }
+            }
+        }
+        Mock -CommandName Get-OneDriveAccountList -MockWith { @($owner, $other) }
+        Mock -CommandName Resolve-FreshSyncAccounts -MockWith { @() }
+        Mock -CommandName Get-CurrentKfmPath -MockWith { $kfmCurrent }
+        Mock -CommandName Set-OneDrivePolicy
+        Mock -CommandName Stop-OneDriveExe
+        Mock -CommandName Move-OneDriveFolder
+        Mock -CommandName Update-OneDriveAccountRegistry
+        Mock -CommandName Invoke-AppFixUps
+        Mock -CommandName Start-OneDriveExe
+        Mock -CommandName New-Item
+        Mock -CommandName Get-Process -MockWith { $null }
+        Mock -CommandName Update-KfmBindings
+
+        Invoke-MarkMichaelisOneDriveConfiguration -RootDir $rootDir -KfmOwner 'Michaelis' -FreshSync @() -Confirm:$false
+
+        Should -Invoke Update-KfmBindings -Times 1 -ParameterFilter {
+            $OldRoot -eq 'C:\OneDrive\OneDrive - IntelliTect' -and
+            $NewRoot -eq 'C:\OneDrive\OneDrive - Michaelis Consulting'
+        }
+    }
+
+    It 'warns and skips rebind when the current KFM path is orphaned' {
+        $owner = [pscustomobject]@{
+            Slot = 'Business1'; AccountType = 'Business'; DisplayName = 'Michaelis Consulting'
+            UserEmail = 'owner@example.com'; UserFolder = 'C:\OneDrive\OneDrive - Michaelis Consulting'; TenantId = 'tid-owner'; RegistryPath = 'HKCU:\Software\Microsoft\OneDrive\Accounts\Business1'
+        }
+
+        Mock -CommandName Test-Path -MockWith {
+            param($Path)
+            $Path -eq 'C:\OneDrive'
+        }
+        Mock -CommandName Get-OneDriveAccountList -MockWith { @($owner) }
+        Mock -CommandName Resolve-FreshSyncAccounts -MockWith { @() }
+        Mock -CommandName Get-CurrentKfmPath -MockWith { 'D:\Elsewhere\Documents' }
+        Mock -CommandName Set-OneDrivePolicy
+        Mock -CommandName Stop-OneDriveExe
+        Mock -CommandName Move-OneDriveFolder
+        Mock -CommandName Update-OneDriveAccountRegistry
+        Mock -CommandName Invoke-AppFixUps
+        Mock -CommandName Start-OneDriveExe
+        Mock -CommandName New-Item
+        Mock -CommandName Get-Process -MockWith { $null }
+        Mock -CommandName Update-KfmBindings
+        Mock -CommandName Write-Warning
+
+        Invoke-MarkMichaelisOneDriveConfiguration -RootDir 'C:\OneDrive' -KfmOwner 'Michaelis' -FreshSync @() -Confirm:$false
+
+        Should -Invoke Update-KfmBindings -Times 0
+        Should -Invoke Write-Warning -Times 1 -ParameterFilter { $Message -like '*not under any discovered OneDrive account UserFolder*' }
     }
 }
 

--- a/bucket/MarkMichaelisOneDriveConfiguration.Tests.ps1
+++ b/bucket/MarkMichaelisOneDriveConfiguration.Tests.ps1
@@ -361,6 +361,82 @@ Describe 'Move-OneDriveFolder' -Tag 'Light' {
         }
         Should -Invoke New-Item -Times 0
     }
+
+    It 'renames the source to a .migrated-* folder after successful cross-volume copy by default' {
+        Mock -CommandName Test-Path -MockWith {
+            param($Path)
+            switch ($Path) {
+                'C:\Users\me\OneDrive - IntelliTect' { $true; break }
+                'D:\OneDrive\OneDrive - IntelliTect' { $false; break }
+                'D:\OneDrive' { $true; break }
+                default { $false }
+            }
+        }
+        Mock -CommandName Test-IsSameVolume -MockWith { $false }
+        Mock -CommandName Invoke-RobocopyMirror -MockWith { 1 }
+        Mock -CommandName Get-Date -MockWith { '20240102-030405' }
+        Mock -CommandName Test-OneDriveFolderMoveVerification -MockWith { $true }
+        Mock -CommandName Move-Item
+        Mock -CommandName Remove-Item
+
+        $result = Move-OneDriveFolder -Source 'C:\Users\me\OneDrive - IntelliTect' -Destination 'D:\OneDrive\OneDrive - IntelliTect' -Confirm:$false
+
+        $result.DeferredDeletePath | Should -Be 'C:\Users\me\OneDrive - IntelliTect.migrated-20240102-030405'
+        Should -Invoke Move-Item -Times 1 -ParameterFilter {
+            $LiteralPath -eq 'C:\Users\me\OneDrive - IntelliTect' -and
+            $Destination -eq 'C:\Users\me\OneDrive - IntelliTect.migrated-20240102-030405'
+        }
+        Should -Invoke Remove-Item -Times 0
+    }
+
+    It 'only deletes the renamed source when -DeleteSourceOnSuccess is supplied and verification passed' {
+        Mock -CommandName Test-Path -MockWith {
+            param($Path)
+            switch ($Path) {
+                'C:\Users\me\OneDrive - IntelliTect' { $true; break }
+                'D:\OneDrive\OneDrive - IntelliTect' { $false; break }
+                'D:\OneDrive' { $true; break }
+                default { $false }
+            }
+        }
+        Mock -CommandName Test-IsSameVolume -MockWith { $false }
+        Mock -CommandName Invoke-RobocopyMirror -MockWith { 1 }
+        Mock -CommandName Get-Date -MockWith { '20240102-030405' }
+        Mock -CommandName Test-OneDriveFolderMoveVerification -MockWith { $true }
+        Mock -CommandName Move-Item
+        Mock -CommandName Remove-Item
+
+        $result = Move-OneDriveFolder -Source 'C:\Users\me\OneDrive - IntelliTect' -Destination 'D:\OneDrive\OneDrive - IntelliTect' -DeleteSourceOnSuccess -Confirm:$false
+
+        $result.DeferredDeletePath | Should -BeNullOrEmpty
+        Should -Invoke Remove-Item -Times 1 -ParameterFilter {
+            $LiteralPath -eq 'C:\Users\me\OneDrive - IntelliTect.migrated-20240102-030405'
+        }
+    }
+
+    It 'refuses delete cleanup when cross-volume verification fails' {
+        Mock -CommandName Test-Path -MockWith {
+            param($Path)
+            switch ($Path) {
+                'C:\Users\me\OneDrive - IntelliTect' { $true; break }
+                'D:\OneDrive\OneDrive - IntelliTect' { $false; break }
+                'D:\OneDrive' { $true; break }
+                default { $false }
+            }
+        }
+        Mock -CommandName Test-IsSameVolume -MockWith { $false }
+        Mock -CommandName Invoke-RobocopyMirror -MockWith { 1 }
+        Mock -CommandName Get-Date -MockWith { '20240102-030405' }
+        Mock -CommandName Test-OneDriveFolderMoveVerification -MockWith { $false }
+        Mock -CommandName Move-Item
+        Mock -CommandName Remove-Item
+
+        { Move-OneDriveFolder -Source 'C:\Users\me\OneDrive - IntelliTect' -Destination 'D:\OneDrive\OneDrive - IntelliTect' -DeleteSourceOnSuccess -Confirm:$false } |
+            Should -Throw -ExpectedMessage '*Original data was preserved*'
+
+        Should -Invoke Move-Item -Times 1
+        Should -Invoke Remove-Item -Times 0
+    }
 }
 
 Describe 'Invoke-MarkMichaelisOneDriveConfiguration pre-create behavior' -Tag 'Light' {

--- a/bucket/MarkMichaelisOneDriveConfiguration.Tests.ps1
+++ b/bucket/MarkMichaelisOneDriveConfiguration.Tests.ps1
@@ -300,6 +300,80 @@ Describe 'Set-OneDrivePolicy' -Tag 'Light' {
     }
 }
 
+Describe 'Move-OneDriveFolder' -Tag 'Light' {
+    It 'moves successfully when only the destination parent exists' {
+        Mock -CommandName Test-Path -MockWith {
+            param($Path)
+            switch ($Path) {
+                'C:\Users\me\OneDrive - IntelliTect' { $true; break }
+                'C:\OneDrive\OneDrive - IntelliTect' { $false; break }
+                'C:\OneDrive' { $true; break }
+                default { $false }
+            }
+        }
+        Mock -CommandName Move-Item
+        Mock -CommandName New-Item
+
+        { Move-OneDriveFolder -Source 'C:\Users\me\OneDrive - IntelliTect' -Destination 'C:\OneDrive\OneDrive - IntelliTect' -Confirm:$false } |
+            Should -Not -Throw
+
+        Should -Invoke Move-Item -Times 1 -ParameterFilter {
+            $LiteralPath -eq 'C:\Users\me\OneDrive - IntelliTect' -and
+            $Destination -eq 'C:\OneDrive\OneDrive - IntelliTect'
+        }
+        Should -Invoke New-Item -Times 0
+    }
+}
+
+Describe 'Invoke-MarkMichaelisOneDriveConfiguration pre-create behavior' -Tag 'Light' {
+    It 'creates RootDir and bare tenant directories but not the per-account destination' {
+        $rootDir = 'C:\OneDrive'
+        $tenantDir = 'C:\OneDrive\IntelliTect'
+        $targetDir = 'C:\OneDrive\OneDrive - IntelliTect'
+        $sourceDir = 'C:\Users\me\OneDrive - IntelliTect'
+        $createdPaths = New-Object System.Collections.Generic.List[string]
+        $acct = [pscustomobject]@{
+            Slot = 'Business1'; AccountType = 'Business'; DisplayName = 'IntelliTect'
+            UserEmail = 'user@example.com'; UserFolder = $sourceDir; TenantId = 'tid-1'; RegistryPath = 'HKCU:\Software\Microsoft\OneDrive\Accounts\Business1'
+        }
+
+        Mock -CommandName Test-Path -MockWith {
+            param($Path)
+            switch ($Path) {
+                $rootDir { $false; break }
+                $tenantDir { $false; break }
+                $sourceDir { $true; break }
+                default { $false }
+            }
+        }
+        Mock -CommandName New-Item -MockWith {
+            param($ItemType, $Path)
+            $createdPaths.Add($Path) | Out-Null
+        }
+        Mock -CommandName Get-OneDriveAccountList -MockWith { @($acct) }
+        Mock -CommandName Resolve-FreshSyncAccounts -MockWith { @() }
+        Mock -CommandName Get-CurrentKfmPath -MockWith { $null }
+        Mock -CommandName Resolve-KfmRebindAction -MockWith {
+            [pscustomobject]@{ Action = 'None'; OwnerAccount = $acct; Reason = 'KFM inactive' }
+        }
+        Mock -CommandName Set-OneDrivePolicy
+        Mock -CommandName Stop-OneDriveExe
+        Mock -CommandName Move-OneDriveFolder
+        Mock -CommandName Update-OneDriveAccountRegistry
+        Mock -CommandName Invoke-AppFixUps
+        Mock -CommandName Start-OneDriveExe
+
+        Invoke-MarkMichaelisOneDriveConfiguration -RootDir $rootDir -KfmOwner 'Michaelis' -FreshSync @() -Confirm:$false
+
+        $createdPaths | Should -Contain $rootDir
+        $createdPaths | Should -Contain $tenantDir
+        $createdPaths | Should -Not -Contain $targetDir
+        Should -Invoke Move-OneDriveFolder -Times 1 -ParameterFilter {
+            $Source -eq $sourceDir -and $Destination -eq $targetDir
+        }
+    }
+}
+
 Describe 'Resolve-FreshSyncAccounts' -Tag 'Light' {
     BeforeAll {
         $script:b1 = [pscustomobject]@{

--- a/bucket/MarkMichaelisOneDriveConfiguration.Tests.ps1
+++ b/bucket/MarkMichaelisOneDriveConfiguration.Tests.ps1
@@ -249,6 +249,57 @@ Describe 'Get-OneDriveAccountList (zombie slot filter)' -Tag 'Light' {
     }
 }
 
+Describe 'Set-OneDrivePolicy' -Tag 'Light' {
+    It 'writes DefaultRootDir in HKCU per tenant and GPOSetUpdateRing=0 in HKLM' {
+        $accounts = @(
+            [pscustomobject]@{
+                Slot = 'Business1'; AccountType = 'Business'; DisplayName = 'IntelliTect'
+                TenantId = '11111111-1111-1111-1111-111111111111'; UserFolder = 'C:\Users\me\OneDrive - IntelliTect'
+            },
+            [pscustomobject]@{
+                Slot = 'Personal'; AccountType = 'Personal'; DisplayName = $null
+                TenantId = $null; UserFolder = 'C:\Users\me\OneDrive'
+            }
+        )
+
+        Mock -CommandName Test-Path -MockWith {
+            param($Path)
+            $Path -in @(
+                'HKCU:\SOFTWARE\Policies\Microsoft\OneDrive',
+                'HKCU:\SOFTWARE\Policies\Microsoft\OneDrive\DefaultRootDir',
+                'HKLM:\SOFTWARE\Policies\Microsoft\OneDrive'
+            )
+        }
+        Mock -CommandName Get-ItemProperty -MockWith {
+            param($Path, $Name)
+            if ($Path -eq 'HKCU:\SOFTWARE\Policies\Microsoft\OneDrive\DefaultRootDir' -and $Name -eq '11111111-1111-1111-1111-111111111111') {
+                return [pscustomobject]@{ '11111111-1111-1111-1111-111111111111' = 'C:\SomewhereElse' }
+            }
+            if ($Path -eq 'HKLM:\SOFTWARE\Policies\Microsoft\OneDrive' -and $Name -eq 'GPOSetUpdateRing') {
+                return [pscustomobject]@{ GPOSetUpdateRing = 4 }
+            }
+            return [pscustomobject]@{}
+        }
+        Mock -CommandName Set-ItemProperty
+        Mock -CommandName New-Item
+
+        Set-OneDrivePolicy -Accounts $accounts -RootDir 'C:\OneDrive' -Confirm:$false
+
+        Should -Invoke Set-ItemProperty -Times 1 -ParameterFilter {
+            $Path -eq 'HKCU:\SOFTWARE\Policies\Microsoft\OneDrive\DefaultRootDir' -and
+            $Name -eq '11111111-1111-1111-1111-111111111111' -and
+            $Value -eq 'C:\OneDrive\OneDrive - IntelliTect' -and
+            $Type -eq 'String'
+        }
+        Should -Invoke Set-ItemProperty -Times 1 -ParameterFilter {
+            $Path -eq 'HKLM:\SOFTWARE\Policies\Microsoft\OneDrive' -and
+            $Name -eq 'GPOSetUpdateRing' -and
+            $Value -eq 0 -and
+            $Type -eq 'DWord'
+        }
+    }
+}
+
 Describe 'Resolve-FreshSyncAccounts' -Tag 'Light' {
     BeforeAll {
         $script:b1 = [pscustomobject]@{

--- a/bucket/MarkMichaelisOneDriveConfiguration.Tests.ps1
+++ b/bucket/MarkMichaelisOneDriveConfiguration.Tests.ps1
@@ -547,7 +547,7 @@ Describe 'Move-OneDriveFolder' -Tag 'Light' {
     }
 }
 
-Describe 'Invoke-MarkMichaelisOneDriveConfiguration pre-create behavior' -Tag 'Light' {
+Describe 'Invoke-MarkMichaelisOneDriveConfiguration pre-create behavior' -Tag 'Heavy' {
     It 'creates RootDir and bare tenant directories but not the per-account destination' {
         $rootDir = 'C:\OneDrive'
         $tenantDir = 'C:\OneDrive\IntelliTect'
@@ -601,7 +601,7 @@ Describe 'Invoke-MarkMichaelisOneDriveConfiguration pre-create behavior' -Tag 'L
     }
 }
 
-Describe 'Invoke-MarkMichaelisOneDriveConfiguration running state' -Tag 'Light' {
+Describe 'Invoke-MarkMichaelisOneDriveConfiguration running state' -Tag 'Heavy' {
     BeforeEach {
         $script:acct = [pscustomobject]@{
             Slot = 'Business1'; AccountType = 'Business'; DisplayName = 'IntelliTect'
@@ -652,7 +652,7 @@ Describe 'Invoke-MarkMichaelisOneDriveConfiguration running state' -Tag 'Light' 
     }
 }
 
-Describe 'Invoke-MarkMichaelisOneDriveConfiguration rollback' -Tag 'Light' {
+Describe 'Invoke-MarkMichaelisOneDriveConfiguration rollback' -Tag 'Heavy' {
     It 'moves the source back when a same-volume registry update fails' {
         $rootDir = 'C:\OneDrive'
         $oldPath = 'C:\Users\me\OneDrive - IntelliTect'
@@ -706,7 +706,7 @@ Describe 'Invoke-MarkMichaelisOneDriveConfiguration rollback' -Tag 'Light' {
     }
 }
 
-Describe 'Invoke-MarkMichaelisOneDriveConfiguration KFM rebind' -Tag 'Light' {
+Describe 'Invoke-MarkMichaelisOneDriveConfiguration KFM rebind' -Tag 'Heavy' {
     It 'preserves the known-folder suffix by rebinding from the owning account root for <Suffix>' -ForEach @(
         @{ Suffix = 'Documents' }
         @{ Suffix = 'Desktop' }
@@ -792,7 +792,7 @@ Describe 'Invoke-MarkMichaelisOneDriveConfiguration KFM rebind' -Tag 'Light' {
     }
 }
 
-Describe 'Plan-then-execute architecture' -Tag 'Light' {
+Describe 'Plan-then-execute architecture' -Tag 'Heavy' {
     It '-WhatIf renders the plan without invoking state-changing helpers' {
         $acct = [pscustomobject]@{
             Slot = 'Business1'; AccountType = 'Business'; DisplayName = 'IntelliTect'
@@ -833,6 +833,62 @@ Describe 'Plan-then-execute architecture' -Tag 'Light' {
         Should -Invoke Update-OneDriveAccountRegistry -Times 0
         Should -Invoke Stop-OneDriveExe -Times 0
         Should -Invoke Start-OneDriveExe -Times 0
+    }
+
+    It 'performs a same-volume move on the first run and is a no-op on the second run' {
+        $script:firstRunComplete = $false
+        $decision = [pscustomobject]@{ Action = 'None'; OwnerAccount = $null; Reason = 'KFM inactive' }
+
+        Mock -CommandName Get-OneDriveAccountList -MockWith {
+            if (-not $script:firstRunComplete) {
+                return @([pscustomobject]@{
+                    Slot = 'Business1'; AccountType = 'Business'; DisplayName = 'IntelliTect'
+                    UserEmail = 'user@example.com'; UserFolder = 'C:\Users\me\OneDrive - IntelliTect'; TenantId = 'tid-1'; RegistryPath = 'HKCU:\Software\Microsoft\OneDrive\Accounts\Business1'
+                })
+            }
+            return @([pscustomobject]@{
+                Slot = 'Business1'; AccountType = 'Business'; DisplayName = 'IntelliTect'
+                UserEmail = 'user@example.com'; UserFolder = 'C:\OneDrive\OneDrive - IntelliTect'; TenantId = 'tid-1'; RegistryPath = 'HKCU:\Software\Microsoft\OneDrive\Accounts\Business1'
+            })
+        }
+        Mock -CommandName Resolve-FreshSyncAccounts -MockWith { @() }
+        Mock -CommandName Get-OneDriveSharePointSiteList -MockWith { @() }
+        Mock -CommandName Get-CurrentKfmPath -MockWith { $null }
+        Mock -CommandName Resolve-KfmRebindAction -MockWith { $decision }
+        Mock -CommandName Test-Path -MockWith {
+            param($Path)
+            switch ($Path) {
+                'C:\OneDrive' { $true; break }
+                'C:\OneDrive\IntelliTect' { $true; break }
+                'C:\Users\me\OneDrive - IntelliTect' { -not $script:firstRunComplete; break }
+                'C:\OneDrive\OneDrive - IntelliTect' { $script:firstRunComplete; break }
+                default { $false }
+            }
+        }
+        Mock -CommandName Get-ItemProperty -MockWith {
+            param($Path, $Name)
+            if ($Path -eq 'HKCU:\Software\Microsoft\OneDrive\Accounts\Business1' -and $Name -eq 'UserFolder') {
+                return [pscustomobject]@{ UserFolder = $(if ($script:firstRunComplete) { 'C:\OneDrive\OneDrive - IntelliTect' } else { 'C:\Users\me\OneDrive - IntelliTect' }) }
+            }
+            return [pscustomobject]@{}
+        }
+        Mock -CommandName Export-OneDriveRegistryBackup -MockWith { 'C:\backup.reg' }
+        Mock -CommandName Set-OneDriveTenantDefaultRootDirPolicy
+        Mock -CommandName Set-OneDriveUpdateRingPolicy
+        Mock -CommandName Stop-OneDriveExe
+        Mock -CommandName Move-OneDriveFolder -MockWith { $script:firstRunComplete = $true }
+        Mock -CommandName Update-OneDriveAccountRegistry
+        Mock -CommandName Test-OneDriveFolderMoveVerification -MockWith { $true }
+        Mock -CommandName Start-OneDriveExe
+        Mock -CommandName New-Item
+        Mock -CommandName Get-Process -MockWith { $null }
+
+        Invoke-MarkMichaelisOneDriveConfiguration -RootDir 'C:\OneDrive' -KfmOwner 'Michaelis' -FreshSync @() -Confirm:$false | Out-Null
+        $secondPlan = Invoke-MarkMichaelisOneDriveConfiguration -RootDir 'C:\OneDrive' -KfmOwner 'Michaelis' -FreshSync @() -Confirm:$false
+
+        Should -Invoke Move-OneDriveFolder -Times 1
+        @($secondPlan | Where-Object { $_.Type -eq 'MoveAccount' -and -not $_.Skipped }).Count | Should -Be 0
+        @($secondPlan | Where-Object { $_.Type -eq 'UpdateAccountRegistry' -and -not $_.Skipped }).Count | Should -Be 0
     }
 
     It 'emits SharePoint move and cache-rewrite plan items for sibling and nested mounts' {

--- a/bucket/MarkMichaelisOneDriveConfiguration.Tests.ps1
+++ b/bucket/MarkMichaelisOneDriveConfiguration.Tests.ps1
@@ -470,10 +470,12 @@ Describe 'Invoke-MarkMichaelisOneDriveConfiguration pre-create behavior' -Tag 'L
         Mock -CommandName Resolve-KfmRebindAction -MockWith {
             [pscustomobject]@{ Action = 'None'; OwnerAccount = $acct; Reason = 'KFM inactive' }
         }
-        Mock -CommandName Set-OneDrivePolicy
+        Mock -CommandName Set-OneDriveTenantDefaultRootDirPolicy
+        Mock -CommandName Set-OneDriveUpdateRingPolicy
         Mock -CommandName Stop-OneDriveExe
         Mock -CommandName Move-OneDriveFolder
         Mock -CommandName Update-OneDriveAccountRegistry
+        Mock -CommandName Test-OneDriveFolderMoveVerification -MockWith { $true }
         Mock -CommandName Invoke-AppFixUps
         Mock -CommandName Start-OneDriveExe
         Mock -CommandName Get-Process -MockWith { [pscustomobject]@{ Name = 'OneDrive' } }
@@ -510,10 +512,12 @@ Describe 'Invoke-MarkMichaelisOneDriveConfiguration running state' -Tag 'Light' 
         Mock -CommandName Resolve-KfmRebindAction -MockWith {
             [pscustomobject]@{ Action = 'None'; OwnerAccount = $null; Reason = 'KFM inactive' }
         }
-        Mock -CommandName Set-OneDrivePolicy
+        Mock -CommandName Set-OneDriveTenantDefaultRootDirPolicy
+        Mock -CommandName Set-OneDriveUpdateRingPolicy
         Mock -CommandName Stop-OneDriveExe
         Mock -CommandName Move-OneDriveFolder
         Mock -CommandName Update-OneDriveAccountRegistry
+        Mock -CommandName Test-OneDriveFolderMoveVerification -MockWith { $true }
         Mock -CommandName Invoke-AppFixUps
         Mock -CommandName Start-OneDriveExe
         Mock -CommandName New-Item
@@ -563,7 +567,8 @@ Describe 'Invoke-MarkMichaelisOneDriveConfiguration rollback' -Tag 'Light' {
         Mock -CommandName Resolve-KfmRebindAction -MockWith {
             [pscustomobject]@{ Action = 'None'; OwnerAccount = $null; Reason = 'KFM inactive' }
         }
-        Mock -CommandName Set-OneDrivePolicy
+        Mock -CommandName Set-OneDriveTenantDefaultRootDirPolicy
+        Mock -CommandName Set-OneDriveUpdateRingPolicy
         Mock -CommandName Stop-OneDriveExe
         Mock -CommandName Move-OneDriveFolder -MockWith { $script:afterMove = $true }
         Mock -CommandName Get-OneDriveAccountRegistrySnapshot -MockWith { [pscustomobject]@{ UserFolder = $oldPath; CacheValues = @{} } }
@@ -618,7 +623,8 @@ Describe 'Invoke-MarkMichaelisOneDriveConfiguration KFM rebind' -Tag 'Light' {
         Mock -CommandName Get-OneDriveAccountList -MockWith { @($owner, $other) }
         Mock -CommandName Resolve-FreshSyncAccounts -MockWith { @() }
         Mock -CommandName Get-CurrentKfmPath -MockWith { $kfmCurrent }
-        Mock -CommandName Set-OneDrivePolicy
+        Mock -CommandName Set-OneDriveTenantDefaultRootDirPolicy
+        Mock -CommandName Set-OneDriveUpdateRingPolicy
         Mock -CommandName Stop-OneDriveExe
         Mock -CommandName Move-OneDriveFolder
         Mock -CommandName Update-OneDriveAccountRegistry
@@ -649,7 +655,8 @@ Describe 'Invoke-MarkMichaelisOneDriveConfiguration KFM rebind' -Tag 'Light' {
         Mock -CommandName Get-OneDriveAccountList -MockWith { @($owner) }
         Mock -CommandName Resolve-FreshSyncAccounts -MockWith { @() }
         Mock -CommandName Get-CurrentKfmPath -MockWith { 'D:\Elsewhere\Documents' }
-        Mock -CommandName Set-OneDrivePolicy
+        Mock -CommandName Set-OneDriveTenantDefaultRootDirPolicy
+        Mock -CommandName Set-OneDriveUpdateRingPolicy
         Mock -CommandName Stop-OneDriveExe
         Mock -CommandName Move-OneDriveFolder
         Mock -CommandName Update-OneDriveAccountRegistry
@@ -664,6 +671,85 @@ Describe 'Invoke-MarkMichaelisOneDriveConfiguration KFM rebind' -Tag 'Light' {
 
         Should -Invoke Update-KfmBindings -Times 0
         Should -Invoke Write-Warning -Times 1 -ParameterFilter { $Message -like '*not under any discovered OneDrive account UserFolder*' }
+    }
+}
+
+Describe 'Plan-then-execute architecture' -Tag 'Light' {
+    It '-WhatIf renders the plan without invoking state-changing helpers' {
+        $acct = [pscustomobject]@{
+            Slot = 'Business1'; AccountType = 'Business'; DisplayName = 'IntelliTect'
+            UserEmail = 'user@example.com'; UserFolder = 'C:\Users\me\OneDrive - IntelliTect'; TenantId = 'tid-1'; RegistryPath = 'HKCU:\Software\Microsoft\OneDrive\Accounts\Business1'
+        }
+
+        Mock -CommandName Test-Path -MockWith {
+            param($Path)
+            switch ($Path) {
+                'C:\OneDrive' { $true; break }
+                'C:\OneDrive\IntelliTect' { $true; break }
+                'C:\Users\me\OneDrive - IntelliTect' { $true; break }
+                default { $false }
+            }
+        }
+        Mock -CommandName Get-OneDriveAccountList -MockWith { @($acct) }
+        Mock -CommandName Resolve-FreshSyncAccounts -MockWith { @() }
+        Mock -CommandName Get-CurrentKfmPath -MockWith { $null }
+        Mock -CommandName Resolve-KfmRebindAction -MockWith {
+            [pscustomobject]@{ Action = 'None'; OwnerAccount = $null; Reason = 'KFM inactive' }
+        }
+        Mock -CommandName Set-OneDriveTenantDefaultRootDirPolicy -MockWith { throw 'state change not allowed under WhatIf' }
+        Mock -CommandName Set-OneDriveUpdateRingPolicy -MockWith { throw 'state change not allowed under WhatIf' }
+        Mock -CommandName Move-OneDriveFolder -MockWith { throw 'state change not allowed under WhatIf' }
+        Mock -CommandName Update-OneDriveAccountRegistry -MockWith { throw 'state change not allowed under WhatIf' }
+        Mock -CommandName Stop-OneDriveExe -MockWith { throw 'state change not allowed under WhatIf' }
+        Mock -CommandName Start-OneDriveExe -MockWith { throw 'state change not allowed under WhatIf' }
+        Mock -CommandName Update-KfmBindings -MockWith { throw 'state change not allowed under WhatIf' }
+        Mock -CommandName Invoke-AppFixUps -MockWith { throw 'state change not allowed under WhatIf' }
+        Mock -CommandName Remove-OneDriveAccountLink -MockWith { throw 'state change not allowed under WhatIf' }
+        Mock -CommandName Get-Process -MockWith { [pscustomobject]@{ Name = 'OneDrive' } }
+
+        { Invoke-MarkMichaelisOneDriveConfiguration -RootDir 'C:\OneDrive' -KfmOwner 'Michaelis' -FreshSync @() -WhatIf } |
+            Should -Not -Throw
+
+        Should -Invoke Move-OneDriveFolder -Times 0
+        Should -Invoke Update-OneDriveAccountRegistry -Times 0
+        Should -Invoke Stop-OneDriveExe -Times 0
+        Should -Invoke Start-OneDriveExe -Times 0
+    }
+
+    It 'marks every plan item skipped on a second idempotent run' {
+        $acct = [pscustomobject]@{
+            Slot = 'Business1'; AccountType = 'Business'; DisplayName = 'IntelliTect'
+            UserEmail = 'user@example.com'; UserFolder = 'C:\OneDrive\OneDrive - IntelliTect'; TenantId = 'tid-1'; RegistryPath = 'HKCU:\Software\Microsoft\OneDrive\Accounts\Business1'
+        }
+        $decision = [pscustomobject]@{ Action = 'None'; OwnerAccount = $null; Reason = 'KFM inactive' }
+
+        Mock -CommandName Test-Path -MockWith {
+            param($Path)
+            switch ($Path) {
+                'C:\OneDrive' { $true; break }
+                'C:\OneDrive\IntelliTect' { $true; break }
+                'C:\OneDrive\OneDrive - IntelliTect' { $true; break }
+                default { $false }
+            }
+        }
+        Mock -CommandName Get-ItemProperty -MockWith {
+            param($Path, $Name)
+            if ($Path -eq 'HKCU:\SOFTWARE\Policies\Microsoft\OneDrive\DefaultRootDir' -and $Name -eq 'tid-1') {
+                return [pscustomobject]@{ 'tid-1' = 'C:\OneDrive\OneDrive - IntelliTect' }
+            }
+            if ($Path -eq 'HKLM:\SOFTWARE\Policies\Microsoft\OneDrive' -and $Name -eq 'GPOSetUpdateRing') {
+                return [pscustomobject]@{ GPOSetUpdateRing = 0 }
+            }
+            if ($Path -eq 'HKCU:\Software\Microsoft\OneDrive\Accounts\Business1' -and $Name -eq 'UserFolder') {
+                return [pscustomobject]@{ UserFolder = 'C:\OneDrive\OneDrive - IntelliTect' }
+            }
+            return [pscustomobject]@{}
+        }
+
+        $plan = New-OneDriveMigrationPlan -RootDir 'C:\OneDrive' -Accounts @($acct) -FreshSyncAccounts @() -KfmCurrentPath $null -KfmDecision $decision -WasRunning:$false
+
+        @($plan).Count | Should -BeGreaterThan 0
+        @($plan | Where-Object { -not $_.Skipped }).Count | Should -Be 0
     }
 }
 

--- a/bucket/MarkMichaelisOneDriveConfiguration.json
+++ b/bucket/MarkMichaelisOneDriveConfiguration.json
@@ -1,6 +1,6 @@
 {
     "$schema": "https://raw.githubusercontent.com/lukesampson/scoop/master/schema.json",
-    "version": "1.03.000",
+    "version": "1.04.000",
     "description": "Personal post-install customization bundle (member of the MarkMichaelis* run-last family). Pins OneDrive sync roots under a single parent, applies tenant-redirection policy, and rewrites KFM bindings to follow the canonical Work account. Runs AFTER all install bundles; reshapes state rather than installing software.",
     "url": [
         "https://raw.githubusercontent.com/MarkMichaelis/ScoopBucket/master/bucket/MarkMichaelisOneDriveConfiguration.ps1"

--- a/bucket/MarkMichaelisOneDriveConfiguration.json
+++ b/bucket/MarkMichaelisOneDriveConfiguration.json
@@ -1,6 +1,6 @@
 {
     "$schema": "https://raw.githubusercontent.com/lukesampson/scoop/master/schema.json",
-    "version": "1.10.000"
+    "version": "1.11.000",
     "description": "Personal post-install customization bundle (member of the MarkMichaelis* run-last family). Pins OneDrive sync roots under a single parent, applies tenant-redirection policy, and rewrites KFM bindings to follow the canonical Work account. Runs AFTER all install bundles; reshapes state rather than installing software.",
     "url": [
         "https://raw.githubusercontent.com/MarkMichaelis/ScoopBucket/master/bucket/MarkMichaelisOneDriveConfiguration.ps1"

--- a/bucket/MarkMichaelisOneDriveConfiguration.ps1
+++ b/bucket/MarkMichaelisOneDriveConfiguration.ps1
@@ -74,6 +74,17 @@
     intentionally want to preview or run the remaining logic from a
     non-elevated shell.
 
+.NOTES
+    OneDrive's HKCU:\Software\Microsoft\OneDrive\Accounts\<slot>\UserFolder
+    and the various ScopeIdToMountPointPathCache* values are internal
+    OneDrive client state. Microsoft does not publish a supported
+    migration API for them. This script mutates them pragmatically
+    because (a) OneDrive otherwise treats a moved sync root as a new
+    location and re-syncs from scratch, and (b) cached SharePoint mount
+    paths must follow the move or the client will fall back to the old
+    location. If a future OneDrive client version changes this state
+    shape, this script will need updating.
+
 .EXAMPLE
     .\MarkMichaelisOneDriveConfiguration.ps1 -WhatIf
 
@@ -685,6 +696,10 @@ function Update-OneDriveAccountRegistry {
     .SYNOPSIS
         Update OneDrive's per-account registry so it knows where the
         UserFolder lives after a move.
+    .NOTES
+        Mutates OneDrive client internal registry state
+        (Accounts\<slot>\UserFolder and ScopeIdToMountPointPathCache*).
+        Microsoft does not document these as supported migration APIs.
     #>
     [CmdletBinding(SupportsShouldProcess)]
     param(
@@ -1072,6 +1087,14 @@ function Get-OneDriveSharePointSiteList {
 }
 
 function Update-OneDriveSharePointCache {
+    <#
+    .SYNOPSIS
+        Rewrite cached SharePoint mount-point paths after a move.
+    .NOTES
+        Mutates OneDrive client internal ScopeIdToMountPointPathCache*
+        values. Microsoft does not document these as supported migration
+        APIs.
+    #>
     [CmdletBinding(SupportsShouldProcess)]
     param(
         [Parameter(Mandatory)][pscustomobject]$Account,
@@ -1692,6 +1715,7 @@ function Invoke-MarkMichaelisOneDriveConfiguration {
         [switch]$ForceHydrate
     )
 
+    Write-Warning 'Mutates OneDrive client internal registry state (Accounts\<slot>\UserFolder, ScopeIdToMountPointPathCache*); these are not Microsoft-documented migration APIs.'
     Write-Host "MarkMichaelisOneDriveConfiguration: RootDir=$RootDir, KfmOwner=$KfmOwner"
     if ($KfmOwnerContains) {
         Write-Host '  KfmOwnerContains requested: using substring owner matching'

--- a/bucket/MarkMichaelisOneDriveConfiguration.ps1
+++ b/bucket/MarkMichaelisOneDriveConfiguration.ps1
@@ -763,6 +763,361 @@ function Invoke-AppFixUps {
 # tests can pull in just the helper functions above).
 # ---------------------------------------------------------------------------
 
+function New-OneDriveMigrationPlanItem {
+    [OutputType([pscustomobject])]
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)][string]$Type,
+        [Parameter(Mandatory)][string]$Target,
+        [AllowNull()]$CurrentValue,
+        [AllowNull()]$DesiredValue,
+        [AllowNull()]$SameVolume,
+        [AllowNull()][pscustomobject]$Account,
+        [Parameter(Mandatory)][string]$Reason,
+        $Skipped = $false,
+        [AllowNull()][string]$SkipReason,
+        [string[]]$Warnings = @()
+    )
+
+    return [pscustomobject]@{
+        Type          = $Type
+        Target        = $Target
+        CurrentValue  = $CurrentValue
+        DesiredValue  = $DesiredValue
+        SameVolume    = $SameVolume
+        Account       = $Account
+        Reason        = $Reason
+        Skipped       = [bool]$Skipped
+        SkipReason    = $SkipReason
+        Warnings      = @($Warnings)
+        Status        = if ($Skipped) { 'Skipped' } else { 'Pending' }
+        FailureReason = $null
+    }
+}
+
+function Set-OneDriveTenantDefaultRootDirPolicy {
+    [CmdletBinding(SupportsShouldProcess)]
+    param(
+        [Parameter(Mandatory)][pscustomobject]$Account,
+        [Parameter(Mandatory)][string]$RootDir
+    )
+
+    $hkcuPolicy = 'HKCU:\SOFTWARE\Policies\Microsoft\OneDrive'
+    $hkcuDefRoot = "$hkcuPolicy\DefaultRootDir"
+    foreach ($key in @($hkcuPolicy, $hkcuDefRoot)) {
+        if (-not (Test-Path $key)) {
+            if ($PSCmdlet.ShouldProcess($key, 'Create registry key')) {
+                New-Item -Path $key -Force | Out-Null
+            }
+        }
+    }
+
+    $target = Join-Path $RootDir ("OneDrive - {0}" -f $Account.DisplayName)
+    if ($PSCmdlet.ShouldProcess("$hkcuDefRoot\$($Account.TenantId)", "Set DefaultRootDir -> $target")) {
+        Set-ItemProperty -Path $hkcuDefRoot -Name $Account.TenantId -Value $target -Type String
+    }
+}
+
+function Set-OneDriveUpdateRingPolicy {
+    [CmdletBinding(SupportsShouldProcess)]
+    param()
+
+    $hklmPolicy = 'HKLM:\SOFTWARE\Policies\Microsoft\OneDrive'
+    if (-not (Test-Path $hklmPolicy)) {
+        if ($PSCmdlet.ShouldProcess($hklmPolicy, 'Create registry key')) {
+            try { New-Item -Path $hklmPolicy -Force | Out-Null } catch {
+                Write-Warning "Could not create $hklmPolicy (requires elevation): $($_.Exception.Message)"
+                return
+            }
+        }
+    }
+    if ($PSCmdlet.ShouldProcess("$hklmPolicy\GPOSetUpdateRing", 'Set DWord = 0 (Deferred/Enterprise ring; stable updates)')) {
+        try {
+            Set-ItemProperty -Path $hklmPolicy -Name 'GPOSetUpdateRing' -Value 0 -Type DWord
+        } catch {
+            Write-Warning "Could not set GPOSetUpdateRing (requires elevation): $($_.Exception.Message)"
+        }
+    }
+}
+
+function New-OneDriveMigrationPlan {
+    [OutputType([object[]])]
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)][string]$RootDir,
+        [Parameter(Mandatory)][AllowEmptyCollection()][object[]]$Accounts,
+        [Parameter(Mandatory)][AllowEmptyCollection()][object[]]$FreshSyncAccounts,
+        [AllowNull()][string]$KfmCurrentPath,
+        [Parameter(Mandatory)][pscustomobject]$KfmDecision,
+        [bool]$WasRunning
+    )
+
+    $plan = New-Object System.Collections.Generic.List[object]
+    $executionItems = New-Object System.Collections.Generic.List[object]
+    $freshSyncSlots = @($FreshSyncAccounts | ForEach-Object { $_.Slot })
+    $moveItemsBySlot = @{}
+
+    $rootExists = Test-Path $RootDir
+    $plan.Add((New-OneDriveMigrationPlanItem -Type 'CreateDir' -Target $RootDir -CurrentValue $(if ($rootExists) { $RootDir } else { $null }) -DesiredValue $RootDir -SameVolume $null -Account $null -Reason 'Ensure the canonical OneDrive root exists.' -Skipped:$rootExists -SkipReason $(if ($rootExists) { 'Directory already exists.' } else { $null }))) | Out-Null
+
+    foreach ($a in $Accounts) {
+        if ($freshSyncSlots -contains $a.Slot) { continue }
+        if ($a.AccountType -ne 'Business' -or [string]::IsNullOrWhiteSpace($a.DisplayName)) { continue }
+        $tenantDir = Join-Path $RootDir $a.DisplayName
+        $tenantExists = Test-Path $tenantDir
+        $plan.Add((New-OneDriveMigrationPlanItem -Type 'CreateDir' -Target $tenantDir -CurrentValue $(if ($tenantExists) { $tenantDir } else { $null }) -DesiredValue $tenantDir -SameVolume $null -Account $a -Reason 'Create the bare tenant directory used for SharePoint sibling nesting.' -Skipped:$tenantExists -SkipReason $(if ($tenantExists) { 'Directory already exists.' } else { $null }))) | Out-Null
+    }
+
+    $hkcuDefRoot = 'HKCU:\SOFTWARE\Policies\Microsoft\OneDrive\DefaultRootDir'
+    foreach ($acct in $Accounts) {
+        if ($acct.AccountType -ne 'Business' -or -not $acct.TenantId -or -not $acct.DisplayName) { continue }
+        $target = Join-Path $RootDir ("OneDrive - {0}" -f $acct.DisplayName)
+        $current = (Get-ItemProperty -Path $hkcuDefRoot -Name $acct.TenantId -ErrorAction SilentlyContinue).$($acct.TenantId)
+        $item = New-OneDriveMigrationPlanItem -Type 'WritePolicy' -Target "$hkcuDefRoot\$($acct.TenantId)" -CurrentValue $current -DesiredValue $target -SameVolume $null -Account $acct -Reason 'Keep OneDrive tenant redirection pinned to the canonical target path.' -Skipped:($current -eq $target) -SkipReason $(if ($current -eq $target) { 'Policy already matches desired tenant target.' } else { $null })
+        $item | Add-Member -NotePropertyName PolicyKind -NotePropertyValue 'DefaultRootDir'
+        $plan.Add($item) | Out-Null
+    }
+
+    $hklmPolicy = 'HKLM:\SOFTWARE\Policies\Microsoft\OneDrive'
+    $existingRing = (Get-ItemProperty -Path $hklmPolicy -Name 'GPOSetUpdateRing' -ErrorAction SilentlyContinue).GPOSetUpdateRing
+    $ringItem = New-OneDriveMigrationPlanItem -Type 'WritePolicy' -Target "$hklmPolicy\GPOSetUpdateRing" -CurrentValue $existingRing -DesiredValue 0 -SameVolume $null -Account $null -Reason 'Keep OneDrive on the Deferred/Enterprise update ring.' -Skipped:($existingRing -eq 0) -SkipReason $(if ($existingRing -eq 0) { 'Update ring already set to Deferred/Enterprise.' } else { $null })
+    $ringItem | Add-Member -NotePropertyName PolicyKind -NotePropertyValue 'GPOSetUpdateRing'
+    $plan.Add($ringItem) | Out-Null
+
+    foreach ($a in $Accounts) {
+        $target = Get-OneDriveTargetPath -Account $a -RootDir $RootDir
+        if ($freshSyncSlots -contains $a.Slot) {
+            $hasFolder = $a.UserFolder -and (Test-Path $a.UserFolder)
+            $moveItem = New-OneDriveMigrationPlanItem -Type 'MoveAccount' -Target $a.UserFolder -CurrentValue $a.UserFolder -DesiredValue $null -SameVolume $null -Account $a -Reason 'Fresh-sync unlink instead of migrating the existing local OneDrive tree.' -Skipped:(-not $hasFolder) -SkipReason $(if (-not $hasFolder) { 'Fresh-sync account has no local folder to remove.' } else { $null })
+            $moveItem | Add-Member -NotePropertyName FreshSync -NotePropertyValue $true
+            $executionItems.Add($moveItem) | Out-Null
+            continue
+        }
+
+        $sourceExists = $a.UserFolder -and (Test-Path $a.UserFolder)
+        $alreadyTarget = $a.UserFolder -and ($a.UserFolder.TrimEnd('\') -ieq $target.TrimEnd('\'))
+        $sameVolume = if ($sourceExists) { Test-IsSameVolume -Source $a.UserFolder -Destination $target } else { $null }
+        $moveSkipReason = $null
+        if (-not $a.UserFolder) {
+            $moveSkipReason = 'Account has no UserFolder.'
+        } elseif ($alreadyTarget) {
+            $moveSkipReason = 'Current path already matches the canonical target.'
+        } elseif (-not $sourceExists) {
+            $moveSkipReason = 'Source folder is missing; migration skipped for safety.'
+        }
+
+        $moveItem = New-OneDriveMigrationPlanItem -Type 'MoveAccount' -Target $target -CurrentValue $a.UserFolder -DesiredValue $target -SameVolume $sameVolume -Account $a -Reason 'Move the account sync root to the canonical target path.' -Skipped:([bool]$moveSkipReason) -SkipReason $moveSkipReason
+        $moveItem | Add-Member -NotePropertyName FreshSync -NotePropertyValue $false
+        $executionItems.Add($moveItem) | Out-Null
+        $moveItemsBySlot[$a.Slot] = $moveItem
+
+        $regCurrent = (Get-ItemProperty -Path $a.RegistryPath -Name 'UserFolder' -ErrorAction SilentlyContinue).UserFolder
+        $regSkipReason = if ($regCurrent -eq $target) {
+            'Account registry already points at the canonical target.'
+        } elseif ($moveItem.Skipped -and -not $alreadyTarget) {
+            $moveItem.SkipReason
+        } else {
+            $null
+        }
+        $executionItems.Add((New-OneDriveMigrationPlanItem -Type 'UpdateAccountRegistry' -Target "$($a.RegistryPath)\UserFolder" -CurrentValue $regCurrent -DesiredValue $target -SameVolume $sameVolume -Account $a -Reason 'Rewrite OneDrive account registry paths after the move.' -Skipped:([bool]$regSkipReason) -SkipReason $regSkipReason)) | Out-Null
+
+        if ($AppFixUps.Count -gt 0) {
+            $executionItems.Add((New-OneDriveMigrationPlanItem -Type 'AppFixUp' -Target $target -CurrentValue $a.UserFolder -DesiredValue $target -SameVolume $sameVolume -Account $a -Reason 'Run application-specific path fix-ups after the move.' -Skipped:$moveItem.Skipped -SkipReason $moveItem.SkipReason)) | Out-Null
+        }
+
+        $verifyItem = New-OneDriveMigrationPlanItem -Type 'Verify' -Target $target -CurrentValue $a.UserFolder -DesiredValue $target -SameVolume $sameVolume -Account $a -Reason 'Verify the migrated sync root exists where expected.' -Skipped:$moveItem.Skipped -SkipReason $moveItem.SkipReason
+        $verifyItem | Add-Member -NotePropertyName DeferredDeletePath -NotePropertyValue $null
+        $moveItem | Add-Member -NotePropertyName VerifyItem -NotePropertyValue $verifyItem
+        $executionItems.Add($verifyItem) | Out-Null
+    }
+
+    $ownerInFreshSync = $KfmDecision.OwnerAccount -and ($freshSyncSlots -contains $KfmDecision.OwnerAccount.Slot)
+    if ($ownerInFreshSync) {
+        $executionItems.Add((New-OneDriveMigrationPlanItem -Type 'RewriteKfm' -Target 'KFM' -CurrentValue $KfmCurrentPath -DesiredValue $null -SameVolume $null -Account $KfmDecision.OwnerAccount -Reason 'Skip KFM rewrite because the configured owner is being fresh-synced.' -Skipped:$true -SkipReason 'KFM owner is in -FreshSync.' -Warnings @("KFM owner account '$($KfmDecision.OwnerAccount.DisplayName)' is in -FreshSync; reconfigure Known Folder Move after re-sign-in."))) | Out-Null
+    } elseif ($KfmDecision.Action -eq 'Track' -and $KfmDecision.OwnerAccount) {
+        $ownerTarget = Get-OneDriveTargetPath -Account $KfmDecision.OwnerAccount -RootDir $RootDir
+        $ownerMoveItem = $moveItemsBySlot[$KfmDecision.OwnerAccount.Slot]
+        $skipReason = if (-not $ownerMoveItem) {
+            'Owner account is not moving.'
+        } elseif ($ownerMoveItem.Skipped) {
+            $ownerMoveItem.SkipReason
+        } else {
+            $null
+        }
+        $executionItems.Add((New-OneDriveMigrationPlanItem -Type 'RewriteKfm' -Target $ownerTarget -CurrentValue $KfmDecision.OwnerAccount.UserFolder -DesiredValue $ownerTarget -SameVolume $ownerMoveItem.SameVolume -Account $KfmDecision.OwnerAccount -Reason 'Keep KFM bound to the owner account after that account moves.' -Skipped:([bool]$skipReason) -SkipReason $skipReason)) | Out-Null
+    } elseif ($KfmDecision.Action -eq 'Rebind' -and $KfmDecision.OwnerAccount) {
+        $ownerTarget = Get-OneDriveTargetPath -Account $KfmDecision.OwnerAccount -RootDir $RootDir
+        $kfmCurrentOwner = Resolve-KfmCurrentOwnerRoot -Accounts $Accounts -KfmCurrentPath $KfmCurrentPath
+        if (-not $kfmCurrentOwner) {
+            $executionItems.Add((New-OneDriveMigrationPlanItem -Type 'RewriteKfm' -Target $ownerTarget -CurrentValue $KfmCurrentPath -DesiredValue $ownerTarget -SameVolume $null -Account $KfmDecision.OwnerAccount -Reason 'Automatic KFM rebind requested.' -Skipped:$true -SkipReason 'Current KFM path is orphaned outside discovered OneDrive roots.' -Warnings @("KFM is currently bound to '$KfmCurrentPath', which is not under any discovered OneDrive account UserFolder. Skipping automatic rebind."))) | Out-Null
+        } else {
+            $skipReason = if ($KfmCurrentPath -and $KfmCurrentPath.StartsWith($ownerTarget, [System.StringComparison]::OrdinalIgnoreCase)) {
+                'KFM already resolves under the desired owner root.'
+            } else {
+                $null
+            }
+            $executionItems.Add((New-OneDriveMigrationPlanItem -Type 'RewriteKfm' -Target $ownerTarget -CurrentValue $kfmCurrentOwner.UserFolder -DesiredValue $ownerTarget -SameVolume $null -Account $KfmDecision.OwnerAccount -Reason 'Rebind KFM from the current owning account root to the desired owner root.' -Skipped:([bool]$skipReason) -SkipReason $skipReason)) | Out-Null
+        }
+    } elseif ($KfmDecision.Action -eq 'WarnOnly') {
+        $executionItems.Add((New-OneDriveMigrationPlanItem -Type 'RewriteKfm' -Target 'KFM' -CurrentValue $KfmCurrentPath -DesiredValue $null -SameVolume $null -Account $KfmDecision.OwnerAccount -Reason 'Respect -NoKfmRebind and leave KFM on its current non-owner path.' -Skipped:$true -SkipReason $KfmDecision.Reason -Warnings @($KfmDecision.Reason))) | Out-Null
+    } else {
+        $executionItems.Add((New-OneDriveMigrationPlanItem -Type 'RewriteKfm' -Target 'KFM' -CurrentValue $KfmCurrentPath -DesiredValue $null -SameVolume $null -Account $KfmDecision.OwnerAccount -Reason 'No KFM rewrite required.' -Skipped:$true -SkipReason $KfmDecision.Reason)) | Out-Null
+    }
+
+    $needsStopStart = @($executionItems | Where-Object { -not $_.Skipped -and $_.Type -in @('MoveAccount','UpdateAccountRegistry','RewriteKfm','AppFixUp') }).Count -gt 0
+    $plan.Add((New-OneDriveMigrationPlanItem -Type 'StopOneDrive' -Target 'OneDrive.exe' -CurrentValue $(if ($WasRunning) { 'Running' } else { 'NotRunning' }) -DesiredValue 'Stopped' -SameVolume $null -Account $null -Reason 'Stop OneDrive before mutating sync roots or registry.' -Skipped:(-not $needsStopStart) -SkipReason $(if (-not $needsStopStart) { 'No file or registry mutations are required.' } else { $null }))) | Out-Null
+    foreach ($item in $executionItems) {
+        $plan.Add($item) | Out-Null
+    }
+    $startSkipReason = if (-not $needsStopStart) {
+        'No file or registry mutations were required.'
+    } elseif (-not $WasRunning) {
+        'OneDrive was not running before the script started.'
+    } else {
+        $null
+    }
+    $plan.Add((New-OneDriveMigrationPlanItem -Type 'StartOneDrive' -Target 'OneDrive.exe' -CurrentValue 'Stopped' -DesiredValue $(if ($WasRunning) { 'Running' } else { 'NotRunning' }) -SameVolume $null -Account $null -Reason 'Restore OneDrive to its pre-run process state.' -Skipped:([bool]$startSkipReason) -SkipReason $startSkipReason)) | Out-Null
+
+    return $plan.ToArray()
+}
+
+function Format-OneDriveMigrationPlan {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)][AllowEmptyCollection()][object[]]$Plan
+    )
+
+    Write-Host ''
+    Write-Host 'Planned OneDrive migration:'
+    foreach ($item in $Plan) {
+        $status = if ($item.Skipped) { '[Skip]' } else { '[Plan]' }
+        Write-Host ("  {0} {1}: {2}" -f $status, $item.Type, $item.Target)
+        if ($null -ne $item.CurrentValue -or $null -ne $item.DesiredValue) {
+            Write-Host ("      Current: {0}" -f $item.CurrentValue)
+            Write-Host ("      Desired: {0}" -f $item.DesiredValue)
+        }
+        Write-Host ("      Reason : {0}" -f $item.Reason)
+        if ($item.SkipReason) {
+            Write-Host ("      Skip   : {0}" -f $item.SkipReason)
+        }
+        foreach ($warning in @($item.Warnings)) {
+            Write-Host ("      Warning: {0}" -f $warning)
+        }
+    }
+    Write-Host ''
+}
+
+function Invoke-OneDriveMigrationPlan {
+    [CmdletBinding(SupportsShouldProcess)]
+    param(
+        [Parameter(Mandatory)][AllowEmptyCollection()][object[]]$Plan,
+        [switch]$DeleteSourceOnSuccess
+    )
+
+    $deferredCleanupPaths = New-Object System.Collections.Generic.List[string]
+    foreach ($item in $Plan) {
+        if ($item.Skipped) {
+            $item.Status = 'Skipped'
+            foreach ($warning in @($item.Warnings)) {
+                Write-Warning $warning
+            }
+            continue
+        }
+        if (-not $PSCmdlet.ShouldProcess($item.Target, "$($item.Type): $($item.Reason)")) {
+            $item.Status = 'Skipped'
+            $item.SkipReason = 'ShouldProcess declined the operation.'
+            continue
+        }
+
+        try {
+            switch ($item.Type) {
+                'CreateDir' {
+                    if (-not (Test-Path $item.Target)) {
+                        New-Item -ItemType Directory -Path $item.Target -Force | Out-Null
+                    }
+                }
+                'WritePolicy' {
+                    if ($item.PolicyKind -eq 'DefaultRootDir') {
+                        Set-OneDriveTenantDefaultRootDirPolicy -Account $item.Account -RootDir (Split-Path -Parent $item.DesiredValue)
+                    } elseif ($item.PolicyKind -eq 'GPOSetUpdateRing') {
+                        Set-OneDriveUpdateRingPolicy
+                    }
+                }
+                'StopOneDrive' {
+                    Stop-OneDriveExe
+                }
+                'MoveAccount' {
+                    if ($item.FreshSync) {
+                        Remove-OneDriveAccountLink -Account $item.Account
+                    } else {
+                        $sameVolume = Test-IsSameVolume -Source $item.CurrentValue -Destination $item.DesiredValue
+                        $registrySnapshot = $null
+                        if ($sameVolume) {
+                            $registrySnapshot = Get-OneDriveAccountRegistrySnapshot -Account $item.Account
+                        }
+                        $moveResult = Move-OneDriveFolder -Source $item.CurrentValue -Destination $item.DesiredValue -DeleteSourceOnSuccess:$DeleteSourceOnSuccess
+                        if ($moveResult -and $moveResult.DeferredDeletePath) {
+                            $deferredCleanupPaths.Add($moveResult.DeferredDeletePath) | Out-Null
+                            $item.Warnings += "Manual cleanup pending: $($moveResult.DeferredDeletePath)"
+                            if ($item.VerifyItem) {
+                                $item.VerifyItem.DeferredDeletePath = $moveResult.DeferredDeletePath
+                            }
+                        }
+                        $item | Add-Member -NotePropertyName SameVolume -NotePropertyValue $sameVolume -Force
+                        $item | Add-Member -NotePropertyName RegistrySnapshot -NotePropertyValue $registrySnapshot -Force
+                    }
+                }
+                'UpdateAccountRegistry' {
+                    Update-OneDriveAccountRegistry -Account $item.Account -NewPath $item.DesiredValue
+                }
+                'RewriteKfm' {
+                    if ($item.CurrentValue -and $item.DesiredValue) {
+                        Update-KfmBindings -OldRoot $item.CurrentValue -NewRoot $item.DesiredValue
+                    }
+                    foreach ($warning in @($item.Warnings)) {
+                        Write-Warning $warning
+                    }
+                }
+                'AppFixUp' {
+                    Invoke-AppFixUps -OldRoot $item.CurrentValue -NewRoot $item.DesiredValue
+                }
+                'Verify' {
+                    if (-not (Test-OneDriveFolderMoveVerification -Destination $item.DesiredValue -DeferredSource $item.DeferredDeletePath)) {
+                        throw "Verification failed for '$($item.DesiredValue)'."
+                    }
+                }
+                'StartOneDrive' {
+                    Start-OneDriveExe
+                }
+                'RegistryBackup' {
+                }
+                default {
+                    throw "Unsupported plan item type '$($item.Type)'."
+                }
+            }
+            $item.Status = 'Done'
+        } catch {
+            $item.Status = 'Failed'
+            $item.FailureReason = $_.Exception.Message
+            if ($item.Type -eq 'UpdateAccountRegistry' -and $item.SameVolume) {
+                $moveItem = $Plan | Where-Object { $_.Type -eq 'MoveAccount' -and -not $_.FreshSync -and $_.Account -and $_.Account.Slot -eq $item.Account.Slot } | Select-Object -First 1
+                if ($moveItem -and (Test-Path $moveItem.DesiredValue) -and -not (Test-Path $moveItem.CurrentValue)) {
+                    Move-Item -LiteralPath $moveItem.DesiredValue -Destination $moveItem.CurrentValue
+                }
+                if ($moveItem -and $moveItem.RegistrySnapshot) {
+                    Restore-OneDriveAccountRegistrySnapshot -Account $item.Account -Snapshot $moveItem.RegistrySnapshot
+                }
+            }
+            throw
+        }
+    }
+
+    return [pscustomobject]@{
+        DeferredCleanupPaths = $deferredCleanupPaths
+        Plan                 = $Plan
+    }
+}
+
 function Invoke-MarkMichaelisOneDriveConfiguration {
     [CmdletBinding(SupportsShouldProcess)]
     param(
@@ -778,17 +1133,7 @@ function Invoke-MarkMichaelisOneDriveConfiguration {
         Write-Host "  FreshSync requested: $($FreshSync -join ', ')"
     }
 
-    # 1. Pre-create $RootDir.
-    if (-not (Test-Path $RootDir)) {
-        if ($PSCmdlet.ShouldProcess($RootDir, 'Create directory')) {
-            New-Item -ItemType Directory -Path $RootDir -Force | Out-Null
-        }
-    }
-
-    # 2. Discover accounts.
     $accounts = Get-OneDriveAccountList
-
-    # 2a. Resolve -FreshSync entries against the discovered accounts.
     $freshSyncAccounts = Resolve-FreshSyncAccounts -Accounts $accounts -FreshSync $FreshSync
     $freshSyncSlots = @($freshSyncAccounts | ForEach-Object { $_.Slot })
 
@@ -798,161 +1143,48 @@ function Invoke-MarkMichaelisOneDriveConfiguration {
         Write-Host ("    [{0}] {1} <{2}> -> {3}{4}" -f $a.AccountType, $a.DisplayName, $a.UserEmail, $a.UserFolder, $tag)
     }
 
-    # 3. Pre-create bare Work-tenant directories under $RootDir for SharePoint
-    #    sibling nesting only (e.g. <RootDir>\IntelliTect\Library). Do NOT
-    #    pre-create the per-account destination itself; Move-OneDriveFolder must
-    #    keep refusing to merge into an existing destination.
-    foreach ($a in $accounts) {
-        if ($freshSyncSlots -contains $a.Slot) { continue }
-        if ($a.AccountType -ne 'Business' -or [string]::IsNullOrWhiteSpace($a.DisplayName)) { continue }
-        $tenantDir = Join-Path $RootDir $a.DisplayName
-        if (-not (Test-Path $tenantDir)) {
-            if ($PSCmdlet.ShouldProcess($tenantDir, 'Create directory')) {
-                New-Item -ItemType Directory -Path $tenantDir -Force | Out-Null
-            }
-        }
-    }
-
-    # 4. KFM decision (computed before any moves so we know who to track).
     $kfmCurrent = Get-CurrentKfmPath
-    $kfmDecision = Resolve-KfmRebindAction -Accounts $accounts -KfmCurrentPath $kfmCurrent `
-        -KfmOwner $KfmOwner -NoKfmRebind:$NoKfmRebind
+    $kfmDecision = Resolve-KfmRebindAction -Accounts $accounts -KfmCurrentPath $kfmCurrent -KfmOwner $KfmOwner -NoKfmRebind:$NoKfmRebind
     Write-Host "  KFM: [$($kfmDecision.Action)] $($kfmDecision.Reason)"
     if ($kfmDecision.Action -eq 'OwnerNotSignedIn') {
         throw "KFM owner '$KfmOwner' is not signed in. Sign in to the matching Work account in OneDrive and re-run."
     }
 
-    # If the KFM owner itself is being fresh-synced, KFM bindings will
-    # break -- skip the rewrite/rebind work and warn the user.
-    $kfmOwnerInFreshSync = $false
-    if ($kfmDecision.OwnerAccount -and ($freshSyncSlots -contains $kfmDecision.OwnerAccount.Slot)) {
-        $kfmOwnerInFreshSync = $true
-        Write-Warning ("KFM owner account '{0}' ({1}) is in -FreshSync. KFM bindings will break when the account is unlinked. After re-sign-in, reconfigure KFM via OneDrive Settings -> Backup -> Manage backup." -f $kfmDecision.OwnerAccount.DisplayName, $kfmDecision.OwnerAccount.Slot)
+    $wasRunning = [bool](Get-Process -Name 'OneDrive' -ErrorAction SilentlyContinue)
+    $plan = New-OneDriveMigrationPlan -RootDir $RootDir -Accounts $accounts -FreshSyncAccounts @($freshSyncAccounts) -KfmCurrentPath $kfmCurrent -KfmDecision $kfmDecision -WasRunning:$wasRunning
+    Format-OneDriveMigrationPlan -Plan $plan
+
+    if ($WhatIfPreference) {
+        return $plan
     }
 
-    # 5. Apply policy. Still applied for FreshSync accounts so the
-    #    new sync root lands at the policy-directed path on re-sign-in.
-    Set-OneDrivePolicy -Accounts $accounts -RootDir $RootDir
-
-    # 6. Compute migration plan (file-copy) and execute. FreshSync
-    #    accounts are excluded from the file-copy list and handled
-    #    separately via Remove-OneDriveAccountLink.
-    $stoppedOneDrive = $false
-    $deferredCleanupPaths = New-Object System.Collections.Generic.List[string]
-    $migrations = @()
-    foreach ($a in $accounts) {
-        if ($freshSyncSlots -contains $a.Slot) { continue }
-        $target = Get-OneDriveTargetPath -Account $a -RootDir $RootDir
-        if ($a.UserFolder -and (Test-Path $a.UserFolder) -and
-            ($a.UserFolder.TrimEnd('\') -ine $target.TrimEnd('\'))) {
-            $migrations += [pscustomobject]@{ Account = $a; OldPath = $a.UserFolder; NewPath = $target }
+    $deferredCleanupPaths = @()
+    try {
+        $execution = Invoke-OneDriveMigrationPlan -Plan $plan -DeleteSourceOnSuccess:$DeleteSourceOnSuccess -Confirm:$false
+        $deferredCleanupPaths = @($execution.DeferredCleanupPaths)
+    } catch {
+        $failedItem = $plan | Where-Object { $_.Status -eq 'Failed' } | Select-Object -First 1
+        if ($failedItem -and $failedItem.Type -eq 'UpdateAccountRegistry' -and $failedItem.Account) {
+            Write-Error "Migration failed for $($failedItem.Account.DisplayName): $($failedItem.FailureReason) Best-effort rollback attempted. Inspect the old and new paths and verify OneDrive account registry under '$($failedItem.Account.RegistryPath)' before restarting OneDrive. OneDrive NOT restarted automatically."
         }
+        throw
     }
 
-    if ($migrations.Count -gt 0 -or $freshSyncAccounts.Count -gt 0) {
-        $wasRunning = [bool](Get-Process -Name 'OneDrive' -ErrorAction SilentlyContinue)
-        Stop-OneDriveExe
-        $stoppedOneDrive = $true
-
-        foreach ($m in $migrations) {
-            $sameVolume = Test-IsSameVolume -Source $m.OldPath -Destination $m.NewPath
-            $registrySnapshot = $null
-            try {
-                Write-Host "  Migrating $($m.Account.DisplayName): $($m.OldPath) -> $($m.NewPath)"
-                if ($sameVolume) {
-                    $registrySnapshot = Get-OneDriveAccountRegistrySnapshot -Account $m.Account
-                }
-                $moveResult = Move-OneDriveFolder -Source $m.OldPath -Destination $m.NewPath -DeleteSourceOnSuccess:$DeleteSourceOnSuccess
-                if ($moveResult -and $moveResult.DeferredDeletePath) {
-                    $deferredCleanupPaths.Add($moveResult.DeferredDeletePath) | Out-Null
-                }
-                try {
-                    Update-OneDriveAccountRegistry -Account $m.Account -NewPath $m.NewPath
-                } catch {
-                    if ($sameVolume) {
-                        if ((Test-Path $m.NewPath) -and -not (Test-Path $m.OldPath)) {
-                            Move-Item -LiteralPath $m.NewPath -Destination $m.OldPath
-                        }
-                        if ($registrySnapshot) {
-                            Restore-OneDriveAccountRegistrySnapshot -Account $m.Account -Snapshot $registrySnapshot
-                        }
-                    }
-                    throw
-                }
-
-                # Rewrite KFM if this account is the (tracked) owner.
-                if (-not $kfmOwnerInFreshSync -and
-                    $kfmDecision.Action -eq 'Track' -and
-                    $kfmDecision.OwnerAccount -and
-                    $kfmDecision.OwnerAccount.Slot -eq $m.Account.Slot) {
-                    Update-KfmBindings -OldRoot $m.OldPath -NewRoot $m.NewPath
-                }
-                Invoke-AppFixUps -OldRoot $m.OldPath -NewRoot $m.NewPath
-            } catch {
-                $recovery = if ($sameVolume) {
-                    "Best-effort rollback attempted. Inspect '$($m.OldPath)' and '$($m.NewPath)', then verify OneDrive account registry under '$($m.Account.RegistryPath)' before restarting OneDrive."
-                } else {
-                    "Registry may still point to '$($m.OldPath)' while copied data remains at '$($m.NewPath)'. Inspect both paths and '$($m.Account.RegistryPath)' before restarting OneDrive."
-                }
-                Write-Error "Migration failed for $($m.Account.DisplayName): $($_.Exception.Message) $recovery OneDrive NOT restarted automatically."
-                throw
-            }
-        }
-
-        foreach ($fa in $freshSyncAccounts) {
-            try {
-                Write-Verbose "Fresh-sync: unlinking account '$($fa.Slot)' ($($fa.DisplayName)) (registry + local folder)..."
-                Write-Host "  Fresh-sync unlink: $($fa.DisplayName) (Slot=$($fa.Slot))"
-                Remove-OneDriveAccountLink -Account $fa
-            } catch {
-                Write-Error "Fresh-sync unlink failed for $($fa.DisplayName): $($_.Exception.Message). OneDrive NOT restarted."
-                throw
-            }
-        }
-    }
-
-    # 7. Handle Rebind / WarnOnly cases (skip if owner is in FreshSync).
-    if (-not $kfmOwnerInFreshSync) {
-        if ($kfmDecision.Action -eq 'Rebind' -and $kfmDecision.OwnerAccount) {
-            $ownerTarget = Get-OneDriveTargetPath -Account $kfmDecision.OwnerAccount -RootDir $RootDir
-            $kfmCurrentOwner = Resolve-KfmCurrentOwnerRoot -Accounts $accounts -KfmCurrentPath $kfmCurrent
-            if (-not $kfmCurrentOwner) {
-                Write-Warning "KFM is currently bound to '$kfmCurrent', which is not under any discovered OneDrive account UserFolder. Skipping automatic rebind."
-            } else {
-                $kfmOwnerOldRoot = $kfmCurrentOwner.UserFolder
-                if ($PSCmdlet.ShouldProcess("KFM root '$kfmOwnerOldRoot' -> '$ownerTarget'", "Rebind KFM")) {
-                    Update-KfmBindings -OldRoot $kfmOwnerOldRoot -NewRoot $ownerTarget
-                }
-            }
-        } elseif ($kfmDecision.Action -eq 'WarnOnly') {
-            Write-Warning $kfmDecision.Reason
-        }
-    }
-
-    if ($wasRunning -and $stoppedOneDrive) {
-        Start-OneDriveExe
-    }
-
-    # 8. Banner.
-    Write-Host ""
-    Write-Host "MarkMichaelisOneDriveConfiguration complete:"
-    Write-Host "  Accounts found:   $($accounts.Count)"
-    Write-Host "  Migrations:       $($migrations.Count)"
-    Write-Host "  Fresh-sync:       $($freshSyncAccounts.Count)"
-    if ($kfmOwnerInFreshSync) {
-        Write-Host "  KFM action:       Skipped (owner in -FreshSync)"
-    } else {
-        Write-Host "  KFM action:       $($kfmDecision.Action)"
-    }
-    Write-Host ""
+    Write-Host ''
+    Write-Host 'MarkMichaelisOneDriveConfiguration complete:'
+    Write-Host ("  Accounts found:   {0}" -f $accounts.Count)
+    Write-Host ("  Planned items:    {0}" -f $plan.Count)
+    Write-Host ("  Completed items:  {0}" -f @($plan | Where-Object Status -eq 'Done').Count)
+    Write-Host ("  Skipped items:    {0}" -f @($plan | Where-Object Status -eq 'Skipped').Count)
+    Write-Host ''
 
     if ($freshSyncAccounts.Count -gt 0) {
-        Write-Host "FRESH-SYNC accounts unlinked:"
+        Write-Host 'FRESH-SYNC accounts unlinked:'
         foreach ($fa in $freshSyncAccounts) {
             Write-Host ("  - {0} ({1})" -f $fa.DisplayName, $fa.Slot)
         }
-        Write-Host ""
-        Write-Host "To complete the migration:"
+        Write-Host ''
+        Write-Host 'To complete the migration:'
         Write-Host "  1. Open OneDrive Settings (right-click cloud icon -> Settings -> Account)"
         Write-Host "  2. Click 'Add an account'"
         foreach ($fa in $freshSyncAccounts) {
@@ -960,20 +1192,21 @@ function Invoke-MarkMichaelisOneDriveConfiguration {
             Write-Host ("  3. Sign in to: {0}" -f $fa.UserEmail)
             Write-Host ("     Policy will direct the new sync root to: {0}" -f $newTarget)
         }
-        Write-Host "  4. OneDrive will create cloud-only placeholders (no bulk download)."
-        Write-Host ""
+        Write-Host '  4. OneDrive will create cloud-only placeholders (no bulk download).'
+        Write-Host ''
     }
 
     if ($deferredCleanupPaths.Count -gt 0) {
-        Write-Host ""
-        Write-Host "Cross-volume recovery folders preserved for manual cleanup:"
+        Write-Host ''
+        Write-Host 'Cross-volume recovery folders preserved for manual cleanup:'
         foreach ($path in $deferredCleanupPaths) {
             Write-Host ("  - {0}" -f $path)
         }
-        Write-Host "  Review the destination, confirm OneDrive is healthy, then delete the .migrated-* folder(s) manually or re-run with -DeleteSourceOnSuccess."
+        Write-Host '  Review the destination, confirm OneDrive is healthy, then delete the .migrated-* folder(s) manually or re-run with -DeleteSourceOnSuccess.'
     }
 
-    Write-Warning "MRU staleness: Office recent docs / Snagit Recent File List / VS recent files may reference old OneDrive paths; reopen as needed."
+    Write-Warning 'MRU staleness: Office recent docs / Snagit Recent File List / VS recent files may reference old OneDrive paths; reopen as needed.'
+    return $plan
 }
 
 # Only run when invoked as a script (Scoop's installer does

--- a/bucket/MarkMichaelisOneDriveConfiguration.ps1
+++ b/bucket/MarkMichaelisOneDriveConfiguration.ps1
@@ -1120,6 +1120,126 @@ function Update-OneDriveSharePointCache {
     }
 }
 
+function New-OneDriveVerificationCheck {
+    [OutputType([pscustomobject])]
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)][string]$Name,
+        [Parameter(Mandatory)][ValidateSet('Pass','Fail','Skip')][string]$Status,
+        [Parameter(Mandatory)][string]$Detail
+    )
+
+    return [pscustomobject]@{
+        Name   = $Name
+        Status = $Status
+        Detail = $Detail
+    }
+}
+
+function Invoke-OneDriveMigrationVerification {
+    [OutputType([pscustomobject])]
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)][AllowEmptyCollection()][object[]]$Plan
+    )
+
+    $checks = New-Object System.Collections.Generic.List[object]
+    $accounts = @(Get-OneDriveAccountList)
+    $freshSyncSlots = @($Plan | Where-Object { $_.Type -eq 'MoveAccount' -and $_.FreshSync } | ForEach-Object { $_.Account.Slot })
+    $rootDirItem = $Plan | Where-Object { $_.Type -eq 'CreateDir' -and -not $_.Account } | Select-Object -First 1
+    $rootDir = if ($rootDirItem) { $rootDirItem.DesiredValue } else { $null }
+
+    $accountFailures = New-Object System.Collections.Generic.List[string]
+    $verifiableAccounts = @($accounts | Where-Object { $_.AccountType -in @('Business','Personal') -and ($freshSyncSlots -notcontains $_.Slot) })
+    if (-not $rootDir) {
+        $checks.Add((New-OneDriveVerificationCheck -Name 'A. Account UserFolder registry targets' -Status 'Skip' -Detail 'RootDir could not be inferred from the plan.')) | Out-Null
+    } elseif ($verifiableAccounts.Count -eq 0) {
+        $checks.Add((New-OneDriveVerificationCheck -Name 'A. Account UserFolder registry targets' -Status 'Skip' -Detail 'No non-FreshSync accounts require verification.')) | Out-Null
+    } else {
+        foreach ($account in $verifiableAccounts) {
+            $desired = Get-OneDriveTargetPath -Account $account -RootDir $rootDir
+            $actual = (Get-ItemProperty -Path $account.RegistryPath -Name 'UserFolder' -ErrorAction SilentlyContinue).UserFolder
+            $actualTrimmed = if ($actual) { $actual.TrimEnd('\') } else { $actual }
+            $desiredTrimmed = if ($desired) { $desired.TrimEnd('\') } else { $desired }
+            if (-not [string]::Equals($actualTrimmed, $desiredTrimmed, [System.StringComparison]::OrdinalIgnoreCase)) {
+                $accountFailures.Add("$($account.Slot): '$actual' != '$desired'") | Out-Null
+            }
+        }
+        $checks.Add((New-OneDriveVerificationCheck -Name 'A. Account UserFolder registry targets' -Status $(if ($accountFailures.Count -eq 0) { 'Pass' } else { 'Fail' }) -Detail $(if ($accountFailures.Count -eq 0) { "Verified $($verifiableAccounts.Count) account target(s)." } else { $accountFailures -join '; ' }))) | Out-Null
+    }
+
+    $tenantCreateItems = @($Plan | Where-Object { $_.Type -eq 'CreateDir' -and $_.Account -and $_.Account.AccountType -eq 'Business' })
+    if ($tenantCreateItems.Count -eq 0) {
+        $checks.Add((New-OneDriveVerificationCheck -Name 'B. Tenant directory existence' -Status 'Skip' -Detail 'No tenant-display-name folders were planned.')) | Out-Null
+    } else {
+        $missingTenantDirs = @($tenantCreateItems | Where-Object { -not (Test-Path $_.Target) } | ForEach-Object { $_.Target })
+        $checks.Add((New-OneDriveVerificationCheck -Name 'B. Tenant directory existence' -Status $(if ($missingTenantDirs.Count -eq 0) { 'Pass' } else { 'Fail' }) -Detail $(if ($missingTenantDirs.Count -eq 0) { "Verified $($tenantCreateItems.Count) tenant folder(s)." } else { 'Missing: ' + ($missingTenantDirs -join '; ') }))) | Out-Null
+    }
+
+    $rewriteKfmItem = $Plan | Where-Object { $_.Type -eq 'RewriteKfm' } | Select-Object -First 1
+    if (-not $rewriteKfmItem -or -not $rewriteKfmItem.DesiredValue) {
+        $checks.Add((New-OneDriveVerificationCheck -Name 'C. KFM owner binding' -Status 'Skip' -Detail 'KFM track/rebind verification was not applicable.')) | Out-Null
+    } else {
+        $documentsPath = (Get-ItemProperty -Path 'HKCU:\Software\Microsoft\Windows\CurrentVersion\Explorer\User Shell Folders' -Name 'Personal' -ErrorAction SilentlyContinue).Personal
+        $kfmPass = $documentsPath -and $documentsPath.StartsWith($rewriteKfmItem.DesiredValue.TrimEnd('\'), [System.StringComparison]::OrdinalIgnoreCase)
+        $checks.Add((New-OneDriveVerificationCheck -Name 'C. KFM owner binding' -Status $(if ($kfmPass) { 'Pass' } else { 'Fail' }) -Detail $(if ($kfmPass) { "Documents resolves under '$($rewriteKfmItem.DesiredValue)'." } else { "Documents path '$documentsPath' does not resolve under '$($rewriteKfmItem.DesiredValue)'." }))) | Out-Null
+    }
+
+    $policyItems = @($Plan | Where-Object { $_.Type -eq 'WritePolicy' -and $_.PolicyKind -eq 'DefaultRootDir' })
+    if ($policyItems.Count -eq 0) {
+        $checks.Add((New-OneDriveVerificationCheck -Name 'D. DefaultRootDir policy' -Status 'Skip' -Detail 'No tenant DefaultRootDir policy writes were planned.')) | Out-Null
+    } else {
+        $policyFailures = New-Object System.Collections.Generic.List[string]
+        foreach ($item in $policyItems) {
+            $actual = (Get-ItemProperty -Path 'HKCU:\SOFTWARE\Policies\Microsoft\OneDrive\DefaultRootDir' -Name $item.Account.TenantId -ErrorAction SilentlyContinue).$($item.Account.TenantId)
+            if (-not [string]::Equals(($actual ?? '').TrimEnd('\'), ($item.DesiredValue ?? '').TrimEnd('\'), [System.StringComparison]::OrdinalIgnoreCase)) {
+                $policyFailures.Add("$($item.Account.TenantId): '$actual' != '$($item.DesiredValue)'") | Out-Null
+            }
+        }
+        $checks.Add((New-OneDriveVerificationCheck -Name 'D. DefaultRootDir policy' -Status $(if ($policyFailures.Count -eq 0) { 'Pass' } else { 'Fail' }) -Detail $(if ($policyFailures.Count -eq 0) { "Verified $($policyItems.Count) policy value(s)." } else { $policyFailures -join '; ' }))) | Out-Null
+    }
+
+    $sharePointMoves = @($Plan | Where-Object { $_.Type -eq 'MoveAccount' -and $_.SharePointSite -and $_.Status -eq 'Done' -and $_.CurrentValue })
+    if ($sharePointMoves.Count -eq 0) {
+        $checks.Add((New-OneDriveVerificationCheck -Name 'E. SharePoint cache old-root purge' -Status 'Skip' -Detail 'No SharePoint site moves completed in this plan.')) | Out-Null
+    } else {
+        $cacheFailures = New-Object System.Collections.Generic.List[string]
+        foreach ($move in $sharePointMoves) {
+            foreach ($account in $accounts) {
+                foreach ($cacheLeaf in 'ScopeIdToMountPointPathCache','ScopeIdToMountPointPathCacheRoot') {
+                    $cacheKey = Join-Path $account.RegistryPath $cacheLeaf
+                    foreach ($entry in @(Get-OneDriveRegistryStringValuesUnderPath -Path $cacheKey)) {
+                        if ($entry.Value.StartsWith($move.CurrentValue, [System.StringComparison]::OrdinalIgnoreCase)) {
+                            $cacheFailures.Add("$($entry.KeyPath)\\$($entry.ValueName) still references '$($move.CurrentValue)' via '$($entry.Value)'") | Out-Null
+                        }
+                    }
+                }
+            }
+        }
+        $checks.Add((New-OneDriveVerificationCheck -Name 'E. SharePoint cache old-root purge' -Status $(if ($cacheFailures.Count -eq 0) { 'Pass' } else { 'Fail' }) -Detail $(if ($cacheFailures.Count -eq 0) { "Verified $($sharePointMoves.Count) SharePoint move(s)." } else { $cacheFailures -join '; ' }))) | Out-Null
+    }
+
+    $startItem = $Plan | Where-Object { $_.Type -eq 'StartOneDrive' } | Select-Object -First 1
+    $shouldBeRunning = [bool]($startItem -and -not $startItem.Skipped -and $startItem.Status -eq 'Done')
+    $isRunning = [bool](Get-Process -Name 'OneDrive' -ErrorAction SilentlyContinue)
+    $checks.Add((New-OneDriveVerificationCheck -Name 'F. OneDrive.exe running state' -Status $(if ($isRunning -eq $shouldBeRunning) { 'Pass' } else { 'Fail' }) -Detail $(if ($isRunning -eq $shouldBeRunning) { "OneDrive running state matched expectation ($shouldBeRunning)." } else { "Expected running=$shouldBeRunning but observed running=$isRunning." }))) | Out-Null
+
+    $failedChecks = @($checks | Where-Object Status -eq 'Fail')
+    $overallStatus = if ($failedChecks.Count -gt 0) {
+        'Fail'
+    } elseif (@($checks | Where-Object Status -eq 'Pass').Count -gt 0) {
+        'Pass'
+    } else {
+        'Skip'
+    }
+
+    return [pscustomobject]@{
+        Checks        = $checks.ToArray()
+        OverallStatus = $overallStatus
+        FailedChecks  = $failedChecks
+    }
+}
+
 # ---------------------------------------------------------------------------
 # Main orchestration. Skipped when the script is dot-sourced (so unit
 # tests can pull in just the helper functions above).
@@ -1304,11 +1424,6 @@ function New-OneDriveMigrationPlan {
         if ($AppFixUps.Count -gt 0) {
             $executionItems.Add((New-OneDriveMigrationPlanItem -Type 'AppFixUp' -Target $target -CurrentValue $a.UserFolder -DesiredValue $target -SameVolume $sameVolume -Account $a -Reason 'Run application-specific path fix-ups after the move.' -Skipped:$moveItem.Skipped -SkipReason $moveItem.SkipReason)) | Out-Null
         }
-
-        $verifyItem = New-OneDriveMigrationPlanItem -Type 'Verify' -Target $target -CurrentValue $a.UserFolder -DesiredValue $target -SameVolume $sameVolume -Account $a -Reason 'Verify the migrated sync root exists where expected.' -Skipped:$moveItem.Skipped -SkipReason $moveItem.SkipReason
-        $verifyItem | Add-Member -NotePropertyName DeferredDeletePath -NotePropertyValue $null
-        $moveItem | Add-Member -NotePropertyName VerifyItem -NotePropertyValue $verifyItem
-        $executionItems.Add($verifyItem) | Out-Null
     }
 
     foreach ($site in $SharePointSites) {
@@ -1347,11 +1462,6 @@ function New-OneDriveMigrationPlan {
         $rewriteItem | Add-Member -NotePropertyName Site -NotePropertyValue $site
         $rewriteItem | Add-Member -NotePropertyName MoveItem -NotePropertyValue $moveItem
         $executionItems.Add($rewriteItem) | Out-Null
-
-        $verifyItem = New-OneDriveMigrationPlanItem -Type 'Verify' -Target $site.DesiredPath -CurrentValue $site.CurrentPath -DesiredValue $site.DesiredPath -SameVolume $sameVolume -Account $site.OwnerAccount -Reason 'Verify the SharePoint site/library mount exists where expected.' -Skipped:$moveItem.Skipped -SkipReason $moveItem.SkipReason
-        $verifyItem | Add-Member -NotePropertyName DeferredDeletePath -NotePropertyValue $null
-        $moveItem | Add-Member -NotePropertyName VerifyItem -NotePropertyValue $verifyItem
-        $executionItems.Add($verifyItem) | Out-Null
     }
 
     $ownerInFreshSync = $KfmDecision.OwnerAccount -and ($freshSyncSlots -contains $KfmDecision.OwnerAccount.Slot)
@@ -1404,6 +1514,7 @@ function New-OneDriveMigrationPlan {
         $null
     }
     $plan.Add((New-OneDriveMigrationPlanItem -Type 'StartOneDrive' -Target 'OneDrive.exe' -CurrentValue 'Stopped' -DesiredValue $(if ($WasRunning) { 'Running' } else { 'NotRunning' }) -SameVolume $null -Account $null -Reason 'Restore OneDrive to its pre-run process state.' -Skipped:([bool]$startSkipReason) -SkipReason $startSkipReason)) | Out-Null
+    $plan.Add((New-OneDriveMigrationPlanItem -Type 'Verify' -Target 'PostMigration' -CurrentValue $null -DesiredValue $null -SameVolume $null -Account $null -Reason 'Run post-migration verification checks across account registry, tenant folders, KFM, policy, SharePoint cache, and OneDrive.exe state.' -Skipped:(-not $needsStopStart) -SkipReason $(if (-not $needsStopStart) { 'No file or registry mutations were required.' } else { $null }))) | Out-Null
 
     return $plan.ToArray()
 }
@@ -1498,9 +1609,6 @@ function Invoke-OneDriveMigrationPlan {
                         if ($moveResult -and $moveResult.DeferredDeletePath) {
                             $deferredCleanupPaths.Add($moveResult.DeferredDeletePath) | Out-Null
                             $item.Warnings += "Manual cleanup pending: $($moveResult.DeferredDeletePath)"
-                            if ($item.VerifyItem) {
-                                $item.VerifyItem.DeferredDeletePath = $moveResult.DeferredDeletePath
-                            }
                         }
                         $item | Add-Member -NotePropertyName SameVolume -NotePropertyValue $sameVolume -Force
                         $item | Add-Member -NotePropertyName RegistrySnapshot -NotePropertyValue $registrySnapshot -Force
@@ -1524,9 +1632,8 @@ function Invoke-OneDriveMigrationPlan {
                     Invoke-AppFixUps -OldRoot $item.CurrentValue -NewRoot $item.DesiredValue
                 }
                 'Verify' {
-                    if (-not (Test-OneDriveFolderMoveVerification -Destination $item.DesiredValue -DeferredSource $item.DeferredDeletePath)) {
-                        throw "Verification failed for '$($item.DesiredValue)'."
-                    }
+                    $verifyResult = Invoke-OneDriveMigrationVerification -Plan $Plan
+                    $item | Add-Member -NotePropertyName VerifyResult -NotePropertyValue $verifyResult -Force
                 }
                 'StartOneDrive' {
                     Start-OneDriveExe
@@ -1569,6 +1676,13 @@ function Get-OneDrivePlanItemStatusText {
     param(
         [Parameter(Mandatory)][pscustomobject]$Item
     )
+
+    if ($Item.Type -eq 'Verify' -and ($Item.PSObject.Properties.Name -contains 'VerifyResult')) {
+        switch ($Item.VerifyResult.OverallStatus) {
+            'Fail' { return "Failed: $($Item.VerifyResult.FailedChecks.Count) check(s)" }
+            'Skip' { return 'Skipped: Verification not required.' }
+        }
+    }
 
     switch ($Item.Status) {
         'Done' { return 'Done' }
@@ -1702,6 +1816,22 @@ function Write-OneDriveMigrationSummary {
     }
 }
 
+function Write-OneDriveMigrationVerificationSummary {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)][pscustomobject]$VerifyResult
+    )
+
+    Write-Host ''
+    Write-Host 'Verification checks:'
+    $table = ($VerifyResult.Checks | Select-Object Status, Name, Detail | Format-Table -AutoSize | Out-String -Width 220).TrimEnd()
+    foreach ($line in ($table -split "`r?`n")) {
+        if (-not [string]::IsNullOrWhiteSpace($line)) {
+            Write-Host $line
+        }
+    }
+}
+
 function Invoke-MarkMichaelisOneDriveConfiguration {
     [CmdletBinding(SupportsShouldProcess)]
     param(
@@ -1775,6 +1905,15 @@ function Invoke-MarkMichaelisOneDriveConfiguration {
 
     $summaryLines = Get-OneDriveMigrationSummaryLines -Accounts $accounts -SharePointSites @($sharePointSites) -Plan $plan -DeferredCleanupPaths @($deferredCleanupPaths) -FreshSyncRecoveryPaths @($freshSyncRecoveryPaths)
     Write-OneDriveMigrationSummary -Lines $summaryLines
+
+    $verifyItem = $plan | Where-Object Type -eq 'Verify' | Select-Object -First 1
+    if ($verifyItem -and ($verifyItem.PSObject.Properties.Name -contains 'VerifyResult')) {
+        Write-OneDriveMigrationVerificationSummary -VerifyResult $verifyItem.VerifyResult
+        if ($verifyItem.VerifyResult.FailedChecks.Count -gt 0) {
+            $failedChecksSummary = ($verifyItem.VerifyResult.FailedChecks | ForEach-Object { "[$($_.Name)] $($_.Detail)" }) -join '; '
+            throw "Post-migration verification failed: $failedChecksSummary. Registry backup: $backupPath. Data was already migrated; investigate manually (no rollback performed)."
+        }
+    }
 
     if ($freshSyncAccounts.Count -gt 0) {
         Write-Host ''

--- a/bucket/MarkMichaelisOneDriveConfiguration.ps1
+++ b/bucket/MarkMichaelisOneDriveConfiguration.ps1
@@ -539,6 +539,59 @@ function Update-OneDriveAccountRegistry {
     }
 }
 
+function Get-OneDriveAccountRegistrySnapshot {
+    [OutputType([pscustomobject])]
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)][pscustomobject]$Account
+    )
+
+    $regPath = $Account.RegistryPath
+    $snapshot = [ordered]@{
+        UserFolder  = (Get-ItemProperty -Path $regPath -Name 'UserFolder' -ErrorAction SilentlyContinue).UserFolder
+        CacheValues = @{}
+    }
+
+    foreach ($valueName in 'ScopeIdToMountPointPathCache','ScopeIdToMountPointPathCacheRoot') {
+        $cacheKey = Join-Path $regPath $valueName
+        if (-not (Test-Path $cacheKey)) { continue }
+        $props = Get-ItemProperty -Path $cacheKey -ErrorAction SilentlyContinue
+        if (-not $props) { continue }
+        foreach ($pName in $props.PSObject.Properties.Name) {
+            if ($pName -like 'PS*') { continue }
+            $cur = $props.$pName
+            if ($cur -is [string] -and $Account.UserFolder -and
+                $cur.StartsWith($Account.UserFolder, [System.StringComparison]::OrdinalIgnoreCase)) {
+                $snapshot.CacheValues["$cacheKey|$pName"] = $cur
+            }
+        }
+    }
+
+    return [pscustomobject]$snapshot
+}
+
+function Restore-OneDriveAccountRegistrySnapshot {
+    [CmdletBinding(SupportsShouldProcess)]
+    param(
+        [Parameter(Mandatory)][pscustomobject]$Account,
+        [Parameter(Mandatory)][pscustomobject]$Snapshot
+    )
+
+    $regPath = $Account.RegistryPath
+    if ($PSCmdlet.ShouldProcess("$regPath\UserFolder", "Restore -> $($Snapshot.UserFolder)")) {
+        Set-ItemProperty -Path $regPath -Name 'UserFolder' -Value $Snapshot.UserFolder -Type String
+    }
+
+    foreach ($entry in $Snapshot.CacheValues.GetEnumerator()) {
+        $parts = $entry.Key -split '\|', 2
+        $cacheKey = $parts[0]
+        $pName = $parts[1]
+        if ($PSCmdlet.ShouldProcess("$cacheKey\$pName", "Restore -> $($entry.Value)")) {
+            Set-ItemProperty -Path $cacheKey -Name $pName -Value $entry.Value
+        }
+    }
+}
+
 function Update-KfmBindings {
     <#
     .SYNOPSIS
@@ -747,10 +800,27 @@ function Invoke-MarkMichaelisOneDriveConfiguration {
         $stoppedOneDrive = $true
 
         foreach ($m in $migrations) {
+            $sameVolume = Test-IsSameVolume -Source $m.OldPath -Destination $m.NewPath
+            $registrySnapshot = $null
             try {
                 Write-Host "  Migrating $($m.Account.DisplayName): $($m.OldPath) -> $($m.NewPath)"
+                if ($sameVolume) {
+                    $registrySnapshot = Get-OneDriveAccountRegistrySnapshot -Account $m.Account
+                }
                 Move-OneDriveFolder -Source $m.OldPath -Destination $m.NewPath
-                Update-OneDriveAccountRegistry -Account $m.Account -NewPath $m.NewPath
+                try {
+                    Update-OneDriveAccountRegistry -Account $m.Account -NewPath $m.NewPath
+                } catch {
+                    if ($sameVolume) {
+                        if ((Test-Path $m.NewPath) -and -not (Test-Path $m.OldPath)) {
+                            Move-Item -LiteralPath $m.NewPath -Destination $m.OldPath
+                        }
+                        if ($registrySnapshot) {
+                            Restore-OneDriveAccountRegistrySnapshot -Account $m.Account -Snapshot $registrySnapshot
+                        }
+                    }
+                    throw
+                }
 
                 # Rewrite KFM if this account is the (tracked) owner.
                 if (-not $kfmOwnerInFreshSync -and
@@ -761,7 +831,12 @@ function Invoke-MarkMichaelisOneDriveConfiguration {
                 }
                 Invoke-AppFixUps -OldRoot $m.OldPath -NewRoot $m.NewPath
             } catch {
-                Write-Error "Migration failed for $($m.Account.DisplayName): $($_.Exception.Message). Source left in place; OneDrive NOT restarted."
+                $recovery = if ($sameVolume) {
+                    "Best-effort rollback attempted. Inspect '$($m.OldPath)' and '$($m.NewPath)', then verify OneDrive account registry under '$($m.Account.RegistryPath)' before restarting OneDrive."
+                } else {
+                    "Registry may still point to '$($m.OldPath)' while copied data remains at '$($m.NewPath)'. Inspect both paths and '$($m.Account.RegistryPath)' before restarting OneDrive."
+                }
+                Write-Error "Migration failed for $($m.Account.DisplayName): $($_.Exception.Message) $recovery OneDrive NOT restarted automatically."
                 throw
             }
         }

--- a/bucket/MarkMichaelisOneDriveConfiguration.ps1
+++ b/bucket/MarkMichaelisOneDriveConfiguration.ps1
@@ -50,6 +50,10 @@
     Suppress the warning + automatic rebind that fires when KFM is
     currently bound to a different account than -KfmOwner.
 
+.PARAMETER NoFolderDescriptionsWrite
+    Skip the undocumented writes under Explorer\FolderDescriptions\<GUID>
+    and rely only on User Shell Folders updates when rebinding KFM.
+
 .PARAMETER FreshSync
     Names (Slot or DisplayName) of Business* accounts that should
     be unlinked instead of file-copy-migrated. For each match, the
@@ -103,6 +107,7 @@ param(
     [string] $KfmOwner  = 'Michaelis',
     [switch] $KfmOwnerContains,
     [switch] $NoKfmRebind,
+    [switch] $NoFolderDescriptionsWrite,
     [string[]] $FreshSync = @(),
     [switch] $DeleteSourceOnSuccess,
     [switch] $ForceHydrate,
@@ -772,7 +777,8 @@ function Update-KfmBindings {
     [CmdletBinding(SupportsShouldProcess)]
     param(
         [Parameter(Mandatory)][string]$OldRoot,
-        [Parameter(Mandatory)][string]$NewRoot
+        [Parameter(Mandatory)][string]$NewRoot,
+        [switch]$NoFolderDescriptionsWrite
     )
 
     foreach ($leaf in 'User Shell Folders','Shell Folders') {
@@ -796,6 +802,18 @@ function Update-KfmBindings {
         }
     }
 
+    if ($NoFolderDescriptionsWrite) {
+        return
+    }
+
+    # WARNING: FolderDescriptions\<GUID>\RelativePath and ParsingName are
+    # Windows shell internals, not a Microsoft-documented KFM migration
+    # interface. The supported KFM mechanism is the KFMSilentOptIn policy +
+    # standard User Shell Folders updates. We write here empirically because
+    # some apps (notably Office) cache these for known-folder resolution and
+    # stale entries cause silent breakage. If a future Windows release removes
+    # or relocates these values, drop this block and rely solely on User Shell
+    # Folders.
     foreach ($guid in $KnownFolderGuids) {
         $key = "HKCU:\Software\Microsoft\Windows\CurrentVersion\Explorer\FolderDescriptions\$guid"
         if (-not (Test-Path $key)) { continue }
@@ -1397,7 +1415,8 @@ function Invoke-OneDriveMigrationPlan {
     [CmdletBinding(SupportsShouldProcess)]
     param(
         [Parameter(Mandatory)][AllowEmptyCollection()][object[]]$Plan,
-        [switch]$DeleteSourceOnSuccess
+        [switch]$DeleteSourceOnSuccess,
+        [switch]$NoFolderDescriptionsWrite
     )
 
     $deferredCleanupPaths = New-Object System.Collections.Generic.List[string]
@@ -1472,7 +1491,7 @@ function Invoke-OneDriveMigrationPlan {
                 }
                 'RewriteKfm' {
                     if ($item.CurrentValue -and $item.DesiredValue) {
-                        Update-KfmBindings -OldRoot $item.CurrentValue -NewRoot $item.DesiredValue
+                        Update-KfmBindings -OldRoot $item.CurrentValue -NewRoot $item.DesiredValue -NoFolderDescriptionsWrite:$NoFolderDescriptionsWrite
                     }
                     foreach ($warning in @($item.Warnings)) {
                         Write-Warning $warning
@@ -1667,6 +1686,7 @@ function Invoke-MarkMichaelisOneDriveConfiguration {
         [Parameter(Mandatory)][string]$KfmOwner,
         [switch]$KfmOwnerContains,
         [switch]$NoKfmRebind,
+        [switch]$NoFolderDescriptionsWrite,
         [AllowEmptyCollection()][AllowNull()][string[]]$FreshSync,
         [switch]$DeleteSourceOnSuccess,
         [switch]$ForceHydrate
@@ -1681,6 +1701,9 @@ function Invoke-MarkMichaelisOneDriveConfiguration {
     }
     if ($ForceHydrate) {
         Write-Host '  ForceHydrate requested: cross-volume placeholder hydration is allowed'
+    }
+    if ($NoFolderDescriptionsWrite) {
+        Write-Host '  NoFolderDescriptionsWrite requested: skipping FolderDescriptions internal rewrites'
     }
 
     $accounts = Get-OneDriveAccountList
@@ -1713,7 +1736,7 @@ function Invoke-MarkMichaelisOneDriveConfiguration {
     $deferredCleanupPaths = @()
     $freshSyncRecoveryPaths = @()
     try {
-        $execution = Invoke-OneDriveMigrationPlan -Plan $plan -DeleteSourceOnSuccess:$DeleteSourceOnSuccess -Confirm:$false
+        $execution = Invoke-OneDriveMigrationPlan -Plan $plan -DeleteSourceOnSuccess:$DeleteSourceOnSuccess -NoFolderDescriptionsWrite:$NoFolderDescriptionsWrite -Confirm:$false
         $deferredCleanupPaths = @($execution.DeferredCleanupPaths)
         $freshSyncRecoveryPaths = @($execution.FreshSyncRecoveryPaths)
     } catch {
@@ -1756,5 +1779,5 @@ function Invoke-MarkMichaelisOneDriveConfiguration {
 # `& "$dir\MarkMichaelisOneDriveConfiguration.ps1"`). When dot-sourced
 # (Pester tests), expose the helpers without running migration.
 if ($MyInvocation.InvocationName -ne '.') {
-    Invoke-MarkMichaelisOneDriveConfiguration -RootDir $RootDir -KfmOwner $KfmOwner -KfmOwnerContains:$KfmOwnerContains -NoKfmRebind:$NoKfmRebind -FreshSync $FreshSync -DeleteSourceOnSuccess:$DeleteSourceOnSuccess -ForceHydrate:$ForceHydrate
+    Invoke-MarkMichaelisOneDriveConfiguration -RootDir $RootDir -KfmOwner $KfmOwner -KfmOwnerContains:$KfmOwnerContains -NoKfmRebind:$NoKfmRebind -NoFolderDescriptionsWrite:$NoFolderDescriptionsWrite -FreshSync $FreshSync -DeleteSourceOnSuccess:$DeleteSourceOnSuccess -ForceHydrate:$ForceHydrate
 }

--- a/bucket/MarkMichaelisOneDriveConfiguration.ps1
+++ b/bucket/MarkMichaelisOneDriveConfiguration.ps1
@@ -662,14 +662,17 @@ function Invoke-MarkMichaelisOneDriveConfiguration {
         Write-Host ("    [{0}] {1} <{2}> -> {3}{4}" -f $a.AccountType, $a.DisplayName, $a.UserEmail, $a.UserFolder, $tag)
     }
 
-    # 3. Pre-create per-account target directories under $RootDir.
-    #    Skip FreshSync accounts: OneDrive will create the folder on re-sign-in.
+    # 3. Pre-create bare Work-tenant directories under $RootDir for SharePoint
+    #    sibling nesting only (e.g. <RootDir>\IntelliTect\Library). Do NOT
+    #    pre-create the per-account destination itself; Move-OneDriveFolder must
+    #    keep refusing to merge into an existing destination.
     foreach ($a in $accounts) {
         if ($freshSyncSlots -contains $a.Slot) { continue }
-        $target = Get-OneDriveTargetPath -Account $a -RootDir $RootDir
-        if (-not (Test-Path $target)) {
-            if ($PSCmdlet.ShouldProcess($target, 'Create directory')) {
-                New-Item -ItemType Directory -Path $target -Force | Out-Null
+        if ($a.AccountType -ne 'Business' -or [string]::IsNullOrWhiteSpace($a.DisplayName)) { continue }
+        $tenantDir = Join-Path $RootDir $a.DisplayName
+        if (-not (Test-Path $tenantDir)) {
+            if ($PSCmdlet.ShouldProcess($tenantDir, 'Create directory')) {
+                New-Item -ItemType Directory -Path $tenantDir -Force | Out-Null
             }
         }
     }

--- a/bucket/MarkMichaelisOneDriveConfiguration.ps1
+++ b/bucket/MarkMichaelisOneDriveConfiguration.ps1
@@ -69,6 +69,21 @@
     Run for real: pre-create $RootDir, apply policy, migrate any
     mis-located accounts, rewrite KFM, restart OneDrive.
 #>
+
+<#
+Policy research (authoritative: https://learn.microsoft.com/sharepoint/use-group-policy)
+
+Confirmed policy shape baked into this script:
+  1. DefaultRootDir lives at HKCU:\SOFTWARE\Policies\Microsoft\OneDrive\DefaultRootDir
+     (per-user policy, not machine-wide).
+  2. Each DefaultRootDir value name is the TenantId (GUID), and each value's
+     data is the final tenant folder path, e.g. C:\OneDrive\OneDrive - Contoso.
+  3. GPOSetUpdateRing lives at HKLM:\SOFTWARE\Policies\Microsoft\OneDrive
+     and therefore requires elevation to write.
+  4. GPOSetUpdateRing must be 0 for the Deferred/Enterprise ring (stable
+     updates). 4 would opt the machine into Insider/Preview builds; 5 is
+     Production.
+#>
 [CmdletBinding(SupportsShouldProcess)]
 param(
     [string] $RootDir   = 'C:\OneDrive',
@@ -326,6 +341,12 @@ function Set-OneDrivePolicy {
     .SYNOPSIS
         Apply tenant-redirection policy (DefaultRootDir per Work tenant)
         and the GPOSetUpdateRing policy in HKLM.
+    .DESCRIPTION
+        Policy shape verified against https://learn.microsoft.com/sharepoint/use-group-policy:
+          - DefaultRootDir is a per-user HKCU policy whose value name is the
+            tenant GUID and whose value data is the final tenant folder.
+          - GPOSetUpdateRing is a machine HKLM policy. Value 0 selects the
+            Deferred/Enterprise ring (stable updates).
     #>
     [CmdletBinding(SupportsShouldProcess)]
     param(
@@ -365,10 +386,10 @@ function Set-OneDrivePolicy {
         }
     }
     $existingRing = (Get-ItemProperty -Path $hklmPolicy -Name 'GPOSetUpdateRing' -ErrorAction SilentlyContinue).GPOSetUpdateRing
-    if ($existingRing -ne 4) {
-        if ($PSCmdlet.ShouldProcess("$hklmPolicy\GPOSetUpdateRing", 'Set DWord = 4 (Deferred ring)')) {
+    if ($existingRing -ne 0) {
+        if ($PSCmdlet.ShouldProcess("$hklmPolicy\GPOSetUpdateRing", 'Set DWord = 0 (Deferred/Enterprise ring; stable updates)')) {
             try {
-                Set-ItemProperty -Path $hklmPolicy -Name 'GPOSetUpdateRing' -Value 4 -Type DWord
+                Set-ItemProperty -Path $hklmPolicy -Name 'GPOSetUpdateRing' -Value 0 -Type DWord
             } catch {
                 Write-Warning "Could not set GPOSetUpdateRing (requires elevation): $($_.Exception.Message)"
             }

--- a/bucket/MarkMichaelisOneDriveConfiguration.ps1
+++ b/bucket/MarkMichaelisOneDriveConfiguration.ps1
@@ -336,6 +336,35 @@ function Get-CurrentKfmPath {
     return $props.Personal  # the "Personal" value here = Documents
 }
 
+function Resolve-KfmCurrentOwnerRoot {
+    <#
+    .SYNOPSIS
+        Find the discovered OneDrive account whose UserFolder is the longest
+        prefix of the current KFM path.
+    #>
+    [OutputType([pscustomobject])]
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)][AllowEmptyCollection()][object[]]$Accounts,
+        [AllowNull()][string]$KfmCurrentPath
+    )
+
+    if ([string]::IsNullOrWhiteSpace($KfmCurrentPath)) { return $null }
+
+    $match = $Accounts |
+        Where-Object { -not [string]::IsNullOrWhiteSpace($_.UserFolder) } |
+        Sort-Object { $_.UserFolder.TrimEnd('\').Length } -Descending |
+        Where-Object {
+            $root = $_.UserFolder.TrimEnd('\')
+            $current = $KfmCurrentPath.TrimEnd('\')
+            $current.Equals($root, [System.StringComparison]::OrdinalIgnoreCase) -or
+            $current.StartsWith("$root\", [System.StringComparison]::OrdinalIgnoreCase)
+        } |
+        Select-Object -First 1
+
+    return $match
+}
+
 function Set-OneDrivePolicy {
     <#
     .SYNOPSIS
@@ -753,10 +782,14 @@ function Invoke-MarkMichaelisOneDriveConfiguration {
     if (-not $kfmOwnerInFreshSync) {
         if ($kfmDecision.Action -eq 'Rebind' -and $kfmDecision.OwnerAccount) {
             $ownerTarget = Get-OneDriveTargetPath -Account $kfmDecision.OwnerAccount -RootDir $RootDir
-            $kfmRoot = $kfmCurrent
-            # Trim to drive root if it doesn't match a known account folder.
-            if ($PSCmdlet.ShouldProcess("KFM root '$kfmRoot' -> '$ownerTarget'", "Rebind KFM")) {
-                Update-KfmBindings -OldRoot $kfmRoot -NewRoot $ownerTarget
+            $kfmCurrentOwner = Resolve-KfmCurrentOwnerRoot -Accounts $accounts -KfmCurrentPath $kfmCurrent
+            if (-not $kfmCurrentOwner) {
+                Write-Warning "KFM is currently bound to '$kfmCurrent', which is not under any discovered OneDrive account UserFolder. Skipping automatic rebind."
+            } else {
+                $kfmOwnerOldRoot = $kfmCurrentOwner.UserFolder
+                if ($PSCmdlet.ShouldProcess("KFM root '$kfmOwnerOldRoot' -> '$ownerTarget'", "Rebind KFM")) {
+                    Update-KfmBindings -OldRoot $kfmOwnerOldRoot -NewRoot $ownerTarget
+                }
             }
         } elseif ($kfmDecision.Action -eq 'WarnOnly') {
             Write-Warning $kfmDecision.Reason

--- a/bucket/MarkMichaelisOneDriveConfiguration.ps1
+++ b/bucket/MarkMichaelisOneDriveConfiguration.ps1
@@ -170,6 +170,14 @@ function Resolve-KfmRebindAction {
         [switch]$NoKfmRebind
     )
 
+    if (-not $KfmCurrentPath) {
+        return [pscustomobject]@{
+            Action       = 'None'
+            OwnerAccount = $null
+            Reason       = "KFM is not currently active; nothing to track."
+        }
+    }
+
     $ownerAcct = $Accounts |
         Where-Object { $_.AccountType -ne 'Personal' -and $_.DisplayName -and ($_.DisplayName -match [regex]::Escape($KfmOwner)) } |
         Select-Object -First 1
@@ -179,14 +187,6 @@ function Resolve-KfmRebindAction {
             Action       = 'OwnerNotSignedIn'
             OwnerAccount = $null
             Reason       = "KfmOwner '$KfmOwner' is not signed in to OneDrive (no Business* slot has matching DisplayName)."
-        }
-    }
-
-    if (-not $KfmCurrentPath) {
-        return [pscustomobject]@{
-            Action       = 'None'
-            OwnerAccount = $ownerAcct
-            Reason       = "KFM is not currently active; nothing to track."
         }
     }
 
@@ -713,6 +713,7 @@ function Invoke-MarkMichaelisOneDriveConfiguration {
     }
 
     if ($migrations.Count -gt 0 -or $freshSyncAccounts.Count -gt 0) {
+        $wasRunning = [bool](Get-Process -Name 'OneDrive' -ErrorAction SilentlyContinue)
         Stop-OneDriveExe
         $stoppedOneDrive = $true
 
@@ -762,7 +763,7 @@ function Invoke-MarkMichaelisOneDriveConfiguration {
         }
     }
 
-    if ($stoppedOneDrive) {
+    if ($wasRunning -and $stoppedOneDrive) {
         Start-OneDriveExe
     }
 

--- a/bucket/MarkMichaelisOneDriveConfiguration.ps1
+++ b/bucket/MarkMichaelisOneDriveConfiguration.ps1
@@ -788,6 +788,64 @@ function Get-OneDriveRegistryStringValuesUnderPath {
     return $results.ToArray()
 }
 
+function New-OneDriveRegistryBackupPath {
+    [OutputType([string])]
+    [CmdletBinding()]
+    param()
+
+    $dir = Join-Path $env:LOCALAPPDATA 'MarkMichaelis\OneDriveMigration'
+    return (Join-Path $dir ("backup-{0}.reg" -f (Get-Date -Format 'yyyyMMdd-HHmmss')))
+}
+
+function Invoke-RegExportCommand {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)][string]$SubKey,
+        [Parameter(Mandatory)][string]$OutputPath
+    )
+
+    & reg.exe export $SubKey $OutputPath /y | Out-Null
+    if ($LASTEXITCODE -ne 0) {
+        throw "reg.exe export failed for '$SubKey' (exit $LASTEXITCODE)."
+    }
+}
+
+function Export-OneDriveRegistryBackup {
+    [OutputType([string])]
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)][string]$OutputPath
+    )
+
+    $subKeys = @(
+        'HKCU\Software\Microsoft\OneDrive\Accounts',
+        'HKCU\Software\Microsoft\Windows\CurrentVersion\Explorer\User Shell Folders',
+        'HKCU\Software\Microsoft\Windows\CurrentVersion\Explorer\Shell Folders',
+        'HKCU\Software\Microsoft\Windows\CurrentVersion\Explorer\FolderDescriptions',
+        'HKCU\SOFTWARE\Policies\Microsoft\OneDrive',
+        'HKLM\SOFTWARE\Policies\Microsoft\OneDrive'
+    )
+
+    $dir = Split-Path -Parent $OutputPath
+    if (-not (Test-Path $dir)) {
+        New-Item -ItemType Directory -Path $dir -Force | Out-Null
+    }
+
+    Set-Content -Path $OutputPath -Value "Windows Registry Editor Version 5.00`r`n" -Encoding ascii
+    $index = 0
+    foreach ($subKey in $subKeys) {
+        $index++
+        $scratch = Join-Path $dir ("backup-part-{0:00}.reg" -f $index)
+        Invoke-RegExportCommand -SubKey $subKey -OutputPath $scratch
+        $content = Get-Content -Path $scratch -Raw -ErrorAction Stop
+        $content = $content -replace '^Windows Registry Editor Version 5\.00\s*', ''
+        Add-Content -Path $OutputPath -Value "`r`n$content" -Encoding ascii
+        Remove-Item -LiteralPath $scratch -Force
+    }
+
+    return $OutputPath
+}
+
 function Get-OneDriveFileAttributes {
     [OutputType([System.IO.FileAttributes])]
     [CmdletBinding()]
@@ -1155,7 +1213,11 @@ function New-OneDriveMigrationPlan {
         $executionItems.Add((New-OneDriveMigrationPlanItem -Type 'RewriteKfm' -Target 'KFM' -CurrentValue $KfmCurrentPath -DesiredValue $null -SameVolume $null -Account $KfmDecision.OwnerAccount -Reason 'No KFM rewrite required.' -Skipped:$true -SkipReason $KfmDecision.Reason)) | Out-Null
     }
 
-    $needsStopStart = @($executionItems | Where-Object { -not $_.Skipped -and $_.Type -in @('MoveAccount','UpdateAccountRegistry','RewriteKfm','AppFixUp') }).Count -gt 0
+    $needsBackup = @($plan | Where-Object { -not $_.Skipped -and $_.Type -in @('CreateDir','WritePolicy') }).Count -gt 0 -or
+                   @($executionItems | Where-Object { -not $_.Skipped -and $_.Type -in @('MoveAccount','UpdateAccountRegistry','RewriteSPCache','RewriteKfm','AppFixUp') }).Count -gt 0
+    $plan.Insert(0, (New-OneDriveMigrationPlanItem -Type 'RegistryBackup' -Target (New-OneDriveRegistryBackupPath) -CurrentValue $null -DesiredValue $null -SameVolume $null -Account $null -Reason 'Export a registry backup before any mutations.' -Skipped:(-not $needsBackup) -SkipReason $(if (-not $needsBackup) { 'No registry-affecting mutations are required.' } else { $null })))
+
+    $needsStopStart = @($executionItems | Where-Object { -not $_.Skipped -and $_.Type -in @('MoveAccount','UpdateAccountRegistry','RewriteSPCache','RewriteKfm','AppFixUp') }).Count -gt 0
     $plan.Add((New-OneDriveMigrationPlanItem -Type 'StopOneDrive' -Target 'OneDrive.exe' -CurrentValue $(if ($WasRunning) { 'Running' } else { 'NotRunning' }) -DesiredValue 'Stopped' -SameVolume $null -Account $null -Reason 'Stop OneDrive before mutating sync roots or registry.' -Skipped:(-not $needsStopStart) -SkipReason $(if (-not $needsStopStart) { 'No file or registry mutations are required.' } else { $null }))) | Out-Null
     foreach ($item in $executionItems) {
         $plan.Add($item) | Out-Null
@@ -1222,6 +1284,9 @@ function Invoke-OneDriveMigrationPlan {
 
         try {
             switch ($item.Type) {
+                'RegistryBackup' {
+                    Export-OneDriveRegistryBackup -OutputPath $item.Target | Out-Null
+                }
                 'CreateDir' {
                     if (-not (Test-Path $item.Target)) {
                         New-Item -ItemType Directory -Path $item.Target -Force | Out-Null
@@ -1282,8 +1347,6 @@ function Invoke-OneDriveMigrationPlan {
                 }
                 'StartOneDrive' {
                     Start-OneDriveExe
-                }
-                'RegistryBackup' {
                 }
                 default {
                     throw "Unsupported plan item type '$($item.Type)'."
@@ -1361,6 +1424,7 @@ function Invoke-MarkMichaelisOneDriveConfiguration {
         return $plan
     }
 
+    $backupPath = ($plan | Where-Object Type -eq 'RegistryBackup' | Select-Object -First 1).Target
     $deferredCleanupPaths = @()
     try {
         $execution = Invoke-OneDriveMigrationPlan -Plan $plan -DeleteSourceOnSuccess:$DeleteSourceOnSuccess -Confirm:$false
@@ -1368,7 +1432,9 @@ function Invoke-MarkMichaelisOneDriveConfiguration {
     } catch {
         $failedItem = $plan | Where-Object { $_.Status -eq 'Failed' } | Select-Object -First 1
         if ($failedItem -and $failedItem.Type -eq 'UpdateAccountRegistry' -and $failedItem.Account) {
-            Write-Error "Migration failed for $($failedItem.Account.DisplayName): $($failedItem.FailureReason) Best-effort rollback attempted. Inspect the old and new paths and verify OneDrive account registry under '$($failedItem.Account.RegistryPath)' before restarting OneDrive. OneDrive NOT restarted automatically."
+            Write-Error "Migration failed for $($failedItem.Account.DisplayName): $($failedItem.FailureReason) Best-effort rollback attempted. Inspect the old and new paths and verify OneDrive account registry under '$($failedItem.Account.RegistryPath)' before restarting OneDrive. Registry backup: $backupPath. OneDrive NOT restarted automatically."
+        } elseif ($failedItem) {
+            Write-Error "Migration failed during $($failedItem.Type): $($failedItem.FailureReason). Registry backup: $backupPath. OneDrive NOT restarted automatically."
         }
         throw
     }
@@ -1411,7 +1477,7 @@ function Invoke-MarkMichaelisOneDriveConfiguration {
     $fodGatedItems = @($plan | Where-Object { $_.Type -eq 'MoveAccount' -and $_.SkipReason -like 'Refusing cross-volume move of *cloud-only files*' })
     if ($fodGatedItems.Count -gt 0) {
         Write-Warning ("Files-On-Demand gate blocked {0} cross-volume move(s). Re-run with -ForceHydrate to proceed after accepting hydration." -f $fodGatedItems.Count)
-        throw "Files-On-Demand gate blocked $($fodGatedItems.Count) move(s)."
+        throw "Files-On-Demand gate blocked $($fodGatedItems.Count) move(s). Registry backup: $backupPath."
     }
 
     Write-Warning 'MRU staleness: Office recent docs / Snagit Recent File List / VS recent files may reference old OneDrive paths; reopen as needed.'

--- a/bucket/MarkMichaelisOneDriveConfiguration.ps1
+++ b/bucket/MarkMichaelisOneDriveConfiguration.ps1
@@ -90,7 +90,8 @@ param(
     [string] $KfmOwner  = 'Michaelis',
     [switch] $NoKfmRebind,
     [string[]] $FreshSync = @(),
-    [switch] $DeleteSourceOnSuccess
+    [switch] $DeleteSourceOnSuccess,
+    [switch] $ForceHydrate
 )
 
 $ErrorActionPreference = 'Stop'
@@ -787,6 +788,35 @@ function Get-OneDriveRegistryStringValuesUnderPath {
     return $results.ToArray()
 }
 
+function Get-OneDriveFileAttributes {
+    [OutputType([System.IO.FileAttributes])]
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)][string]$Path
+    )
+
+    return [System.IO.File]::GetAttributes($Path)
+}
+
+function Get-OneDrivePlaceholderCount {
+    [OutputType([int])]
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)][string]$Path
+    )
+
+    if (-not (Test-Path $Path)) { return 0 }
+
+    $count = 0
+    foreach ($file in @(Get-ChildItem -Path $Path -File -Recurse -ErrorAction SilentlyContinue)) {
+        $attrs = Get-OneDriveFileAttributes -Path $file.FullName
+        if (($attrs -band 0x00400000) -or ($attrs -band 0x00001000)) {
+            $count++
+        }
+    }
+    return $count
+}
+
 function Get-OneDriveSharePointSiteList {
     [OutputType([object[]])]
     [CmdletBinding()]
@@ -951,7 +981,8 @@ function New-OneDriveMigrationPlan {
         [AllowEmptyCollection()][object[]]$SharePointSites = @(),
         [AllowNull()][string]$KfmCurrentPath,
         [Parameter(Mandatory)][pscustomobject]$KfmDecision,
-        [bool]$WasRunning
+        [bool]$WasRunning,
+        [switch]$ForceHydrate
     )
 
     $plan = New-Object System.Collections.Generic.List[object]
@@ -1001,6 +1032,7 @@ function New-OneDriveMigrationPlan {
         $alreadyTarget = $a.UserFolder -and ($a.UserFolder.TrimEnd('\') -ieq $target.TrimEnd('\'))
         $sameVolume = if ($sourceExists) { Test-IsSameVolume -Source $a.UserFolder -Destination $target } else { $null }
         $moveSkipReason = $null
+        $moveWarnings = @()
         if (-not $a.UserFolder) {
             $moveSkipReason = 'Account has no UserFolder.'
         } elseif ($alreadyTarget) {
@@ -1008,8 +1040,18 @@ function New-OneDriveMigrationPlan {
         } elseif (-not $sourceExists) {
             $moveSkipReason = 'Source folder is missing; migration skipped for safety.'
         }
+        if (-not $moveSkipReason -and -not $sameVolume) {
+            $placeholderCount = Get-OneDrivePlaceholderCount -Path $a.UserFolder
+            if ($placeholderCount -gt 0) {
+                if ($ForceHydrate) {
+                    $moveWarnings += "Will hydrate $placeholderCount cloud-only files (~size unknown)."
+                } else {
+                    $moveSkipReason = "Refusing cross-volume move of $placeholderCount cloud-only files; re-run with -ForceHydrate to proceed."
+                }
+            }
+        }
 
-        $moveItem = New-OneDriveMigrationPlanItem -Type 'MoveAccount' -Target $target -CurrentValue $a.UserFolder -DesiredValue $target -SameVolume $sameVolume -Account $a -Reason 'Move the account sync root to the canonical target path.' -Skipped:([bool]$moveSkipReason) -SkipReason $moveSkipReason
+        $moveItem = New-OneDriveMigrationPlanItem -Type 'MoveAccount' -Target $target -CurrentValue $a.UserFolder -DesiredValue $target -SameVolume $sameVolume -Account $a -Reason 'Move the account sync root to the canonical target path.' -Skipped:([bool]$moveSkipReason) -SkipReason $moveSkipReason -Warnings $moveWarnings
         $moveItem | Add-Member -NotePropertyName FreshSync -NotePropertyValue $false
         $moveItem | Add-Member -NotePropertyName SharePointSite -NotePropertyValue $false
         $executionItems.Add($moveItem) | Out-Null
@@ -1043,6 +1085,7 @@ function New-OneDriveMigrationPlan {
         $alreadyTarget = $site.CurrentPath -and ($site.CurrentPath.TrimEnd('\') -ieq $site.DesiredPath.TrimEnd('\'))
         $sameVolume = if ($sourceExists) { Test-IsSameVolume -Source $site.CurrentPath -Destination $site.DesiredPath } else { $null }
         $moveSkipReason = $null
+        $moveWarnings = @()
         if (-not $site.CurrentPath) {
             $moveSkipReason = 'SharePoint site has no current mount path.'
         } elseif ($alreadyTarget) {
@@ -1050,8 +1093,18 @@ function New-OneDriveMigrationPlan {
         } elseif (-not $sourceExists) {
             $moveSkipReason = 'SharePoint site source folder is missing; migration skipped for safety.'
         }
+        if (-not $moveSkipReason -and -not $sameVolume) {
+            $placeholderCount = Get-OneDrivePlaceholderCount -Path $site.CurrentPath
+            if ($placeholderCount -gt 0) {
+                if ($ForceHydrate) {
+                    $moveWarnings += "Will hydrate $placeholderCount cloud-only files (~size unknown)."
+                } else {
+                    $moveSkipReason = "Refusing cross-volume move of $placeholderCount cloud-only files; re-run with -ForceHydrate to proceed."
+                }
+            }
+        }
 
-        $moveItem = New-OneDriveMigrationPlanItem -Type 'MoveAccount' -Target $site.DesiredPath -CurrentValue $site.CurrentPath -DesiredValue $site.DesiredPath -SameVolume $sameVolume -Account $site.OwnerAccount -Reason 'Move the SharePoint site/library mount to the canonical tenant sibling path.' -Skipped:([bool]$moveSkipReason) -SkipReason $moveSkipReason
+        $moveItem = New-OneDriveMigrationPlanItem -Type 'MoveAccount' -Target $site.DesiredPath -CurrentValue $site.CurrentPath -DesiredValue $site.DesiredPath -SameVolume $sameVolume -Account $site.OwnerAccount -Reason 'Move the SharePoint site/library mount to the canonical tenant sibling path.' -Skipped:([bool]$moveSkipReason) -SkipReason $moveSkipReason -Warnings $moveWarnings
         $moveItem | Add-Member -NotePropertyName FreshSync -NotePropertyValue $false
         $moveItem | Add-Member -NotePropertyName SharePointSite -NotePropertyValue $true
         $moveItem | Add-Member -NotePropertyName Site -NotePropertyValue $site
@@ -1270,12 +1323,16 @@ function Invoke-MarkMichaelisOneDriveConfiguration {
         [Parameter(Mandatory)][string]$KfmOwner,
         [switch]$NoKfmRebind,
         [AllowEmptyCollection()][AllowNull()][string[]]$FreshSync,
-        [switch]$DeleteSourceOnSuccess
+        [switch]$DeleteSourceOnSuccess,
+        [switch]$ForceHydrate
     )
 
     Write-Host "MarkMichaelisOneDriveConfiguration: RootDir=$RootDir, KfmOwner=$KfmOwner"
     if ($FreshSync -and $FreshSync.Count -gt 0) {
         Write-Host "  FreshSync requested: $($FreshSync -join ', ')"
+    }
+    if ($ForceHydrate) {
+        Write-Host '  ForceHydrate requested: cross-volume placeholder hydration is allowed'
     }
 
     $accounts = Get-OneDriveAccountList
@@ -1297,7 +1354,7 @@ function Invoke-MarkMichaelisOneDriveConfiguration {
     }
 
     $wasRunning = [bool](Get-Process -Name 'OneDrive' -ErrorAction SilentlyContinue)
-    $plan = New-OneDriveMigrationPlan -RootDir $RootDir -Accounts $accounts -FreshSyncAccounts @($freshSyncAccounts) -SharePointSites @($sharePointSites) -KfmCurrentPath $kfmCurrent -KfmDecision $kfmDecision -WasRunning:$wasRunning
+    $plan = New-OneDriveMigrationPlan -RootDir $RootDir -Accounts $accounts -FreshSyncAccounts @($freshSyncAccounts) -SharePointSites @($sharePointSites) -KfmCurrentPath $kfmCurrent -KfmDecision $kfmDecision -WasRunning:$wasRunning -ForceHydrate:$ForceHydrate
     Format-OneDriveMigrationPlan -Plan $plan
 
     if ($WhatIfPreference) {
@@ -1351,6 +1408,12 @@ function Invoke-MarkMichaelisOneDriveConfiguration {
         Write-Host '  Review the destination, confirm OneDrive is healthy, then delete the .migrated-* folder(s) manually or re-run with -DeleteSourceOnSuccess.'
     }
 
+    $fodGatedItems = @($plan | Where-Object { $_.Type -eq 'MoveAccount' -and $_.SkipReason -like 'Refusing cross-volume move of *cloud-only files*' })
+    if ($fodGatedItems.Count -gt 0) {
+        Write-Warning ("Files-On-Demand gate blocked {0} cross-volume move(s). Re-run with -ForceHydrate to proceed after accepting hydration." -f $fodGatedItems.Count)
+        throw "Files-On-Demand gate blocked $($fodGatedItems.Count) move(s)."
+    }
+
     Write-Warning 'MRU staleness: Office recent docs / Snagit Recent File List / VS recent files may reference old OneDrive paths; reopen as needed.'
     return $plan
 }
@@ -1359,5 +1422,5 @@ function Invoke-MarkMichaelisOneDriveConfiguration {
 # `& "$dir\MarkMichaelisOneDriveConfiguration.ps1"`). When dot-sourced
 # (Pester tests), expose the helpers without running migration.
 if ($MyInvocation.InvocationName -ne '.') {
-    Invoke-MarkMichaelisOneDriveConfiguration -RootDir $RootDir -KfmOwner $KfmOwner -NoKfmRebind:$NoKfmRebind -FreshSync $FreshSync -DeleteSourceOnSuccess:$DeleteSourceOnSuccess
+    Invoke-MarkMichaelisOneDriveConfiguration -RootDir $RootDir -KfmOwner $KfmOwner -NoKfmRebind:$NoKfmRebind -FreshSync $FreshSync -DeleteSourceOnSuccess:$DeleteSourceOnSuccess -ForceHydrate:$ForceHydrate
 }

--- a/bucket/MarkMichaelisOneDriveConfiguration.ps1
+++ b/bucket/MarkMichaelisOneDriveConfiguration.ps1
@@ -1308,7 +1308,7 @@ function Invoke-OneDriveMigrationPlan {
                     } else {
                         $sameVolume = Test-IsSameVolume -Source $item.CurrentValue -Destination $item.DesiredValue
                         $registrySnapshot = $null
-                        if ($sameVolume) {
+                        if ($sameVolume -and -not $item.SharePointSite) {
                             $registrySnapshot = Get-OneDriveAccountRegistrySnapshot -Account $item.Account
                         }
                         $moveResult = Move-OneDriveFolder -Source $item.CurrentValue -Destination $item.DesiredValue -DeleteSourceOnSuccess:$DeleteSourceOnSuccess
@@ -1379,6 +1379,135 @@ function Invoke-OneDriveMigrationPlan {
     }
 }
 
+function Get-OneDrivePlanItemStatusText {
+    [OutputType([string])]
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)][pscustomobject]$Item
+    )
+
+    switch ($Item.Status) {
+        'Done' { return 'Done' }
+        'Failed' { return "Failed: $($Item.FailureReason)" }
+        default {
+            if ($Item.SkipReason) {
+                return "Skipped: $($Item.SkipReason)"
+            }
+            return 'Skipped'
+        }
+    }
+}
+
+function Get-OneDriveMigrationSummaryLines {
+    [OutputType([string[]])]
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)][AllowEmptyCollection()][object[]]$Accounts,
+        [Parameter(Mandatory)][AllowEmptyCollection()][object[]]$SharePointSites,
+        [Parameter(Mandatory)][AllowEmptyCollection()][object[]]$Plan,
+        [AllowEmptyCollection()][string[]]$DeferredCleanupPaths = @()
+    )
+
+    $lines = New-Object System.Collections.Generic.List[string]
+    $lines.Add('MarkMichaelisOneDriveConfiguration summary:') | Out-Null
+    $lines.Add('Discovered Accounts:') | Out-Null
+    if ($Accounts.Count -eq 0) {
+        $lines.Add('  - none') | Out-Null
+    } else {
+        foreach ($account in $Accounts) {
+            $lines.Add(("  - [{0}] {1} -> {2}" -f $account.AccountType, $account.DisplayName, $account.UserFolder)) | Out-Null
+        }
+    }
+
+    $lines.Add('Discovered SharePoint Sites:') | Out-Null
+    if ($SharePointSites.Count -eq 0) {
+        $lines.Add('  - none') | Out-Null
+    } else {
+        foreach ($site in $SharePointSites) {
+            $lines.Add(("  - {0} -> {1}" -f $site.CurrentPath, $site.DesiredPath)) | Out-Null
+        }
+    }
+
+    $sections = @(
+        @{ Name = 'Policy Writes'; Types = @('RegistryBackup','WritePolicy') },
+        @{ Name = 'Moves'; Types = @('MoveAccount') },
+        @{ Name = 'KFM Rewrites'; Types = @('RewriteKfm') },
+        @{ Name = 'SharePoint Cache Rewrites'; Types = @('RewriteSPCache') },
+        @{ Name = 'App Fix-ups'; Types = @('AppFixUp') },
+        @{ Name = 'Verification Results'; Types = @('Verify') }
+    )
+
+    foreach ($section in $sections) {
+        $lines.Add("$($section.Name):") | Out-Null
+        $items = @($Plan | Where-Object { $section.Types -contains $_.Type })
+        if ($items.Count -eq 0) {
+            $lines.Add('  - none') | Out-Null
+            continue
+        }
+        foreach ($item in $items) {
+            $status = Get-OneDrivePlanItemStatusText -Item $item
+            $detail = if ($item.CurrentValue -or $item.DesiredValue) {
+                " ($($item.CurrentValue) -> $($item.DesiredValue))"
+            } else {
+                ''
+            }
+            $lines.Add(("  - {0} | {1}{2}" -f $status, $item.Target, $detail)) | Out-Null
+        }
+    }
+
+    $backupItem = $Plan | Where-Object Type -eq 'RegistryBackup' | Select-Object -First 1
+    $lines.Add('Backup Location:') | Out-Null
+    if ($backupItem) {
+        $lines.Add(("  - {0} | {1}" -f (Get-OneDrivePlanItemStatusText -Item $backupItem), $backupItem.Target)) | Out-Null
+    } else {
+        $lines.Add('  - none') | Out-Null
+    }
+
+    $lines.Add('MRU Warning:') | Out-Null
+    $lines.Add('  - Office / Snagit / VS recent-file lists may still reference old OneDrive paths.') | Out-Null
+
+    $lines.Add('.migrated-* directories awaiting cleanup:') | Out-Null
+    if (@($DeferredCleanupPaths).Count -eq 0) {
+        $lines.Add('  - none') | Out-Null
+    } else {
+        foreach ($path in @($DeferredCleanupPaths)) {
+            $lines.Add(("  - {0}" -f $path)) | Out-Null
+        }
+    }
+
+    return $lines.ToArray()
+}
+
+function Write-OneDriveMigrationSummary {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)][AllowEmptyCollection()][string[]]$Lines
+    )
+
+    foreach ($line in $Lines) {
+        $color = $null
+        if ($line -match ':$') {
+            $color = 'Cyan'
+        } elseif ($line -like '  - Done*') {
+            $color = 'Green'
+        } elseif ($line -like '  - Skipped*') {
+            $color = 'Yellow'
+        } elseif ($line -like '  - Failed*') {
+            $color = 'Red'
+        }
+
+        try {
+            if ($color -and $Host.UI -and $Host.UI.RawUI) {
+                Write-Host $line -ForegroundColor $color
+            } else {
+                Write-Host $line
+            }
+        } catch {
+            Write-Host $line
+        }
+    }
+}
+
 function Invoke-MarkMichaelisOneDriveConfiguration {
     [CmdletBinding(SupportsShouldProcess)]
     param(
@@ -1439,21 +1568,12 @@ function Invoke-MarkMichaelisOneDriveConfiguration {
         throw
     }
 
-    Write-Host ''
-    Write-Host 'MarkMichaelisOneDriveConfiguration complete:'
-    Write-Host ("  Accounts found:   {0}" -f $accounts.Count)
-    Write-Host ("  Planned items:    {0}" -f $plan.Count)
-    Write-Host ("  Completed items:  {0}" -f @($plan | Where-Object Status -eq 'Done').Count)
-    Write-Host ("  Skipped items:    {0}" -f @($plan | Where-Object Status -eq 'Skipped').Count)
-    Write-Host ''
+    $summaryLines = Get-OneDriveMigrationSummaryLines -Accounts $accounts -SharePointSites @($sharePointSites) -Plan $plan -DeferredCleanupPaths @($deferredCleanupPaths)
+    Write-OneDriveMigrationSummary -Lines $summaryLines
 
     if ($freshSyncAccounts.Count -gt 0) {
-        Write-Host 'FRESH-SYNC accounts unlinked:'
-        foreach ($fa in $freshSyncAccounts) {
-            Write-Host ("  - {0} ({1})" -f $fa.DisplayName, $fa.Slot)
-        }
         Write-Host ''
-        Write-Host 'To complete the migration:'
+        Write-Host 'To complete the fresh-sync flow:'
         Write-Host "  1. Open OneDrive Settings (right-click cloud icon -> Settings -> Account)"
         Write-Host "  2. Click 'Add an account'"
         foreach ($fa in $freshSyncAccounts) {
@@ -1462,16 +1582,6 @@ function Invoke-MarkMichaelisOneDriveConfiguration {
             Write-Host ("     Policy will direct the new sync root to: {0}" -f $newTarget)
         }
         Write-Host '  4. OneDrive will create cloud-only placeholders (no bulk download).'
-        Write-Host ''
-    }
-
-    if ($deferredCleanupPaths.Count -gt 0) {
-        Write-Host ''
-        Write-Host 'Cross-volume recovery folders preserved for manual cleanup:'
-        foreach ($path in $deferredCleanupPaths) {
-            Write-Host ("  - {0}" -f $path)
-        }
-        Write-Host '  Review the destination, confirm OneDrive is healthy, then delete the .migrated-* folder(s) manually or re-run with -DeleteSourceOnSuccess.'
     }
 
     $fodGatedItems = @($plan | Where-Object { $_.Type -eq 'MoveAccount' -and $_.SkipReason -like 'Refusing cross-volume move of *cloud-only files*' })

--- a/bucket/MarkMichaelisOneDriveConfiguration.ps1
+++ b/bucket/MarkMichaelisOneDriveConfiguration.ps1
@@ -89,7 +89,8 @@ param(
     [string] $RootDir   = 'C:\OneDrive',
     [string] $KfmOwner  = 'Michaelis',
     [switch] $NoKfmRebind,
-    [string[]] $FreshSync = @()
+    [string[]] $FreshSync = @(),
+    [switch] $DeleteSourceOnSuccess
 )
 
 $ErrorActionPreference = 'Stop'
@@ -453,25 +454,62 @@ function Start-OneDriveExe {
     }
 }
 
-function Move-OneDriveFolder {
-    <#
-    .SYNOPSIS
-        Move an account's UserFolder from $Source to $Destination,
-        using NTFS rename when possible and robocopy /MIR /COPYALL
-        otherwise. Throws on failure (leaves source in place).
-    #>
-    [CmdletBinding(SupportsShouldProcess)]
+function Invoke-RobocopyMirror {
+    [OutputType([int])]
+    [CmdletBinding()]
     param(
         [Parameter(Mandatory)][string]$Source,
         [Parameter(Mandatory)][string]$Destination
     )
 
+    $args = @($Source, $Destination, '/MIR','/COPYALL','/DCOPY:DAT','/B','/R:1','/W:1','/XJ','/NFL','/NDL')
+    & robocopy @args | Out-Null
+    return $LASTEXITCODE
+}
+
+function Test-OneDriveFolderMoveVerification {
+    [OutputType([bool])]
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)][string]$Destination,
+        [AllowNull()][string]$DeferredSource
+    )
+
+    if (-not (Test-Path $Destination)) { return $false }
+    if ($DeferredSource) {
+        return (Test-Path $DeferredSource)
+    }
+    return $true
+}
+
+function Move-OneDriveFolder {
+    <#
+    .SYNOPSIS
+        Move an account's UserFolder from $Source to $Destination,
+        using NTFS rename when possible and robocopy /MIR /COPYALL
+        otherwise. Cross-volume moves rename the original source to a
+        .migrated-* recovery folder and only delete it when explicitly
+        requested via -DeleteSourceOnSuccess.
+    #>
+    [OutputType([pscustomobject])]
+    [CmdletBinding(SupportsShouldProcess)]
+    param(
+        [Parameter(Mandatory)][string]$Source,
+        [Parameter(Mandatory)][string]$Destination,
+        [switch]$DeleteSourceOnSuccess
+    )
+
+    $result = [pscustomobject]@{
+        SameVolume         = $null
+        DeferredDeletePath = $null
+    }
+
     if (-not (Test-Path $Source)) {
         Write-Verbose "Source '$Source' does not exist; treating as new account folder."
-        return
+        return $result
     }
     if ((Test-Path $Destination) -and ((Get-Item $Destination).FullName -ieq (Get-Item $Source).FullName)) {
-        return
+        return $result
     }
     if (Test-Path $Destination) {
         throw "Refusing to merge: destination '$Destination' already exists. Resolve manually."
@@ -484,25 +522,40 @@ function Move-OneDriveFolder {
         }
     }
 
-    if (Test-IsSameVolume -Source $Source -Destination $Destination) {
+    $result.SameVolume = Test-IsSameVolume -Source $Source -Destination $Destination
+    if ($result.SameVolume) {
         if ($PSCmdlet.ShouldProcess($Source, "Move-Item -> $Destination (same volume)")) {
             Move-Item -LiteralPath $Source -Destination $Destination
         }
-    } else {
-        Write-Warning "Cross-volume migration: Files-On-Demand placeholders will be materialized by robocopy. To force-hydrate cloud-only files first, run: attrib -O '$Source\*' /S /D"
-        if ($PSCmdlet.ShouldProcess($Source, "robocopy /MIR /COPYALL -> $Destination (cross volume)")) {
-            $args = @($Source, $Destination, '/MIR','/COPYALL','/DCOPY:DAT','/B','/R:1','/W:1','/XJ','/NFL','/NDL')
-            & robocopy @args | Out-Null
-            $rc = $LASTEXITCODE
-            # robocopy success: 0-7. >=8 is failure.
-            if ($rc -ge 8) {
-                throw "robocopy failed (exit $rc) -- leaving source '$Source' in place."
+        return $result
+    }
+
+    Write-Warning "Cross-volume migration copies data first, then renames the original source to a .migrated-* recovery folder. Use -DeleteSourceOnSuccess only after you are comfortable auto-removing that recovery folder."
+    if ($PSCmdlet.ShouldProcess($Source, "robocopy /MIR /COPYALL -> $Destination (cross volume)")) {
+        $rc = Invoke-RobocopyMirror -Source $Source -Destination $Destination
+        # robocopy success: 0-7. >=8 is failure.
+        if ($rc -ge 8) {
+            throw "robocopy failed (exit $rc) -- leaving source '$Source' in place."
+        }
+
+        $timestamp = Get-Date -Format 'yyyyMMdd-HHmmss'
+        $migratedPath = "$Source.migrated-$timestamp"
+        Move-Item -LiteralPath $Source -Destination $migratedPath
+
+        if (-not (Test-OneDriveFolderMoveVerification -Destination $Destination -DeferredSource $migratedPath)) {
+            throw "Cross-volume verification failed after copying '$Source' to '$Destination'. Original data was preserved at '$migratedPath'."
+        }
+
+        if ($DeleteSourceOnSuccess) {
+            if ($PSCmdlet.ShouldProcess($migratedPath, 'Remove-Item -Recurse (verified cross-volume source cleanup)')) {
+                Remove-Item -LiteralPath $migratedPath -Recurse -Force
             }
-            if ($PSCmdlet.ShouldProcess($Source, 'Remove-Item -Recurse (after successful robocopy)')) {
-                Remove-Item -LiteralPath $Source -Recurse -Force
-            }
+        } else {
+            $result.DeferredDeletePath = $migratedPath
         }
     }
+
+    return $result
 }
 
 function Update-OneDriveAccountRegistry {
@@ -716,7 +769,8 @@ function Invoke-MarkMichaelisOneDriveConfiguration {
         [Parameter(Mandatory)][string]$RootDir,
         [Parameter(Mandatory)][string]$KfmOwner,
         [switch]$NoKfmRebind,
-        [AllowEmptyCollection()][AllowNull()][string[]]$FreshSync
+        [AllowEmptyCollection()][AllowNull()][string[]]$FreshSync,
+        [switch]$DeleteSourceOnSuccess
     )
 
     Write-Host "MarkMichaelisOneDriveConfiguration: RootDir=$RootDir, KfmOwner=$KfmOwner"
@@ -784,6 +838,7 @@ function Invoke-MarkMichaelisOneDriveConfiguration {
     #    accounts are excluded from the file-copy list and handled
     #    separately via Remove-OneDriveAccountLink.
     $stoppedOneDrive = $false
+    $deferredCleanupPaths = New-Object System.Collections.Generic.List[string]
     $migrations = @()
     foreach ($a in $accounts) {
         if ($freshSyncSlots -contains $a.Slot) { continue }
@@ -807,7 +862,10 @@ function Invoke-MarkMichaelisOneDriveConfiguration {
                 if ($sameVolume) {
                     $registrySnapshot = Get-OneDriveAccountRegistrySnapshot -Account $m.Account
                 }
-                Move-OneDriveFolder -Source $m.OldPath -Destination $m.NewPath
+                $moveResult = Move-OneDriveFolder -Source $m.OldPath -Destination $m.NewPath -DeleteSourceOnSuccess:$DeleteSourceOnSuccess
+                if ($moveResult -and $moveResult.DeferredDeletePath) {
+                    $deferredCleanupPaths.Add($moveResult.DeferredDeletePath) | Out-Null
+                }
                 try {
                     Update-OneDriveAccountRegistry -Account $m.Account -NewPath $m.NewPath
                 } catch {
@@ -906,6 +964,15 @@ function Invoke-MarkMichaelisOneDriveConfiguration {
         Write-Host ""
     }
 
+    if ($deferredCleanupPaths.Count -gt 0) {
+        Write-Host ""
+        Write-Host "Cross-volume recovery folders preserved for manual cleanup:"
+        foreach ($path in $deferredCleanupPaths) {
+            Write-Host ("  - {0}" -f $path)
+        }
+        Write-Host "  Review the destination, confirm OneDrive is healthy, then delete the .migrated-* folder(s) manually or re-run with -DeleteSourceOnSuccess."
+    }
+
     Write-Warning "MRU staleness: Office recent docs / Snagit Recent File List / VS recent files may reference old OneDrive paths; reopen as needed."
 }
 
@@ -913,5 +980,5 @@ function Invoke-MarkMichaelisOneDriveConfiguration {
 # `& "$dir\MarkMichaelisOneDriveConfiguration.ps1"`). When dot-sourced
 # (Pester tests), expose the helpers without running migration.
 if ($MyInvocation.InvocationName -ne '.') {
-    Invoke-MarkMichaelisOneDriveConfiguration -RootDir $RootDir -KfmOwner $KfmOwner -NoKfmRebind:$NoKfmRebind -FreshSync $FreshSync
+    Invoke-MarkMichaelisOneDriveConfiguration -RootDir $RootDir -KfmOwner $KfmOwner -NoKfmRebind:$NoKfmRebind -FreshSync $FreshSync -DeleteSourceOnSuccess:$DeleteSourceOnSuccess
 }

--- a/bucket/MarkMichaelisOneDriveConfiguration.ps1
+++ b/bucket/MarkMichaelisOneDriveConfiguration.ps1
@@ -24,7 +24,7 @@
       - Auto-migrates any account whose UserFolder doesn't match the
         target convention. Same-volume migrations use Move-Item (NTFS
         rename, preserves Cloud Files reparse + ACLs). Cross-volume
-        migrations use robocopy /MIR /COPYALL /DCOPY:DAT /B and warn
+        migrations use robocopy /MIR /COPYALL /DCOPY:DAT /ZB and warn
         about Files-On-Demand placeholders.
       - Rewrites KFM bindings (User Shell Folders / Shell Folders /
         KNOWNFOLDERID GUIDs) when the owning account moves.
@@ -38,8 +38,13 @@
 
 .PARAMETER KfmOwner
     Account whose DisplayName identifies the canonical KFM owner.
-    Default: 'Michaelis'. Resolved via a substring/equality match
-    against the DisplayName of Business* registry slots.
+    Default: 'Michaelis'. Resolved via case-insensitive equality
+    against the DisplayName of Business* registry slots unless
+    -KfmOwnerContains is supplied.
+
+.PARAMETER KfmOwnerContains
+    Treat -KfmOwner as a case-insensitive substring match instead of an
+    exact DisplayName match.
 
 .PARAMETER NoKfmRebind
     Suppress the warning + automatic rebind that fires when KFM is
@@ -88,6 +93,7 @@ Confirmed policy shape baked into this script:
 param(
     [string] $RootDir   = 'C:\OneDrive',
     [string] $KfmOwner  = 'Michaelis',
+    [switch] $KfmOwnerContains,
     [switch] $NoKfmRebind,
     [string[]] $FreshSync = @(),
     [switch] $DeleteSourceOnSuccess,
@@ -145,6 +151,26 @@ function Test-IsSameVolume {
             [string]::Equals($srcRoot, $dstRoot, [System.StringComparison]::OrdinalIgnoreCase))
 }
 
+function Test-KfmOwnerMatch {
+    [OutputType([bool])]
+    [CmdletBinding()]
+    param(
+        [AllowNull()][string]$DisplayName,
+        [Parameter(Mandatory)][string]$KfmOwner,
+        [switch]$KfmOwnerContains
+    )
+
+    if ([string]::IsNullOrWhiteSpace($DisplayName)) {
+        return $false
+    }
+
+    if ($KfmOwnerContains) {
+        return ($DisplayName.IndexOf($KfmOwner, [System.StringComparison]::OrdinalIgnoreCase) -ge 0)
+    }
+
+    return [string]::Equals($DisplayName, $KfmOwner, [System.StringComparison]::OrdinalIgnoreCase)
+}
+
 function Resolve-KfmRebindAction {
     <#
     .SYNOPSIS
@@ -155,7 +181,9 @@ function Resolve-KfmRebindAction {
             UserFolder, AccountType).
           - $KfmCurrentPath: current resolved Documents/Pictures path (or
             $null if KFM is not active).
-          - $KfmOwner: the DisplayName substring of the desired owner.
+          - $KfmOwner: the desired owner DisplayName.
+          - $KfmOwnerContains: switch -- use substring matching instead of
+            exact DisplayName equality.
           - $NoKfmRebind: switch -- if set, suppress rebind.
 
         Outputs an object with:
@@ -169,6 +197,7 @@ function Resolve-KfmRebindAction {
         [Parameter(Mandatory)][AllowEmptyCollection()][object[]]$Accounts,
         [AllowNull()][string]$KfmCurrentPath,
         [Parameter(Mandatory)][string]$KfmOwner,
+        [switch]$KfmOwnerContains,
         [switch]$NoKfmRebind
     )
 
@@ -181,7 +210,7 @@ function Resolve-KfmRebindAction {
     }
 
     $ownerAcct = $Accounts |
-        Where-Object { $_.AccountType -ne 'Personal' -and $_.DisplayName -and ($_.DisplayName -match [regex]::Escape($KfmOwner)) } |
+        Where-Object { $_.AccountType -ne 'Personal' -and (Test-KfmOwnerMatch -DisplayName $_.DisplayName -KfmOwner $KfmOwner -KfmOwnerContains:$KfmOwnerContains) } |
         Select-Object -First 1
 
     if (-not $ownerAcct) {
@@ -271,7 +300,12 @@ function Resolve-FreshSyncAccounts {
 $KnownFolderGuids = @(
     '{F42EE2D3-909F-4907-8871-4C22FC0BF756}',  # Documents
     '{0DDD015D-B06C-45D5-8C4C-F59713854639}',  # Pictures
-    '{B4BFCC3A-DB2C-424C-B029-7FE99A87C641}'   # Desktop
+    '{B4BFCC3A-DB2C-424C-B029-7FE99A87C641}',  # Desktop
+    '{4BD8D571-6D19-48D3-BE97-422220080E43}',  # Music
+    '{18989B1D-99B5-455B-841C-AB7C74E4DDFC}',  # Videos
+    '{374DE290-123F-4565-9164-39C4925E467B}',  # Downloads
+    '{1777F761-68AD-4D8A-87BD-30B759FA33DD}',  # Favorites
+    '{B7BEDE81-DF94-4682-A7D8-57A52620B86F}'   # Screenshots
 )
 
 function Get-OneDriveAccountList {
@@ -463,7 +497,7 @@ function Invoke-RobocopyMirror {
         [Parameter(Mandatory)][string]$Destination
     )
 
-    $args = @($Source, $Destination, '/MIR','/COPYALL','/DCOPY:DAT','/B','/R:1','/W:1','/XJ','/NFL','/NDL')
+    $args = @($Source, $Destination, '/MIR','/COPYALL','/DCOPY:DAT','/ZB','/R:1','/W:1','/XJ','/NFL','/NDL')
     & robocopy @args | Out-Null
     return $LASTEXITCODE
 }
@@ -1513,6 +1547,7 @@ function Invoke-MarkMichaelisOneDriveConfiguration {
     param(
         [Parameter(Mandatory)][string]$RootDir,
         [Parameter(Mandatory)][string]$KfmOwner,
+        [switch]$KfmOwnerContains,
         [switch]$NoKfmRebind,
         [AllowEmptyCollection()][AllowNull()][string[]]$FreshSync,
         [switch]$DeleteSourceOnSuccess,
@@ -1520,6 +1555,9 @@ function Invoke-MarkMichaelisOneDriveConfiguration {
     )
 
     Write-Host "MarkMichaelisOneDriveConfiguration: RootDir=$RootDir, KfmOwner=$KfmOwner"
+    if ($KfmOwnerContains) {
+        Write-Host '  KfmOwnerContains requested: using substring owner matching'
+    }
     if ($FreshSync -and $FreshSync.Count -gt 0) {
         Write-Host "  FreshSync requested: $($FreshSync -join ', ')"
     }
@@ -1539,7 +1577,7 @@ function Invoke-MarkMichaelisOneDriveConfiguration {
     }
 
     $kfmCurrent = Get-CurrentKfmPath
-    $kfmDecision = Resolve-KfmRebindAction -Accounts $accounts -KfmCurrentPath $kfmCurrent -KfmOwner $KfmOwner -NoKfmRebind:$NoKfmRebind
+    $kfmDecision = Resolve-KfmRebindAction -Accounts $accounts -KfmCurrentPath $kfmCurrent -KfmOwner $KfmOwner -KfmOwnerContains:$KfmOwnerContains -NoKfmRebind:$NoKfmRebind
     Write-Host "  KFM: [$($kfmDecision.Action)] $($kfmDecision.Reason)"
     if ($kfmDecision.Action -eq 'OwnerNotSignedIn') {
         throw "KFM owner '$KfmOwner' is not signed in. Sign in to the matching Work account in OneDrive and re-run."
@@ -1598,5 +1636,5 @@ function Invoke-MarkMichaelisOneDriveConfiguration {
 # `& "$dir\MarkMichaelisOneDriveConfiguration.ps1"`). When dot-sourced
 # (Pester tests), expose the helpers without running migration.
 if ($MyInvocation.InvocationName -ne '.') {
-    Invoke-MarkMichaelisOneDriveConfiguration -RootDir $RootDir -KfmOwner $KfmOwner -NoKfmRebind:$NoKfmRebind -FreshSync $FreshSync -DeleteSourceOnSuccess:$DeleteSourceOnSuccess -ForceHydrate:$ForceHydrate
+    Invoke-MarkMichaelisOneDriveConfiguration -RootDir $RootDir -KfmOwner $KfmOwner -KfmOwnerContains:$KfmOwnerContains -NoKfmRebind:$NoKfmRebind -FreshSync $FreshSync -DeleteSourceOnSuccess:$DeleteSourceOnSuccess -ForceHydrate:$ForceHydrate
 }

--- a/bucket/MarkMichaelisOneDriveConfiguration.ps1
+++ b/bucket/MarkMichaelisOneDriveConfiguration.ps1
@@ -758,6 +758,107 @@ function Invoke-AppFixUps {
     }
 }
 
+function Get-OneDriveRegistryStringValuesUnderPath {
+    [OutputType([object[]])]
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)][string]$Path
+    )
+
+    if (-not (Test-Path $Path)) { return @() }
+
+    $results = New-Object System.Collections.Generic.List[object]
+    $keys = @([pscustomobject]@{ PSPath = $Path }) + @(Get-ChildItem -Path $Path -Recurse -ErrorAction SilentlyContinue)
+    foreach ($key in $keys) {
+        $props = Get-ItemProperty -Path $key.PSPath -ErrorAction SilentlyContinue
+        if (-not $props) { continue }
+        foreach ($pName in $props.PSObject.Properties.Name) {
+            if ($pName -like 'PS*') { continue }
+            $value = $props.$pName
+            if ($value -is [string] -and [System.IO.Path]::IsPathRooted($value)) {
+                $results.Add([pscustomobject]@{
+                    KeyPath    = $key.PSPath
+                    ValueName  = $pName
+                    Value      = $value
+                }) | Out-Null
+            }
+        }
+    }
+    return $results.ToArray()
+}
+
+function Get-OneDriveSharePointSiteList {
+    [OutputType([object[]])]
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)][AllowEmptyCollection()][object[]]$Accounts,
+        [Parameter(Mandatory)][string]$RootDir
+    )
+
+    $sites = New-Object System.Collections.Generic.List[object]
+    foreach ($account in $Accounts) {
+        if ($account.AccountType -ne 'Business' -or -not $account.TenantId -or -not $account.DisplayName) { continue }
+        $seen = New-Object 'System.Collections.Generic.HashSet[string]' ([System.StringComparer]::OrdinalIgnoreCase)
+        $paths = New-Object System.Collections.Generic.List[string]
+
+        $tenantRoot = Join-Path $account.RegistryPath ("Tenants\{0}" -f $account.TenantId)
+        foreach ($entry in @(Get-OneDriveRegistryStringValuesUnderPath -Path $tenantRoot)) {
+            if ($entry.Value -and $entry.Value -ne $account.UserFolder -and $seen.Add($entry.Value)) {
+                $paths.Add($entry.Value) | Out-Null
+            }
+        }
+
+        foreach ($cacheLeaf in 'ScopeIdToMountPointPathCache','ScopeIdToMountPointPathCacheRoot') {
+            $cacheKey = Join-Path $account.RegistryPath $cacheLeaf
+            foreach ($entry in @(Get-OneDriveRegistryStringValuesUnderPath -Path $cacheKey)) {
+                if ($entry.Value -and $entry.Value -ne $account.UserFolder -and $seen.Add($entry.Value)) {
+                    $paths.Add($entry.Value) | Out-Null
+                }
+            }
+        }
+
+        foreach ($pathValue in $paths) {
+            $leafName = Split-Path -Leaf $pathValue
+            if ([string]::IsNullOrWhiteSpace($leafName)) { continue }
+            $desiredPath = Join-Path (Join-Path $RootDir $account.DisplayName) $leafName
+            $sites.Add([pscustomobject]@{
+                OwnerAccount = $account
+                CurrentPath  = $pathValue
+                LeafName     = $leafName
+                DesiredPath  = $desiredPath
+            }) | Out-Null
+        }
+    }
+
+    return $sites.ToArray()
+}
+
+function Update-OneDriveSharePointCache {
+    [CmdletBinding(SupportsShouldProcess)]
+    param(
+        [Parameter(Mandatory)][pscustomobject]$Account,
+        [Parameter(Mandatory)][string]$OldPath,
+        [Parameter(Mandatory)][string]$NewPath
+    )
+
+    $candidateRoots = @(
+        (Join-Path $Account.RegistryPath ("Tenants\{0}" -f $Account.TenantId)),
+        (Join-Path $Account.RegistryPath 'ScopeIdToMountPointPathCache'),
+        (Join-Path $Account.RegistryPath 'ScopeIdToMountPointPathCacheRoot')
+    )
+
+    foreach ($root in $candidateRoots) {
+        foreach ($entry in @(Get-OneDriveRegistryStringValuesUnderPath -Path $root)) {
+            if ($entry.Value.StartsWith($OldPath, [System.StringComparison]::OrdinalIgnoreCase)) {
+                $newValue = $NewPath + $entry.Value.Substring($OldPath.Length)
+                if ($PSCmdlet.ShouldProcess("$($entry.KeyPath)\$($entry.ValueName)", "Rewrite '$($entry.Value)' -> '$newValue'")) {
+                    Set-ItemProperty -Path $entry.KeyPath -Name $entry.ValueName -Value $newValue -Type String
+                }
+            }
+        }
+    }
+}
+
 # ---------------------------------------------------------------------------
 # Main orchestration. Skipped when the script is dot-sourced (so unit
 # tests can pull in just the helper functions above).
@@ -847,6 +948,7 @@ function New-OneDriveMigrationPlan {
         [Parameter(Mandatory)][string]$RootDir,
         [Parameter(Mandatory)][AllowEmptyCollection()][object[]]$Accounts,
         [Parameter(Mandatory)][AllowEmptyCollection()][object[]]$FreshSyncAccounts,
+        [AllowEmptyCollection()][object[]]$SharePointSites = @(),
         [AllowNull()][string]$KfmCurrentPath,
         [Parameter(Mandatory)][pscustomobject]$KfmDecision,
         [bool]$WasRunning
@@ -890,6 +992,7 @@ function New-OneDriveMigrationPlan {
             $hasFolder = $a.UserFolder -and (Test-Path $a.UserFolder)
             $moveItem = New-OneDriveMigrationPlanItem -Type 'MoveAccount' -Target $a.UserFolder -CurrentValue $a.UserFolder -DesiredValue $null -SameVolume $null -Account $a -Reason 'Fresh-sync unlink instead of migrating the existing local OneDrive tree.' -Skipped:(-not $hasFolder) -SkipReason $(if (-not $hasFolder) { 'Fresh-sync account has no local folder to remove.' } else { $null })
             $moveItem | Add-Member -NotePropertyName FreshSync -NotePropertyValue $true
+            $moveItem | Add-Member -NotePropertyName SharePointSite -NotePropertyValue $false
             $executionItems.Add($moveItem) | Out-Null
             continue
         }
@@ -908,6 +1011,7 @@ function New-OneDriveMigrationPlan {
 
         $moveItem = New-OneDriveMigrationPlanItem -Type 'MoveAccount' -Target $target -CurrentValue $a.UserFolder -DesiredValue $target -SameVolume $sameVolume -Account $a -Reason 'Move the account sync root to the canonical target path.' -Skipped:([bool]$moveSkipReason) -SkipReason $moveSkipReason
         $moveItem | Add-Member -NotePropertyName FreshSync -NotePropertyValue $false
+        $moveItem | Add-Member -NotePropertyName SharePointSite -NotePropertyValue $false
         $executionItems.Add($moveItem) | Out-Null
         $moveItemsBySlot[$a.Slot] = $moveItem
 
@@ -919,13 +1023,47 @@ function New-OneDriveMigrationPlan {
         } else {
             $null
         }
-        $executionItems.Add((New-OneDriveMigrationPlanItem -Type 'UpdateAccountRegistry' -Target "$($a.RegistryPath)\UserFolder" -CurrentValue $regCurrent -DesiredValue $target -SameVolume $sameVolume -Account $a -Reason 'Rewrite OneDrive account registry paths after the move.' -Skipped:([bool]$regSkipReason) -SkipReason $regSkipReason)) | Out-Null
+        $regItem = New-OneDriveMigrationPlanItem -Type 'UpdateAccountRegistry' -Target "$($a.RegistryPath)\UserFolder" -CurrentValue $regCurrent -DesiredValue $target -SameVolume $sameVolume -Account $a -Reason 'Rewrite OneDrive account registry paths after the move.' -Skipped:([bool]$regSkipReason) -SkipReason $regSkipReason
+        $regItem | Add-Member -NotePropertyName MoveItem -NotePropertyValue $moveItem
+        $executionItems.Add($regItem) | Out-Null
 
         if ($AppFixUps.Count -gt 0) {
             $executionItems.Add((New-OneDriveMigrationPlanItem -Type 'AppFixUp' -Target $target -CurrentValue $a.UserFolder -DesiredValue $target -SameVolume $sameVolume -Account $a -Reason 'Run application-specific path fix-ups after the move.' -Skipped:$moveItem.Skipped -SkipReason $moveItem.SkipReason)) | Out-Null
         }
 
         $verifyItem = New-OneDriveMigrationPlanItem -Type 'Verify' -Target $target -CurrentValue $a.UserFolder -DesiredValue $target -SameVolume $sameVolume -Account $a -Reason 'Verify the migrated sync root exists where expected.' -Skipped:$moveItem.Skipped -SkipReason $moveItem.SkipReason
+        $verifyItem | Add-Member -NotePropertyName DeferredDeletePath -NotePropertyValue $null
+        $moveItem | Add-Member -NotePropertyName VerifyItem -NotePropertyValue $verifyItem
+        $executionItems.Add($verifyItem) | Out-Null
+    }
+
+    foreach ($site in $SharePointSites) {
+        if ($freshSyncSlots -contains $site.OwnerAccount.Slot) { continue }
+        $sourceExists = $site.CurrentPath -and (Test-Path $site.CurrentPath)
+        $alreadyTarget = $site.CurrentPath -and ($site.CurrentPath.TrimEnd('\') -ieq $site.DesiredPath.TrimEnd('\'))
+        $sameVolume = if ($sourceExists) { Test-IsSameVolume -Source $site.CurrentPath -Destination $site.DesiredPath } else { $null }
+        $moveSkipReason = $null
+        if (-not $site.CurrentPath) {
+            $moveSkipReason = 'SharePoint site has no current mount path.'
+        } elseif ($alreadyTarget) {
+            $moveSkipReason = 'SharePoint site already matches the canonical target.'
+        } elseif (-not $sourceExists) {
+            $moveSkipReason = 'SharePoint site source folder is missing; migration skipped for safety.'
+        }
+
+        $moveItem = New-OneDriveMigrationPlanItem -Type 'MoveAccount' -Target $site.DesiredPath -CurrentValue $site.CurrentPath -DesiredValue $site.DesiredPath -SameVolume $sameVolume -Account $site.OwnerAccount -Reason 'Move the SharePoint site/library mount to the canonical tenant sibling path.' -Skipped:([bool]$moveSkipReason) -SkipReason $moveSkipReason
+        $moveItem | Add-Member -NotePropertyName FreshSync -NotePropertyValue $false
+        $moveItem | Add-Member -NotePropertyName SharePointSite -NotePropertyValue $true
+        $moveItem | Add-Member -NotePropertyName Site -NotePropertyValue $site
+        $executionItems.Add($moveItem) | Out-Null
+
+        $rewriteSkipReason = if ($moveItem.Skipped) { $moveItem.SkipReason } else { $null }
+        $rewriteItem = New-OneDriveMigrationPlanItem -Type 'RewriteSPCache' -Target $site.DesiredPath -CurrentValue $site.CurrentPath -DesiredValue $site.DesiredPath -SameVolume $sameVolume -Account $site.OwnerAccount -Reason 'Rewrite SharePoint mount-point cache entries after the site move.' -Skipped:([bool]$rewriteSkipReason) -SkipReason $rewriteSkipReason
+        $rewriteItem | Add-Member -NotePropertyName Site -NotePropertyValue $site
+        $rewriteItem | Add-Member -NotePropertyName MoveItem -NotePropertyValue $moveItem
+        $executionItems.Add($rewriteItem) | Out-Null
+
+        $verifyItem = New-OneDriveMigrationPlanItem -Type 'Verify' -Target $site.DesiredPath -CurrentValue $site.CurrentPath -DesiredValue $site.DesiredPath -SameVolume $sameVolume -Account $site.OwnerAccount -Reason 'Verify the SharePoint site/library mount exists where expected.' -Skipped:$moveItem.Skipped -SkipReason $moveItem.SkipReason
         $verifyItem | Add-Member -NotePropertyName DeferredDeletePath -NotePropertyValue $null
         $moveItem | Add-Member -NotePropertyName VerifyItem -NotePropertyValue $verifyItem
         $executionItems.Add($verifyItem) | Out-Null
@@ -1070,6 +1208,9 @@ function Invoke-OneDriveMigrationPlan {
                 'UpdateAccountRegistry' {
                     Update-OneDriveAccountRegistry -Account $item.Account -NewPath $item.DesiredValue
                 }
+                'RewriteSPCache' {
+                    Update-OneDriveSharePointCache -Account $item.Account -OldPath $item.CurrentValue -NewPath $item.DesiredValue
+                }
                 'RewriteKfm' {
                     if ($item.CurrentValue -and $item.DesiredValue) {
                         Update-KfmBindings -OldRoot $item.CurrentValue -NewRoot $item.DesiredValue
@@ -1099,12 +1240,16 @@ function Invoke-OneDriveMigrationPlan {
         } catch {
             $item.Status = 'Failed'
             $item.FailureReason = $_.Exception.Message
-            if ($item.Type -eq 'UpdateAccountRegistry' -and $item.SameVolume) {
-                $moveItem = $Plan | Where-Object { $_.Type -eq 'MoveAccount' -and -not $_.FreshSync -and $_.Account -and $_.Account.Slot -eq $item.Account.Slot } | Select-Object -First 1
+            if ($item.Type -in @('UpdateAccountRegistry','RewriteSPCache') -and $item.SameVolume) {
+                $moveItem = if ($item.PSObject.Properties.Name -contains 'MoveItem') {
+                    $item.MoveItem
+                } else {
+                    $Plan | Where-Object { $_.Type -eq 'MoveAccount' -and -not $_.FreshSync -and $_.Account -and $_.Account.Slot -eq $item.Account.Slot } | Select-Object -First 1
+                }
                 if ($moveItem -and (Test-Path $moveItem.DesiredValue) -and -not (Test-Path $moveItem.CurrentValue)) {
                     Move-Item -LiteralPath $moveItem.DesiredValue -Destination $moveItem.CurrentValue
                 }
-                if ($moveItem -and $moveItem.RegistrySnapshot) {
+                if ($item.Type -eq 'UpdateAccountRegistry' -and $moveItem -and $moveItem.RegistrySnapshot) {
                     Restore-OneDriveAccountRegistrySnapshot -Account $item.Account -Snapshot $moveItem.RegistrySnapshot
                 }
             }
@@ -1135,6 +1280,7 @@ function Invoke-MarkMichaelisOneDriveConfiguration {
 
     $accounts = Get-OneDriveAccountList
     $freshSyncAccounts = Resolve-FreshSyncAccounts -Accounts $accounts -FreshSync $FreshSync
+    $sharePointSites = Get-OneDriveSharePointSiteList -Accounts $accounts -RootDir $RootDir
     $freshSyncSlots = @($freshSyncAccounts | ForEach-Object { $_.Slot })
 
     Write-Host "  Discovered $($accounts.Count) account(s):"
@@ -1151,7 +1297,7 @@ function Invoke-MarkMichaelisOneDriveConfiguration {
     }
 
     $wasRunning = [bool](Get-Process -Name 'OneDrive' -ErrorAction SilentlyContinue)
-    $plan = New-OneDriveMigrationPlan -RootDir $RootDir -Accounts $accounts -FreshSyncAccounts @($freshSyncAccounts) -KfmCurrentPath $kfmCurrent -KfmDecision $kfmDecision -WasRunning:$wasRunning
+    $plan = New-OneDriveMigrationPlan -RootDir $RootDir -Accounts $accounts -FreshSyncAccounts @($freshSyncAccounts) -SharePointSites @($sharePointSites) -KfmCurrentPath $kfmCurrent -KfmDecision $kfmDecision -WasRunning:$wasRunning
     Format-OneDriveMigrationPlan -Plan $plan
 
     if ($WhatIfPreference) {

--- a/bucket/MarkMichaelisOneDriveConfiguration.ps1
+++ b/bucket/MarkMichaelisOneDriveConfiguration.ps1
@@ -24,7 +24,7 @@
       - Auto-migrates any account whose UserFolder doesn't match the
         target convention. Same-volume migrations use Move-Item (NTFS
         rename, preserves Cloud Files reparse + ACLs). Cross-volume
-        migrations use robocopy /MIR /COPYALL /DCOPY:DAT /ZB and warn
+        migrations use robocopy /E /COPYALL /DCOPY:DAT /ZB and warn
         about Files-On-Demand placeholders.
       - Rewrites KFM bindings (User Shell Folders / Shell Folders /
         KNOWNFOLDERID GUIDs) when the owning account moves.
@@ -595,7 +595,7 @@ function Invoke-RobocopyMirror {
         [Parameter(Mandatory)][string]$Destination
     )
 
-    $args = @($Source, $Destination, '/MIR','/COPYALL','/DCOPY:DAT','/ZB','/R:1','/W:1','/XJ','/NFL','/NDL')
+    $args = @($Source, $Destination, '/E','/COPYALL','/DCOPY:DAT','/ZB','/R:1','/W:1','/XJ','/NFL','/NDL')
     & robocopy @args | Out-Null
     return $LASTEXITCODE
 }
@@ -619,7 +619,7 @@ function Move-OneDriveFolder {
     <#
     .SYNOPSIS
         Move an account's UserFolder from $Source to $Destination,
-        using NTFS rename when possible and robocopy /MIR /COPYALL
+        using NTFS rename when possible and robocopy /E /COPYALL
         otherwise. Cross-volume moves rename the original source to a
         .migrated-* recovery folder and only delete it when explicitly
         requested via -DeleteSourceOnSuccess.
@@ -663,8 +663,8 @@ function Move-OneDriveFolder {
         return $result
     }
 
-    Write-Warning "Cross-volume migration copies data first, then renames the original source to a .migrated-* recovery folder. Use -DeleteSourceOnSuccess only after you are comfortable auto-removing that recovery folder."
-    if ($PSCmdlet.ShouldProcess($Source, "robocopy /MIR /COPYALL -> $Destination (cross volume)")) {
+    Write-Warning "Cross-volume migration uses robocopy /E /COPYALL first, then renames the original source to a .migrated-* recovery folder. Use -DeleteSourceOnSuccess only after you are comfortable auto-removing that recovery folder."
+    if ($PSCmdlet.ShouldProcess($Source, "robocopy /E /COPYALL -> $Destination (cross volume)")) {
         $rc = Invoke-RobocopyMirror -Source $Source -Destination $Destination
         # robocopy success: 0-7. >=8 is failure.
         if ($rc -ge 8) {

--- a/bucket/MarkMichaelisOneDriveConfiguration.ps1
+++ b/bucket/MarkMichaelisOneDriveConfiguration.ps1
@@ -54,13 +54,15 @@
     Names (Slot or DisplayName) of Business* accounts that should
     be unlinked instead of file-copy-migrated. For each match, the
     bundle stops OneDrive, deletes the per-account registry key
-    (HKCU:\Software\Microsoft\OneDrive\Accounts\<Slot>) and the
-    local UserFolder, then restarts OneDrive. The user must
-    re-sign-in via the OneDrive UI; the DefaultRootDir policy
-    (still applied) directs the new sync root to the canonical
-    location, and OneDrive recreates cloud-only placeholders
-    without bulk-downloading Files-On-Demand content. Personal
-    accounts are not supported.
+    (HKCU:\Software\Microsoft\OneDrive\Accounts\<Slot>) and renames
+    the local UserFolder to <UserFolder>.freshsync-<yyyyMMdd-HHmmss>
+    by default so a recovery copy is preserved. Pass
+    -DeleteSourceOnSuccess to remove that recovery folder after a
+    successful fresh-sync unlink. The user must re-sign-in via the
+    OneDrive UI; the DefaultRootDir policy (still applied) directs the
+    new sync root to the canonical location, and OneDrive recreates
+    cloud-only placeholders without bulk-downloading Files-On-Demand
+    content. Personal accounts are not supported.
 
 .PARAMETER SkipElevationCheck
     Skip the top-level elevation pre-flight. Use only when the HKLM
@@ -832,15 +834,21 @@ function Remove-OneDriveAccountLink {
     <#
     .SYNOPSIS
         Unlink a OneDrive Business account: delete its registry slot
-        and local UserFolder so the user can re-sign-in fresh.
+        and preserve the local UserFolder as a fresh-sync recovery copy
+        so the user can re-sign-in fresh.
     .DESCRIPTION
         Used by -FreshSync to avoid bulk-hydrating Files-On-Demand
         placeholders during a cross-volume migration. Caller is
-        responsible for stopping OneDrive.exe first.
+        responsible for stopping OneDrive.exe first. By default the
+        local UserFolder is renamed to <UserFolder>.freshsync-<timestamp>
+        so the user retains a recovery copy. Pass -DeleteRecoveryFolder
+        to remove that renamed recovery folder after the unlink.
     #>
+    [OutputType([string])]
     [CmdletBinding(SupportsShouldProcess)]
     param(
-        [Parameter(Mandatory)][pscustomobject]$Account
+        [Parameter(Mandatory)][pscustomobject]$Account,
+        [switch]$DeleteRecoveryFolder
     )
     $regPath = $Account.RegistryPath
     if ($regPath -and (Test-Path $regPath)) {
@@ -849,11 +857,21 @@ function Remove-OneDriveAccountLink {
         }
     }
     $folder = $Account.UserFolder
+    $recoveryPath = $null
     if ($folder -and (Test-Path $folder)) {
-        if ($PSCmdlet.ShouldProcess($folder, "Remove local OneDrive sync folder (fresh-sync)")) {
-            Remove-Item -LiteralPath $folder -Recurse -Force
+        $timestamp = Get-Date -Format 'yyyyMMdd-HHmmss'
+        $recoveryPath = "$folder.freshsync-$timestamp"
+        if ($PSCmdlet.ShouldProcess($folder, "Rename local OneDrive sync folder -> $recoveryPath (fresh-sync recovery)")) {
+            Move-Item -LiteralPath $folder -Destination $recoveryPath
+        }
+        if ($DeleteRecoveryFolder) {
+            if ($PSCmdlet.ShouldProcess($recoveryPath, 'Remove-Item -Recurse (fresh-sync recovery cleanup)')) {
+                Remove-Item -LiteralPath $recoveryPath -Recurse -Force
+                $recoveryPath = $null
+            }
         }
     }
+    return $recoveryPath
 }
 
 function Invoke-AppFixUps {
@@ -1383,6 +1401,7 @@ function Invoke-OneDriveMigrationPlan {
     )
 
     $deferredCleanupPaths = New-Object System.Collections.Generic.List[string]
+    $freshSyncRecoveryPaths = New-Object System.Collections.Generic.List[string]
     foreach ($item in $Plan) {
         if ($item.Skipped) {
             $item.Status = 'Skipped'
@@ -1422,7 +1441,11 @@ function Invoke-OneDriveMigrationPlan {
                 }
                 'MoveAccount' {
                     if ($item.FreshSync) {
-                        Remove-OneDriveAccountLink -Account $item.Account
+                        $freshSyncRecoveryPath = Remove-OneDriveAccountLink -Account $item.Account -DeleteRecoveryFolder:$DeleteSourceOnSuccess
+                        if ($freshSyncRecoveryPath) {
+                            $freshSyncRecoveryPaths.Add($freshSyncRecoveryPath) | Out-Null
+                            $item.Warnings += "FreshSync recovery folder preserved at: $freshSyncRecoveryPath"
+                        }
                     } else {
                         $sameVolume = Test-IsSameVolume -Source $item.CurrentValue -Destination $item.DesiredValue
                         $registrySnapshot = $null
@@ -1492,8 +1515,9 @@ function Invoke-OneDriveMigrationPlan {
     }
 
     return [pscustomobject]@{
-        DeferredCleanupPaths = $deferredCleanupPaths
-        Plan                 = $Plan
+        DeferredCleanupPaths   = $deferredCleanupPaths
+        FreshSyncRecoveryPaths = $freshSyncRecoveryPaths
+        Plan                   = $Plan
     }
 }
 
@@ -1523,7 +1547,8 @@ function Get-OneDriveMigrationSummaryLines {
         [Parameter(Mandatory)][AllowEmptyCollection()][object[]]$Accounts,
         [Parameter(Mandatory)][AllowEmptyCollection()][object[]]$SharePointSites,
         [Parameter(Mandatory)][AllowEmptyCollection()][object[]]$Plan,
-        [AllowEmptyCollection()][string[]]$DeferredCleanupPaths = @()
+        [AllowEmptyCollection()][string[]]$DeferredCleanupPaths = @(),
+        [AllowEmptyCollection()][string[]]$FreshSyncRecoveryPaths = @()
     )
 
     $lines = New-Object System.Collections.Generic.List[string]
@@ -1589,6 +1614,15 @@ function Get-OneDriveMigrationSummaryLines {
         $lines.Add('  - none') | Out-Null
     } else {
         foreach ($path in @($DeferredCleanupPaths)) {
+            $lines.Add(("  - {0}" -f $path)) | Out-Null
+        }
+    }
+
+    $lines.Add('FreshSync recovery folders preserved at:') | Out-Null
+    if (@($FreshSyncRecoveryPaths).Count -eq 0) {
+        $lines.Add('  - none') | Out-Null
+    } else {
+        foreach ($path in @($FreshSyncRecoveryPaths)) {
             $lines.Add(("  - {0}" -f $path)) | Out-Null
         }
     }
@@ -1677,9 +1711,11 @@ function Invoke-MarkMichaelisOneDriveConfiguration {
 
     $backupPath = ($plan | Where-Object Type -eq 'RegistryBackup' | Select-Object -First 1).Target
     $deferredCleanupPaths = @()
+    $freshSyncRecoveryPaths = @()
     try {
         $execution = Invoke-OneDriveMigrationPlan -Plan $plan -DeleteSourceOnSuccess:$DeleteSourceOnSuccess -Confirm:$false
         $deferredCleanupPaths = @($execution.DeferredCleanupPaths)
+        $freshSyncRecoveryPaths = @($execution.FreshSyncRecoveryPaths)
     } catch {
         $failedItem = $plan | Where-Object { $_.Status -eq 'Failed' } | Select-Object -First 1
         if ($failedItem -and $failedItem.Type -eq 'UpdateAccountRegistry' -and $failedItem.Account) {
@@ -1690,7 +1726,7 @@ function Invoke-MarkMichaelisOneDriveConfiguration {
         throw
     }
 
-    $summaryLines = Get-OneDriveMigrationSummaryLines -Accounts $accounts -SharePointSites @($sharePointSites) -Plan $plan -DeferredCleanupPaths @($deferredCleanupPaths)
+    $summaryLines = Get-OneDriveMigrationSummaryLines -Accounts $accounts -SharePointSites @($sharePointSites) -Plan $plan -DeferredCleanupPaths @($deferredCleanupPaths) -FreshSyncRecoveryPaths @($freshSyncRecoveryPaths)
     Write-OneDriveMigrationSummary -Lines $summaryLines
 
     if ($freshSyncAccounts.Count -gt 0) {


### PR DESCRIPTION
## Summary
- fix OneDrive policy correctness, move planning/execution safety, and idempotence across account/KFM/SharePoint migrations
- add rollback/verification/registry-backup safeguards plus Files-On-Demand and cross-volume handling improvements
- expand Pester coverage for heavy migration flows, owner matching, robocopy behavior, and known-folder rewrites

## Validation
- Invoke-Pester -Path .\bucket\MarkMichaelisOneDriveConfiguration.Tests.ps1
- Invoke-Pester -Path .\bucket\Bundles.Tests.ps1
- .\Test-ManifestVersionBumps.ps1

## Notes
- Manifest version finalized at 1.04.000 to keep version-bump validation consistent with the accumulated script changes.