### PR TITLE
feat(client-base): add sachaos/todoist CLI to ClientBasePackages bundle

### DIFF
--- a/bucket/ClientBasePackages.Tests.ps1
+++ b/bucket/ClientBasePackages.Tests.ps1
@@ -1,0 +1,57 @@
+#requires -Version 7.0
+#requires -Modules @{ ModuleName = 'Pester'; ModuleVersion = '5.0.0' }
+
+<#
+.SYNOPSIS
+    Behavior-first tests for the Todoist + Todoist CLI co-location in
+    ClientBasePackages, including the DependsOn regression guard that
+    locks in "install Todoist, get the CLI too" (issue #208).
+#>
+
+BeforeAll {
+    $scoopBucketPsd1 = Join-Path $PSScriptRoot '..\module\MarkMichaelis.ScoopBucket\MarkMichaelis.ScoopBucket.psd1'
+    if (Test-Path $scoopBucketPsd1) { Import-Module $scoopBucketPsd1 -Force } else { Import-Module MarkMichaelis.ScoopBucket -Force }
+    $script:pkgs = @(Get-Package -BucketPath $PSScriptRoot)
+}
+
+Describe 'ClientBasePackages: Todoist CLI co-located with Todoist desktop' -Tag 'Light','Bundle' {
+
+    It 'declares the existing Todoist desktop entry (regression guard)' {
+        $desktop = @($script:pkgs | Where-Object Name -EQ 'Todoist')
+        $desktop.Count        | Should -Be 1
+        $desktop[0].Installer | Should -Be 'winget'
+        $desktop[0].Id        | Should -Be '9MWF2DWS5Z9N'
+        $desktop[0].Source    | Should -Be 'msstore'
+        $desktop[0].Bundle    | Should -Be 'ClientBasePackages'
+    }
+
+    It 'declares a Todoist CLI package using sachaos/todoist via winget' {
+        $cli = @($script:pkgs | Where-Object Name -EQ 'Todoist CLI')
+        $cli.Count        | Should -Be 1
+        $cli[0].Installer | Should -Be 'winget'
+        $cli[0].Id        | Should -Be 'Sachaos.Todoist'
+        $cli[0].Bundle    | Should -Be 'ClientBasePackages'
+    }
+
+    It 'declares CliCommands=todoist with native completion and expected subcommands' {
+        $cli = @($script:pkgs | Where-Object Name -EQ 'Todoist CLI')[0]
+        $cli.CliCommands              | Should -Be @('todoist')
+        $cli.Completion               | Should -Be 'native'
+        $cli.HasNativeCommandScript   | Should -BeTrue
+        $cli.ExpectedCompletions.ContainsKey('todoist') | Should -BeTrue
+        foreach ($expected in 'add','list','show','completion','--help') {
+            $cli.ExpectedCompletions['todoist'] | Should -Contain $expected
+        }
+    }
+
+    It 'passes --silent and --disable-interactivity to winget' {
+        $cli = @($script:pkgs | Where-Object Name -EQ 'Todoist CLI')[0]
+        $cli.WingetExtraArgs | Should -Contain '--silent'
+        $cli.WingetExtraArgs | Should -Contain '--disable-interactivity'
+    }
+
+    It 'DependsOn the desktop Todoist (auto-install-with-desktop regression guard)' {
+        $cli = @($script:pkgs | Where-Object Name -EQ 'Todoist CLI')[0]
+        @($cli.DependsOn)       | Should -Be @('Todoist')
+    }
+}

--- a/bucket/ClientBasePackages.json
+++ b/bucket/ClientBasePackages.json
@@ -1,6 +1,6 @@
 {
     "$schema": "https://raw.githubusercontent.com/lukesampson/scoop/master/schema.json",
-    "version": "1.16.000",
+    "version": "1.17.000",
     "url": [
         "https://raw.githubusercontent.com/MarkMichaelis/ScoopBucket/master/bucket/ClientBasePackages.ps1"
     ],

--- a/bucket/ClientBasePackages.ps1
+++ b/bucket/ClientBasePackages.ps1
@@ -164,6 +164,18 @@ Register-ArgumentCompleter -Native -CommandName sox -ScriptBlock {
                 Notes = 'winget default source ships user-scope MSIX only; ms-store is the automated path (#9).' }
     [Package]@{ Name = 'Todoist';          Installer = 'winget'; Id = '9MWF2DWS5Z9N'; Source = 'msstore'
                 Notes = 'winget default source ships user-scope MSIX only; ms-store is the automated path (#11).' }
+    [Package]@{
+        Name        = 'Todoist CLI'
+        Installer   = 'winget'
+        Id          = 'Sachaos.Todoist'
+        CliCommands = @('todoist')
+        Completion  = 'native'
+        NativeCommandScript = { todoist completion powershell }
+        WingetExtraArgs = @('--silent', '--disable-interactivity')
+        DependsOn   = @('Todoist')
+        Notes       = 'sachaos/todoist Go CLI for Todoist. Co-located with the Todoist desktop entry above so the ClientBasePackages bundle installs both; DependsOn ensures the desktop app is provisioned first when the CLI is installed directly. Mirrors the Bitwarden / Bitwarden CLI pattern (#208).'
+        ExpectedCompletions = @{ todoist = @('add','list','show','completion','--help') }
+    }
 
     [Package]@{
         Name        = 'Readwise Reader'


### PR DESCRIPTION
## Summary

Adds the sachaos/todoist Go CLI to `bucket/ClientBasePackages.ps1` immediately after the existing Todoist desktop entry, mirroring the Bitwarden / Bitwarden CLI pattern already in this same file (line 99). Running `ClientBasePackages` now installs both the Microsoft Store Todoist client and the `todoist` CLI on PATH in a single bundle run.

## Schema

```powershell
[Package]@{
    Name        = 'Todoist CLI'
    Installer   = 'winget'
    Id          = 'Sachaos.Todoist'
    CliCommands = @('todoist')
    Completion  = 'native'
    NativeCommandScript = { todoist completion powershell }
    WingetExtraArgs = @('--silent', '--disable-interactivity')
    DependsOn   = @('Todoist')
    ExpectedCompletions = @{ todoist = @('add','list','show','completion','--help') }
}
```

## Precedents followed

- **Bitwarden / Bitwarden CLI** (`bucket/ClientBasePackages.ps1:98`) -- separate CLI Package with `DependsOn` pointing at the desktop app.
- **ripgrep** (`bucket/OSBasePackages.ps1:171`) -- `Completion = 'native'` with `NativeCommandScript = { rg --generate complete-powershell }`. `todoist completion powershell` emits the same kind of `Register-ArgumentCompleter` block.
- **Warp** (PR #207) -- `WingetExtraArgs = @('--silent', '--disable-interactivity')` to silence interactive winget installers.

## Tests

New `bucket/ClientBasePackages.Tests.ps1` (5 cases):

- Existing Todoist desktop entry still resolves to `Id=9MWF2DWS5Z9N`, `Source=msstore` (regression guard).
- `Get-Package -Name 'Todoist CLI'` returns exactly one entry with `Installer=winget`, `Id=Sachaos.Todoist`.
- `CliCommands=@('todoist')`, `Completion='native'`, `HasNativeCommandScript=True`, expected subcommands populated.
- `WingetExtraArgs` contains both `--silent` and `--disable-interactivity`.
- `DependsOn -eq @('Todoist')` -- locks in the auto-install-with-desktop behavior.

All 837 tests across `ClientBasePackages.Tests.ps1`, `Bundles.Tests.ps1`, and `Package.Tests.ps1` pass.

## Evidence (Phase 5b)

`Install-WingetPackage -WhatIf` against the resolved package produces:

```
[WhatIf] winget install --id Sachaos.Todoist --accept-package-agreements --accept-source-agreements --scope machine --silent --disable-interactivity
```

Every declared field round-trips through the child-runspace bundle loader and the `Get-Package` flattener intact (including `DependsOn` -- the contract the plan called out as a bundle gotcha).

## Local verification

```
pwsh -NoProfile -Command "Invoke-Pester -Path .\bucket\ClientBasePackages.Tests.ps1, .\bucket\Bundles.Tests.ps1, .\bucket\Package.Tests.ps1 -Output Detailed"
```

Closes #208
