### PR TITLE
feat: add Companions field for symmetric desktop-app/CLI install + uninstall cascade

### DIFF
--- a/bucket/AIAgents.Tests.ps1
+++ b/bucket/AIAgents.Tests.ps1
@@ -39,3 +39,15 @@ Describe 'AIAgents bundle: Warp winget invocation' -Tag 'Light','Bundle' {
         $script:warpPkg.WingetExtraArgs | Should -Contain '--disable-interactivity'
     }
 }
+
+Describe 'AIAgents bundle: Gemini desktop -> Gemini CLI Companions' -Tag 'Light','Bundle' {
+    BeforeAll {
+        $script:aiPkgs = @(Get-Package -BucketPath $PSScriptRoot -Bundle 'AIAgents')
+    }
+
+    It 'Gemini desktop declares Companions=@(Gemini CLI)' {
+        $desktop = @($script:aiPkgs | Where-Object Name -EQ 'Gemini')[0]
+        $desktop                       | Should -Not -BeNullOrEmpty
+        @($desktop.Companions)         | Should -Contain 'Gemini CLI'
+    }
+}

--- a/bucket/AIAgents.json
+++ b/bucket/AIAgents.json
@@ -1,6 +1,6 @@
 {
     "$schema": "https://raw.githubusercontent.com/lukesampson/scoop/master/schema.json",
-    "version": "1.19.000",
+    "version": "1.20.000",
     "url": [
         "https://raw.githubusercontent.com/MarkMichaelis/ScoopBucket/master/bucket/AIAgents.ps1"
     ],

--- a/bucket/AIAgents.ps1
+++ b/bucket/AIAgents.ps1
@@ -100,6 +100,7 @@ Register-ArgumentCompleter -Native -CommandName npx -ScriptBlock {
         Name      = 'Gemini'
         Installer = 'scoop'
         Id        = 'MarkMichaelis/Gemini'
+        Companions = @('Gemini CLI')
         CISkip    = 'Browser-watch installer requires interactive Download click; see #25/#26.'
     }
     [Package]@{

--- a/bucket/Bundles.Tests.ps1
+++ b/bucket/Bundles.Tests.ps1
@@ -98,6 +98,28 @@ Describe 'Declarative bundles (data-driven)' -Tag 'Light','Bundle' {
         $missing | Should -BeNullOrEmpty -Because "unresolved DependsOn: $($missing -join ', ')"
     }
 
+    It 'every Companions reference resolves to a package in the same bundle' {
+        # Companions is same-bundle-only for v1 -- mirrors the DependsOn
+        # constraint in Resolve-PackageOrder. A cross-bundle Companions
+        # reference is a bug because Resolve-PackageOrder runs per bundle.
+        $byBundleName = @{}
+        foreach ($p in $script:allPkgs) {
+            if (-not $byBundleName.ContainsKey($p.Bundle)) {
+                $byBundleName[$p.Bundle] = [System.Collections.Generic.HashSet[string]]::new([System.StringComparer]::OrdinalIgnoreCase)
+            }
+            [void]$byBundleName[$p.Bundle].Add($p.Name)
+        }
+        $missing = New-Object System.Collections.Generic.List[string]
+        foreach ($p in $script:allPkgs) {
+            foreach ($comp in @($p.Companions)) {
+                if (-not [string]::IsNullOrWhiteSpace($comp) -and -not $byBundleName[$p.Bundle].Contains($comp)) {
+                    $missing.Add("$($p.Bundle)/$($p.Name) -> $comp")
+                }
+            }
+        }
+        $missing | Should -BeNullOrEmpty -Because "unresolved Companions (must be same-bundle): $($missing -join ', ')"
+    }
+
     It '<Pkg.Name> (<Bundle>) declares a known Installer' -ForEach $script:pkgCases {
         $Pkg.Installer | Should -BeIn @('winget','scoop','choco','npmGlobal','dotnetTool','custom')
     }

--- a/bucket/ClientBasePackages.Tests.ps1
+++ b/bucket/ClientBasePackages.Tests.ps1
@@ -54,4 +54,14 @@ Describe 'ClientBasePackages: Todoist CLI co-located with Todoist desktop' -Tag 
         $cli = @($script:pkgs | Where-Object Name -EQ 'Todoist CLI')[0]
         @($cli.DependsOn)       | Should -Be @('Todoist')
     }
+
+    It 'Bitwarden desktop declares Companions=@(Bitwarden CLI) (auto-install CLI with app)' {
+        $desktop = @($script:pkgs | Where-Object Name -EQ 'Bitwarden')[0]
+        @($desktop.Companions) | Should -Contain 'Bitwarden CLI'
+    }
+
+    It 'Todoist desktop declares Companions=@(Todoist CLI) (auto-install CLI with app)' {
+        $desktop = @($script:pkgs | Where-Object Name -EQ 'Todoist')[0]
+        @($desktop.Companions) | Should -Contain 'Todoist CLI'
+    }
 }

--- a/bucket/ClientBasePackages.json
+++ b/bucket/ClientBasePackages.json
@@ -1,6 +1,6 @@
 {
     "$schema": "https://raw.githubusercontent.com/lukesampson/scoop/master/schema.json",
-    "version": "1.17.000",
+    "version": "1.18.000",
     "url": [
         "https://raw.githubusercontent.com/MarkMichaelis/ScoopBucket/master/bucket/ClientBasePackages.ps1"
     ],

--- a/bucket/ClientBasePackages.ps1
+++ b/bucket/ClientBasePackages.ps1
@@ -94,7 +94,8 @@ Register-ArgumentCompleter -Native -CommandName espeak-ng -ScriptBlock {
     [Package]@{ Name = 'Zoom';             Installer = 'scoop';  Id = 'extras/zoom' }
 
     [Package]@{ Name = 'Amazon Kindle';    Installer = 'winget'; Id = 'Amazon.Kindle' }
-    [Package]@{ Name = 'Bitwarden';        Installer = 'winget'; Id = 'Bitwarden.Bitwarden' }
+    [Package]@{ Name = 'Bitwarden';        Installer = 'winget'; Id = 'Bitwarden.Bitwarden'
+                Companions = @('Bitwarden CLI') }
     [Package]@{
         Name        = 'Bitwarden CLI'
         Installer   = 'winget'
@@ -163,6 +164,7 @@ Register-ArgumentCompleter -Native -CommandName sox -ScriptBlock {
     [Package]@{ Name = 'Snagit';           Installer = 'winget'; Id = 'XPDNSF6TXN2R6Z'; Source = 'msstore'
                 Notes = 'winget default source ships user-scope MSIX only; ms-store is the automated path (#9).' }
     [Package]@{ Name = 'Todoist';          Installer = 'winget'; Id = '9MWF2DWS5Z9N'; Source = 'msstore'
+                Companions = @('Todoist CLI')
                 Notes = 'winget default source ships user-scope MSIX only; ms-store is the automated path (#11).' }
     [Package]@{
         Name        = 'Todoist CLI'

--- a/bucket/InstallPackageFilter.Tests.ps1
+++ b/bucket/InstallPackageFilter.Tests.ps1
@@ -135,3 +135,67 @@ Describe 'Install-Package <BareManifest> fallback' -Tag 'Light', 'Module' {
             Should -Throw -ExpectedMessage "*no bundle declares a package named 'NoSuchThing'*"
     }
 }
+
+Describe 'Install-Package -- Companions cascade' -Tag 'Light', 'Module' {
+
+    BeforeAll {
+        $script:repoRoot3 = Split-Path -Parent $PSScriptRoot
+        $script:psd1c     = Join-Path $script:repoRoot3 'module\MarkMichaelis.ScoopBucket\MarkMichaelis.ScoopBucket.psd1'
+
+        $script:tmpBucket3 = Join-Path ([System.IO.Path]::GetTempPath()) ("ScoopBucket-install-comp-$([guid]::NewGuid().ToString('N'))")
+        New-Item -ItemType Directory -Path $script:tmpBucket3 | Out-Null
+
+        $bundleText = @"
+`$scoopBucketPsd1 = '$($script:psd1c -replace "'","''")'
+if (Test-Path `$scoopBucketPsd1) { Import-Module `$scoopBucketPsd1 -Force } else { Import-Module MarkMichaelis.ScoopBucket -Force }
+
+`$Packages = [Package[]]@(
+    [Package]@{ Name = 'Owner'; Installer = 'winget'; Id = 'Test.Owner'; Companions = @('OwnerCli') }
+    [Package]@{
+        Name        = 'OwnerCli'
+        Installer   = 'winget'
+        Id          = 'Test.OwnerCli'
+        CliCommands = @('ownercli')
+        Completion  = 'native'
+        DependsOn   = @('Owner')
+        NativeCommandScript = { 'noop' }
+        ExpectedCompletions = @{ ownercli = @('--help') }
+    }
+    [Package]@{ Name = 'Unrelated'; Installer = 'winget'; Id = 'Test.Unrelated' }
+)
+
+Invoke-PackageInstall -Packages `$Packages -Bundle 'CompInstallBundle'
+"@
+        Set-Content -Path (Join-Path $script:tmpBucket3 'CompInstallBundle.ps1') -Value $bundleText -Encoding UTF8
+
+        $bundleManifest = @{
+            '$schema'  = 'https://raw.githubusercontent.com/lukesampson/scoop/master/schema.json'
+            version   = '1.00.000'
+            url       = @('https://example.invalid/comp-install-bundle')
+            installer = @{ script = @('& "$dir\\CompInstallBundle.ps1"') }
+        }
+        Set-Content -LiteralPath (Join-Path $script:tmpBucket3 'CompInstallBundle.json') `
+            -Value ($bundleManifest | ConvertTo-Json -Depth 4) -Encoding UTF8
+    }
+
+    AfterAll {
+        if ($script:tmpBucket3 -and (Test-Path $script:tmpBucket3)) {
+            Remove-Item -LiteralPath $script:tmpBucket3 -Recurse -Force -ErrorAction Ignore
+        }
+    }
+
+    It 'pulls the companion CLI into the plan when the desktop owner is requested, owner first' {
+        $output = Install-Package -Name 'Owner' -DryRun -SkipCompletion -BucketPath $script:tmpBucket3 *>&1 |
+            Out-String
+
+        $output | Should -Match '=== Invoke-PackageInstall: CompInstallBundle \(2 packages\) ==='
+        $output | Should -Match '\[install\] \[winget\] Owner'
+        $output | Should -Match '\[install\] \[winget\] OwnerCli'
+        # Owner must come BEFORE companion (install order: owner first).
+        $ownerIdx = $output.IndexOf('[install] [winget] Owner')
+        $cliIdx   = $output.IndexOf('[install] [winget] OwnerCli')
+        $ownerIdx | Should -BeGreaterThan -1
+        $ownerIdx | Should -BeLessThan $cliIdx
+        $output | Should -Not -Match '\[install\] \[winget\] Unrelated'
+    }
+}

--- a/bucket/OSBasePackages.json
+++ b/bucket/OSBasePackages.json
@@ -1,6 +1,6 @@
 {
     "$schema": "https://raw.githubusercontent.com/lukesampson/scoop/master/schema.json",
-    "version": "1.25.000",
+    "version": "1.26.000",
     "url": [
         "https://raw.githubusercontent.com/MarkMichaelis/ScoopBucket/master/bucket/OSBasePackages.ps1"
     ],

--- a/bucket/OSBasePackages.ps1
+++ b/bucket/OSBasePackages.ps1
@@ -24,7 +24,8 @@ $Packages = [Package[]]@(
         Completion  = 'pscompletions'
         ExpectedCompletions = @{ '7z' = @('a','x','l') }
     }
-    [Package]@{ Name = 'Everything';                    Installer = 'winget'; Id = 'voidtools.Everything' }
+    [Package]@{ Name = 'Everything';                    Installer = 'winget'; Id = 'voidtools.Everything'
+                Companions = @('Everything CLI') }
     [Package]@{
         Name        = 'Everything CLI'
         Installer   = 'winget'

--- a/bucket/OSBasePackagesCompanions.Tests.ps1
+++ b/bucket/OSBasePackagesCompanions.Tests.ps1
@@ -1,0 +1,27 @@
+#requires -Version 7.0
+#requires -Modules @{ ModuleName = 'Pester'; ModuleVersion = '5.0.0' }
+
+<#
+.SYNOPSIS
+    Bundle audit for OSBasePackages Companions cascade:
+    Everything desktop must pull in Everything CLI when installed.
+#>
+
+BeforeAll {
+    $scoopBucketPsd1 = Join-Path $PSScriptRoot '..\module\MarkMichaelis.ScoopBucket\MarkMichaelis.ScoopBucket.psd1'
+    if (Test-Path $scoopBucketPsd1) { Import-Module $scoopBucketPsd1 -Force } else { Import-Module MarkMichaelis.ScoopBucket -Force }
+    $script:osPkgs = @(Get-Package -BucketPath $PSScriptRoot -Bundle 'OSBasePackages')
+}
+
+Describe 'OSBasePackages: Everything desktop -> Everything CLI Companions' -Tag 'Light','Bundle' {
+    It 'Everything desktop declares Companions=@(Everything CLI)' {
+        $desktop = @($script:osPkgs | Where-Object Name -EQ 'Everything')[0]
+        $desktop                       | Should -Not -BeNullOrEmpty
+        @($desktop.Companions)         | Should -Contain 'Everything CLI'
+    }
+
+    It 'Everything CLI exists in the same bundle (round-trip sanity)' {
+        $cli = @($script:osPkgs | Where-Object Name -EQ 'Everything CLI')
+        $cli.Count | Should -Be 1
+    }
+}

--- a/bucket/Package.Tests.ps1
+++ b/bucket/Package.Tests.ps1
@@ -266,6 +266,30 @@ Describe 'Package.Validate() — invariants' -Tag 'Light', 'Module' {
         }
         { $p.Validate() } | Should -Throw -ExpectedMessage '*cannot reference itself*'
     }
+
+    It 'rejects self-referential Companions' {
+        $p = [Package]@{
+            Name       = 'x'
+            Installer  = 'scoop'
+            Id         = 'main/x'
+            Companions = @('x')
+        }
+        { $p.Validate() } | Should -Throw -ExpectedMessage '*Companions cannot reference itself*'
+    }
+}
+
+Describe 'Package.Companions field' -Tag 'Light', 'Module' {
+    It 'defaults to an empty array' {
+        $p = [Package]@{ Name = 'demo'; Installer = 'scoop'; Id = 'main/demo' }
+        ,$p.Companions | Should -BeOfType ([string[]])
+        $p.Companions.Count | Should -Be 0
+    }
+
+    It 'accepts a non-empty Companions list at cast time' {
+        $p = [Package]@{ Name = 'A'; Installer = 'winget'; Id = 'X.A'; Companions = @('B') }
+        $p.Companions | Should -Be @('B')
+        { $p.Validate() } | Should -Not -Throw
+    }
 }
 
 Describe 'Package.ToString()' -Tag 'Light', 'Module' {

--- a/bucket/PackageOrder.Tests.ps1
+++ b/bucket/PackageOrder.Tests.ps1
@@ -17,12 +17,13 @@ BeforeAll {
     . $script:resolvePath
 
     function New-Pkg {
-        param([string]$Name, [string[]]$DependsOn = @())
+        param([string]$Name, [string[]]$DependsOn = @(), [string[]]$Companions = @())
         [Package]@{
             Name = $Name
             Installer = 'scoop'
             Id = "main/$Name"
             DependsOn = $DependsOn
+            Companions = $Companions
         }
     }
 }
@@ -123,6 +124,55 @@ Describe 'Resolve-PackageOrder — error cases' -Tag 'Light', 'Module' {
             (New-Pkg 'b' -DependsOn 'a')
         )
         { Resolve-PackageOrder -Packages $pkgs } |
+            Should -Throw -ExpectedMessage "*cycle or unresolved*"
+    }
+}
+
+Describe 'Resolve-PackageOrder -- Companions' -Tag 'Light', 'Module' {
+    It 'pulls in a companion when the owner is requested by name and schedules owner first' {
+        $pkgs = @(
+            (New-Pkg 'A' -Companions @('B')),
+            (New-Pkg 'B')
+        )
+        $result = Resolve-PackageOrder -Packages $pkgs -Name 'A'
+        ($result | ForEach-Object Name) -join ',' | Should -Be 'A,B'
+    }
+
+    It 'pulls in a companion transitively' {
+        $pkgs = @(
+            (New-Pkg 'A' -Companions @('B')),
+            (New-Pkg 'B' -Companions @('C')),
+            (New-Pkg 'C'),
+            (New-Pkg 'unrelated')
+        )
+        $result = Resolve-PackageOrder -Packages $pkgs -Name 'A'
+        ($result | ForEach-Object Name) -join ',' | Should -Be 'A,B,C'
+    }
+
+    It 'still includes the companion when the requested name is the owner of a DependsOn chain' {
+        # bitwarden has Companions=@(bw); bw DependsOn bitwarden. Request bitwarden.
+        $pkgs = @(
+            (New-Pkg 'bitwarden' -Companions @('bw')),
+            (New-Pkg 'bw' -DependsOn @('bitwarden'))
+        )
+        $result = Resolve-PackageOrder -Packages $pkgs -Name 'bitwarden'
+        ($result | ForEach-Object Name) -join ',' | Should -Be 'bitwarden,bw'
+    }
+
+    It 'rejects Companions references to undefined packages' {
+        $pkgs = @(
+            (New-Pkg 'A' -Companions @('ghost'))
+        )
+        { Resolve-PackageOrder -Packages $pkgs } |
+            Should -Throw -ExpectedMessage "*Companions 'ghost'*not defined*"
+    }
+
+    It 'detects Companions-only cycles' {
+        $pkgs = @(
+            (New-Pkg 'A' -Companions @('B')),
+            (New-Pkg 'B' -Companions @('A'))
+        )
+        { Resolve-PackageOrder -Packages $pkgs -Name 'A' } |
             Should -Throw -ExpectedMessage "*cycle or unresolved*"
     }
 }

--- a/bucket/UninstallPackage.Tests.ps1
+++ b/bucket/UninstallPackage.Tests.ps1
@@ -405,3 +405,72 @@ Invoke-PackageInstall -Packages `$Packages -Bundle 'UninstTestBundle'
             Should -Throw -ExpectedMessage "*no bundle declares a package named 'NoSuchPkg'*"
     }
 }
+
+Describe 'Uninstall-Package -- Companions cascade' -Tag 'Light','Module' {
+
+    BeforeAll {
+        $script:repoRoot2 = Split-Path -Parent $PSScriptRoot
+        $script:psd1b     = Join-Path $script:repoRoot2 'module\MarkMichaelis.ScoopBucket\MarkMichaelis.ScoopBucket.psd1'
+
+        $script:tmpBucket2 = Join-Path ([System.IO.Path]::GetTempPath()) ("ScoopBucket-uninstall-comp-$([guid]::NewGuid().ToString('N'))")
+        New-Item -ItemType Directory -Path $script:tmpBucket2 | Out-Null
+
+        $bundleText = @"
+`$scoopBucketPsd1 = '$($script:psd1b -replace "'","''")'
+if (Test-Path `$scoopBucketPsd1) { Import-Module `$scoopBucketPsd1 -Force } else { Import-Module MarkMichaelis.ScoopBucket -Force }
+
+`$Packages = [Package[]]@(
+    [Package]@{ Name = 'Owner'; Installer = 'winget'; Id = 'Test.Owner'; Companions = @('OwnerCli') }
+    [Package]@{
+        Name        = 'OwnerCli'
+        Installer   = 'winget'
+        Id          = 'Test.OwnerCli'
+        CliCommands = @('ownercli')
+        Completion  = 'native'
+        DependsOn   = @('Owner')
+        NativeCommandScript = { 'noop' }
+        ExpectedCompletions = @{ ownercli = @('--help') }
+    }
+    [Package]@{ Name = 'Unrelated'; Installer = 'winget'; Id = 'Test.Unrelated' }
+)
+
+Invoke-PackageInstall -Packages `$Packages -Bundle 'CompTestBundle'
+"@
+        Set-Content -Path (Join-Path $script:tmpBucket2 'CompTestBundle.ps1') -Value $bundleText -Encoding UTF8
+
+        $bundleManifest = @{
+            '$schema'  = 'https://raw.githubusercontent.com/lukesampson/scoop/master/schema.json'
+            version   = '1.00.000'
+            url       = @('https://example.invalid/test-bundle')
+            installer = @{ script = @('& "$dir\\CompTestBundle.ps1"') }
+        }
+        Set-Content -LiteralPath (Join-Path $script:tmpBucket2 'CompTestBundle.json') `
+            -Value ($bundleManifest | ConvertTo-Json -Depth 4) -Encoding UTF8
+    }
+
+    AfterAll {
+        if ($script:tmpBucket2 -and (Test-Path $script:tmpBucket2)) {
+            Remove-Item -LiteralPath $script:tmpBucket2 -Recurse -Force -ErrorAction Ignore
+        }
+    }
+
+    It 'uninstalling the owner cascades to its Companions (CLI removed before owner)' {
+        $output = Uninstall-Package -Name 'Owner' -DryRun -SkipCompletion -BucketPath $script:tmpBucket2 *>&1 | Out-String
+        # Both must appear in the plan
+        $output | Should -Match '\[uninstall\] \[winget\] Owner \(Test\.Owner\)'
+        $output | Should -Match '\[uninstall\] \[winget\] OwnerCli \(Test\.OwnerCli\)'
+        # And the CLI must precede the desktop owner (reverse of install order)
+        $cliIdx   = $output.IndexOf('[uninstall] [winget] OwnerCli (Test.OwnerCli)')
+        $ownerIdx = $output.IndexOf('[uninstall] [winget] Owner (Test.Owner)')
+        $cliIdx | Should -BeGreaterThan -1
+        $cliIdx | Should -BeLessThan $ownerIdx
+        # And we should not pull in unrelated packages
+        $output | Should -Not -Match '\[uninstall\] \[winget\] Unrelated'
+    }
+
+    It 'uninstalling the CLI directly does NOT pull in the owner (cascade is owner -> companion only)' {
+        $output = Uninstall-Package -Name 'OwnerCli' -DryRun -SkipCompletion -BucketPath $script:tmpBucket2 *>&1 | Out-String
+        $output | Should -Match '\[uninstall\] \[winget\] OwnerCli \(Test\.OwnerCli\)'
+        $output | Should -Not -Match '\[uninstall\] \[winget\] Owner \(Test\.Owner\)'
+    }
+}

--- a/module/MarkMichaelis.ScoopBucket/Classes/Package.ps1
+++ b/module/MarkMichaelis.ScoopBucket/Classes/Package.ps1
@@ -54,6 +54,20 @@ class Package {
 
     [string[]] $DependsOn = @()
 
+    # Forward-link to "always install together" companion packages in the
+    # same bundle. Symmetric with DependsOn but the *other* direction:
+    #
+    #   A.Companions = @('B')   means
+    #     install A  -> also install B (B scheduled AFTER A; implicit
+    #                                   ordering edge in Resolve-PackageOrder)
+    #     uninstall A -> also uninstall B (B removed BEFORE A)
+    #
+    # Cascade is restricted to the explicit Companions list so that
+    # uninstalling a foundational package (e.g. '.NET SDK') does NOT
+    # auto-yank every reverse-DependsOn (which would be too aggressive).
+    # Same-bundle only for v1 (mirrors the DependsOn constraint).
+    [string[]] $Companions = @()
+
     [string]   $CISkip = ''
 
     [string]   $Notes = ''
@@ -129,6 +143,10 @@ class Package {
 
         if ($this.DependsOn -contains $this.Name) {
             throw "Package '$($this.Name)': DependsOn cannot reference itself."
+        }
+
+        if ($this.Companions -contains $this.Name) {
+            throw "Package '$($this.Name)': Companions cannot reference itself."
         }
     }
 

--- a/module/MarkMichaelis.ScoopBucket/Private/Get-BundlePackages.ps1
+++ b/module/MarkMichaelis.ScoopBucket/Private/Get-BundlePackages.ps1
@@ -103,6 +103,7 @@ function global:Invoke-PackageInstall {
             ExpectedCompletions = `$p.ExpectedCompletions
             NativeCommandOutputs = `$nativeOutputs
             DependsOn   = @(`$p.DependsOn)
+            Companions  = @(`$p.Companions)
             CISkip      = `$p.CISkip
             Notes       = `$p.Notes
             WingetExtraArgs = @(`$p.WingetExtraArgs)

--- a/module/MarkMichaelis.ScoopBucket/Private/Resolve-PackageOrder.ps1
+++ b/module/MarkMichaelis.ScoopBucket/Private/Resolve-PackageOrder.ps1
@@ -42,9 +42,35 @@ function Resolve-PackageOrder {
                 throw "Resolve-PackageOrder: Package '$($p.Name)' DependsOn '$dep' which is not defined in this bundle."
             }
         }
+        foreach ($comp in $p.Companions) {
+            if (-not $byName.ContainsKey($comp)) {
+                throw "Resolve-PackageOrder: Package '$($p.Name)' Companions '$comp' which is not defined in this bundle."
+            }
+        }
     }
 
-    # Selective install: compute transitive DependsOn closure of -Name.
+    # Build an effective-DependsOn map combining declared DependsOn with
+    # implicit ordering edges from Companions (companion DependsOn owner).
+    # These edges live ONLY in the resolver's working graph; the [Package]
+    # instances themselves are never mutated.
+    $effectiveDeps = @{}
+    foreach ($p in $Packages) {
+        $set = [System.Collections.Generic.HashSet[string]]::new(
+            [string[]]@($p.DependsOn),
+            [System.StringComparer]::OrdinalIgnoreCase
+        )
+        $effectiveDeps[$p.Name] = $set
+    }
+    foreach ($p in $Packages) {
+        foreach ($comp in $p.Companions) {
+            # Companion gets an implicit DependsOn -> owner so Kahn
+            # schedules the owner first and the companion after.
+            [void]$effectiveDeps[$comp].Add($p.Name)
+        }
+    }
+
+    # Selective install: compute transitive closure of -Name across BOTH
+    # DependsOn (needed prerequisites) and Companions (always-with).
     if ($Name) {
         $wanted = [System.Collections.Generic.HashSet[string]]::new([System.StringComparer]::OrdinalIgnoreCase)
         $queue = [System.Collections.Generic.Queue[string]]::new()
@@ -59,6 +85,9 @@ function Resolve-PackageOrder {
             if (-not $wanted.Add($cur)) { continue }
             foreach ($dep in $byName[$cur].DependsOn) {
                 [void]$queue.Enqueue($dep)
+            }
+            foreach ($comp in $byName[$cur].Companions) {
+                [void]$queue.Enqueue($comp)
             }
         }
         $filtered = @($Packages | Where-Object { $wanted.Contains($_.Name) })
@@ -76,6 +105,7 @@ function Resolve-PackageOrder {
     }
 
     # Kahn's algorithm with deterministic tie-break by original index.
+    # Uses $effectiveDeps so Companions ordering edges participate.
     $remaining = [System.Collections.Generic.HashSet[string]]::new(
         [string[]]@($filtered | ForEach-Object { $_.Name }),
         [System.StringComparer]::OrdinalIgnoreCase
@@ -85,8 +115,9 @@ function Resolve-PackageOrder {
     while ($remaining.Count -gt 0) {
         $ready = @($filtered |
             Where-Object {
-                $remaining.Contains($_.Name) -and
-                -not ($_.DependsOn | Where-Object { $remaining.Contains($_) })
+                $name = $_.Name
+                $remaining.Contains($name) -and
+                -not ($effectiveDeps[$name] | Where-Object { $remaining.Contains($_) })
             } |
             Sort-Object { $index[$_.Name] })
 

--- a/module/MarkMichaelis.ScoopBucket/Public/Get-Package.ps1
+++ b/module/MarkMichaelis.ScoopBucket/Public/Get-Package.ps1
@@ -37,7 +37,7 @@ function Get-Package {
 
     .OUTPUTS
         PSCustomObject[] with Bundle, Name, Installer, Id, Source, Scope,
-        CliCommands, Completion, DependsOn, CISkip, Notes, WingetExtraArgs.
+        CliCommands, Completion, DependsOn, Companions, CISkip, Notes, WingetExtraArgs.
 
     .EXAMPLE
         Get-Package -Installer scoop
@@ -101,6 +101,7 @@ function Get-Package {
                 ExpectedCompletions = $expected
                 NativeCommandOutputs = $nativeOutputs
                 DependsOn   = @($p.DependsOn)
+                Companions  = @($p.Companions)
                 CISkip      = $p.CISkip
                 Notes       = $p.Notes
                 WingetExtraArgs = @($p.WingetExtraArgs)

--- a/module/MarkMichaelis.ScoopBucket/Public/Invoke-PackageUninstall.ps1
+++ b/module/MarkMichaelis.ScoopBucket/Public/Invoke-PackageUninstall.ps1
@@ -74,6 +74,29 @@ function Invoke-PackageUninstall {
     } else { $Packages }
     $filtered = @($filtered)
 
+    # Order matters: companions and DependsOn-dependents must be
+    # uninstalled BEFORE their owners/prerequisites so DependsOn
+    # invariants are respected during teardown. Compute the install
+    # order over the full bundle (so cross-cutting Companions / DependsOn
+    # ordering edges are respected) and reverse the subset we're
+    # actually going to uninstall.
+    try {
+        $installOrder = Resolve-PackageOrder -Packages $Packages
+        $filteredSet  = [System.Collections.Generic.HashSet[string]]::new(
+            [string[]]@($filtered | ForEach-Object { $_.Name }),
+            [System.StringComparer]::OrdinalIgnoreCase
+        )
+        $orderedSubset = @($installOrder | Where-Object { $filteredSet.Contains($_.Name) })
+        [array]::Reverse($orderedSubset)
+        $filtered = $orderedSubset
+    } catch {
+        # Cycle or unresolved reference -- fall back to declaration
+        # order; Resolve-PackageOrder's full-collection sort is best-
+        # effort here. The driver-level Validate() above will have
+        # rejected truly broken inputs.
+        Write-Verbose "Invoke-PackageUninstall: Resolve-PackageOrder failed ($($_.Exception.Message)); falling back to declaration order."
+    }
+
     Write-Host ""
     Write-Host "=== Invoke-PackageUninstall: $Bundle ($($filtered.Count) packages) ==="
 

--- a/module/MarkMichaelis.ScoopBucket/Public/Uninstall-Package.ps1
+++ b/module/MarkMichaelis.ScoopBucket/Public/Uninstall-Package.ps1
@@ -87,7 +87,30 @@ function Uninstall-Package {
                             Names      = [System.Collections.Generic.List[string]]::new()
                         }
                     }
-                    $byBundle[$b.BundlePath].Names.Add($p.Name)
+                    # Cascade: include the requested package AND every
+                    # package transitively reachable via Companions in
+                    # the same bundle. Cascade is restricted to
+                    # Companions only -- we deliberately do NOT walk
+                    # reverse-DependsOn (so uninstalling '.NET SDK'
+                    # does not auto-yank every dotnet tool).
+                    $byNameInBundle = @{}
+                    foreach ($q in $b.Packages) { $byNameInBundle[$q.Name] = $q }
+                    $seen  = [System.Collections.Generic.HashSet[string]]::new([System.StringComparer]::OrdinalIgnoreCase)
+                    $queue = [System.Collections.Generic.Queue[string]]::new()
+                    [void]$queue.Enqueue($p.Name)
+                    while ($queue.Count -gt 0) {
+                        $cur = $queue.Dequeue()
+                        if (-not $seen.Add($cur)) { continue }
+                        $byBundle[$b.BundlePath].Names.Add($cur)
+                        $owner = $byNameInBundle[$cur]
+                        if ($owner -and $owner.Companions) {
+                            foreach ($comp in $owner.Companions) {
+                                if ($byNameInBundle.ContainsKey($comp)) {
+                                    [void]$queue.Enqueue($comp)
+                                }
+                            }
+                        }
+                    }
                     $found = $true
                     break
                 }

--- a/module/MarkMichaelis.ScoopBucket/Public/Uninstall-Package.ps1
+++ b/module/MarkMichaelis.ScoopBucket/Public/Uninstall-Package.ps1
@@ -186,6 +186,7 @@ function ConvertTo-PackageFromMetadata {
         CliCommands = @($Metadata.CliCommands)
         Completion  = if ($Metadata.PSObject.Properties['Completion']) { [string]$Metadata.Completion } else { 'none' }
         DependsOn   = @($Metadata.DependsOn)
+        Companions  = if ($Metadata.PSObject.Properties['Companions']) { @($Metadata.Companions) } else { @() }
         CISkip      = if ($Metadata.PSObject.Properties['CISkip']) { [string]$Metadata.CISkip } else { '' }
         Notes       = if ($Metadata.PSObject.Properties['Notes']) { [string]$Metadata.Notes } else { '' }
     }


### PR DESCRIPTION
## Summary

Adds a new `[string[]] $Companions = @()` field on `[Package]` with **symmetric install / uninstall cascade** semantics, then applies it to the known desktop-app + CLI pairings in this bucket so installing a desktop app auto-installs its CLI (and uninstalling cascades the other way).

Closes #210.

## Behavior

- `Install-Package -Name <App>` -> resolver pulls every name in `App.Companions` into the install set. **Desktop owner installs first, companion CLI after** (companion gets an implicit ordering edge in Resolve-PackageOrder's working graph; the `[Package]` instance is never mutated).
- `Uninstall-Package -Name <App>` -> cascade to `App.Companions` transitively. **Companions removed first, owner second** (reverse install order, so DependsOn invariants are respected during teardown).
- Cascade is restricted to the explicit `Companions` list. We deliberately do **not** walk reverse-`DependsOn` (uninstalling `.NET SDK` does not auto-yank every dotnet tool).
- Same-bundle only for v1 (matches the existing `DependsOn` constraint in `Resolve-PackageOrder`). A new `Bundles.Tests.ps1` invariant enforces this.
- `DependsOn` direction and semantics are unchanged.

## Code changes

- **`module/.../Classes/Package.ps1`** -- adds `[string[]] $Companions` plus a self-reference guard in `Validate()`.
- **`module/.../Private/Get-BundlePackages.ps1`** + **`module/.../Public/Get-Package.ps1`** -- list `Companions` on both the child-runspace probe map and the parent-side flattener (per the bundle-loader contract, fields missing from EITHER round-trip as ``). Docstring updated.
- **`module/.../Private/Resolve-PackageOrder.ps1`** -- validates `Companions` references resolve in-bundle; builds an effective-DependsOn map that combines declared edges with implicit `companion DependsOn owner` edges (working graph only); `-Name` closure now walks BOTH `DependsOn` and `Companions`. Cycle detection still catches Companions-only cycles.
- **`module/.../Public/Uninstall-Package.ps1`** -- expands the per-bundle Names list via the Companions transitive closure.
- **`module/.../Public/Invoke-PackageUninstall.ps1`** -- reorders the filtered set as the reverse of the full-bundle install order, so companions are removed before owners.

## Bundle audit

- `bucket/ClientBasePackages.ps1`: `Bitwarden` -> `Companions = @('Bitwarden CLI')`
- `bucket/ClientBasePackages.ps1`: `Todoist` -> `Companions = @('Todoist CLI')`
- `bucket/OSBasePackages.ps1`:    `Everything` -> `Companions = @('Everything CLI')`
- `bucket/AIAgents.ps1`:         `Gemini` -> `Companions = @('Gemini CLI')`

## Tests (TDD, RED -> GREEN at every step)

- **Schema**: `Package.Tests.ps1` -- Companions defaults to empty, round-trips, self-reference rejected.
- **Resolver**: `PackageOrder.Tests.ps1` -- Companion enqueued by `-Name` closure, ordering (owner first), transitive, undefined-Companion rejected, Companions cycle throws.
- **Install plan**: `InstallPackageFilter.Tests.ps1` -- synthetic Owner / OwnerCli bundle, `-DryRun` plan contains both with desktop first.
- **Uninstall plan**: `UninstallPackage.Tests.ps1` -- same bundle; `-DryRun` plan contains both with CLI first; uninstalling the CLI alone does NOT cascade up to the owner.
- **Bundle audit**: `ClientBasePackages.Tests.ps1`, `AIAgents.Tests.ps1`, `OSBasePackagesCompanions.Tests.ps1` -- each desktop entry exposes the expected `Companions`.
- **Cross-bundle invariant**: `Bundles.Tests.ps1` -- every `Companions` reference resolves within the same bundle.

## Verification

Local: `Invoke-Pester -Path bucket\Bundles.Tests.ps1,bucket\Package.Tests.ps1,bucket\PackageOrder.Tests.ps1,bucket\InstallPackageFilter.Tests.ps1,bucket\UninstallPackage.Tests.ps1,bucket\ClientBasePackages.Tests.ps1,bucket\AIAgents.Tests.ps1,bucket\OSBasePackagesCompanions.Tests.ps1`
Result: all green (Bundles alone: 805 passed, 1 skipped).

Evidence artifact (`Get-Package` + `Install-Package -DryRun` + `Uninstall-Package -DryRun` for both Bitwarden and Everything) will be posted as a PR comment.
