### PR TITLE
feat(aiagents): silence Warp installer progress UI via --silent / --disable-interactivity

### DIFF
--- a/bucket/AIAgents.Tests.ps1
+++ b/bucket/AIAgents.Tests.ps1
@@ -1,0 +1,41 @@
+#requires -Version 7.0
+#requires -Modules @{ ModuleName = 'Pester'; ModuleVersion = '5.0.0' }
+
+<#
+.SYNOPSIS
+    Behavior-first tests for AIAgents bundle entries that need
+    bundle-specific winget invocation tweaks.
+
+.DESCRIPTION
+    Warp ships a Squirrel-based installer whose progress UI pops a
+    window during winget install. That is bad UX for interactive
+    Install-Package calls and outright broken for headless CI. The
+    bucket suppresses it by passing both --silent (installer UI off)
+    and --disable-interactivity (winget itself stays non-interactive)
+    via the Package.WingetExtraArgs surface.
+#>
+
+BeforeAll {
+    $scoopBucketPsd1 = Join-Path $PSScriptRoot '..\module\MarkMichaelis.ScoopBucket\MarkMichaelis.ScoopBucket.psd1'
+    if (Test-Path $scoopBucketPsd1) {
+        Import-Module $scoopBucketPsd1 -Force
+    } else {
+        Import-Module MarkMichaelis.ScoopBucket -Force
+    }
+    $script:warpPkg = Get-Package -BucketPath $PSScriptRoot -Name 'Warp'
+}
+
+Describe 'AIAgents bundle: Warp winget invocation' -Tag 'Light','Bundle' {
+
+    It 'declares the Warp package exactly once' {
+        @($script:warpPkg).Count | Should -Be 1
+    }
+
+    It 'passes --silent to suppress the Squirrel installer progress UI' {
+        $script:warpPkg.WingetExtraArgs | Should -Contain '--silent'
+    }
+
+    It 'passes --disable-interactivity to keep winget itself non-interactive' {
+        $script:warpPkg.WingetExtraArgs | Should -Contain '--disable-interactivity'
+    }
+}

--- a/bucket/AIAgents.json
+++ b/bucket/AIAgents.json
@@ -1,6 +1,6 @@
 {
     "$schema": "https://raw.githubusercontent.com/lukesampson/scoop/master/schema.json",
-    "version": "1.18.000",
+    "version": "1.19.000",
     "url": [
         "https://raw.githubusercontent.com/MarkMichaelis/ScoopBucket/master/bucket/AIAgents.ps1"
     ],

--- a/bucket/AIAgents.ps1
+++ b/bucket/AIAgents.ps1
@@ -116,6 +116,11 @@ Register-ArgumentCompleter -Native -CommandName npx -ScriptBlock {
         # doesn't fall back to a machine-context selection that fails on
         # headless CI runners (mirrors the Claude Desktop note above).
         Scope       = 'user'
+        # Warp ships a Squirrel-based installer that pops a progress
+        # window during install. --silent suppresses that installer UI,
+        # and --disable-interactivity keeps winget itself non-interactive
+        # so headless / CI runs do not stall on prompts.
+        WingetExtraArgs = @('--silent', '--disable-interactivity')
         # Two surfaces from a single binary:
         #   * `warp` — launches the Warp terminal UI (GUI) when run bare,
         #              or the embedded Oz CLI when run with subcommands.


### PR DESCRIPTION
## Summary

Suppresses the Warp installer progress UI by passing both `--silent` and `--disable-interactivity` to `winget install` for the `Warp` package in `bucket/AIAgents.ps1`.

- `--silent` -- suppresses the Squirrel installer's own progress window
- `--disable-interactivity` -- keeps winget itself non-interactive (no prompts on headless / CI runs)

Implemented as a one-line data change: a new `WingetExtraArgs` entry on the Warp `[Package]`. `Install-WingetPackage` already appends `WingetExtraArgs` verbatim to the `winget install` argv (`module/MarkMichaelis.ScoopBucket/Private/Install-WingetPackage.ps1`, lines 53-55). Existing precedent: the `Handy` entry in `bucket/ClientBasePackages.ps1` uses the same surface.

## Tests

New `bucket/AIAgents.Tests.ps1` (Pester 5, discovery-time data wiring per the convention in `bucket/Bundles.Tests.ps1`):

- declares the Warp package exactly once
- passes `--silent`
- passes `--disable-interactivity`

Behavior-first verified: with the production change reverted, the two flag assertions fail with `Expected '--silent' to be found in collection $null` -- a real behavioral failure, not a compile/import error.

Local verification:

```
pwsh -NoProfile -Command "Invoke-Pester -Path ./bucket/AIAgents.Tests.ps1 -Output Detailed"
```

Wider regression run (824 tests, 0 failures):

```
pwsh -NoProfile -Command "Invoke-Pester -Path ./bucket/Bundles.Tests.ps1,./bucket/Package.Tests.ps1,./bucket/AIAgents.Tests.ps1"
```

## Evidence

`Install-WingetPackage -WhatIf` against the post-change `Warp` package emits the resolved argv:

```
[WhatIf] winget install --id Warp.Warp --accept-package-agreements --accept-source-agreements --scope user --silent --disable-interactivity
```

Both flags are present at the tail of the argv, confirming the data change reaches the wire. Full artifact attached as a follow-up PR comment.

Closes #206.
