### PR TITLE
fix(bundle): set Todoist CLI scope to user (Sachaos.Todoist has no machine-scope installer)

### DIFF
--- a/bucket/ClientBasePackages.Tests.ps1
+++ b/bucket/ClientBasePackages.Tests.ps1
@@ -55,6 +55,15 @@ Describe 'ClientBasePackages: Todoist CLI co-located with Todoist desktop' -Tag 
         @($cli.DependsOn)       | Should -Be @('Todoist')
     }
 
+    It 'declares Scope=user (Sachaos.Todoist winget manifest has no machine-scope installer) (#213)' {
+        # Regression guard: without Scope=user, Install-WingetPackage defaults to
+        # --scope machine and winget hard-fails with exit -1978335212
+        # (APPINSTALLER_CLI_ERROR_NO_APPLICABLE_INSTALLER) because the
+        # sachaos/todoist manifest only publishes a user-scope portable .exe.
+        $cli = @($script:pkgs | Where-Object Name -EQ 'Todoist CLI')[0]
+        $cli.Scope | Should -Be 'user'
+    }
+
     It 'Bitwarden desktop declares Companions=@(Bitwarden CLI) (auto-install CLI with app)' {
         $desktop = @($script:pkgs | Where-Object Name -EQ 'Bitwarden')[0]
         @($desktop.Companions) | Should -Contain 'Bitwarden CLI'

--- a/bucket/ClientBasePackages.json
+++ b/bucket/ClientBasePackages.json
@@ -1,6 +1,6 @@
 {
     "$schema": "https://raw.githubusercontent.com/lukesampson/scoop/master/schema.json",
-    "version": "1.18.000",
+    "version": "1.19.000",
     "url": [
         "https://raw.githubusercontent.com/MarkMichaelis/ScoopBucket/master/bucket/ClientBasePackages.ps1"
     ],

--- a/bucket/ClientBasePackages.ps1
+++ b/bucket/ClientBasePackages.ps1
@@ -170,12 +170,13 @@ Register-ArgumentCompleter -Native -CommandName sox -ScriptBlock {
         Name        = 'Todoist CLI'
         Installer   = 'winget'
         Id          = 'Sachaos.Todoist'
+        Scope       = 'user'
         CliCommands = @('todoist')
         Completion  = 'native'
         NativeCommandScript = { todoist completion powershell }
         WingetExtraArgs = @('--silent', '--disable-interactivity')
         DependsOn   = @('Todoist')
-        Notes       = 'sachaos/todoist Go CLI for Todoist. Co-located with the Todoist desktop entry above so the ClientBasePackages bundle installs both; DependsOn ensures the desktop app is provisioned first when the CLI is installed directly. Mirrors the Bitwarden / Bitwarden CLI pattern (#208).'
+        Notes       = 'sachaos/todoist Go CLI for Todoist. Co-located with the Todoist desktop entry above so the ClientBasePackages bundle installs both; DependsOn ensures the desktop app is provisioned first when the CLI is installed directly. Mirrors the Bitwarden / Bitwarden CLI pattern (#208). Scope=user because the upstream winget manifest only publishes a user-scope portable .exe -- omitting Scope causes Install-WingetPackage to default to --scope machine and winget hard-fails with -1978335212 APPINSTALLER_CLI_ERROR_NO_APPLICABLE_INSTALLER (#213).'
         ExpectedCompletions = @{ todoist = @('add','list','show','completion','--help') }
     }
 

--- a/bucket/PackageInstall.Tests.ps1
+++ b/bucket/PackageInstall.Tests.ps1
@@ -109,6 +109,32 @@ Describe 'Engine dispatchers' -Tag 'Light','Module' {
             $script:installArgs | Should -Contain '--force'
         }
 
+        It 'passes --scope user (not --scope machine) when Package.Scope=user (#213)' {
+            # Regression guard for Todoist CLI (Sachaos.Todoist): the upstream
+            # winget manifest only publishes a user-scope portable .exe. When
+            # Package.Scope='user' the wrapper must opt into --scope user and
+            # MUST NOT pass --scope machine (which causes winget to fail with
+            # -1978335212 APPINSTALLER_CLI_ERROR_NO_APPLICABLE_INSTALLER).
+            $script:installArgs = $null
+            Mock -ModuleName MarkMichaelis.ScoopBucket winget {
+                if ($args[0] -eq 'list') { $global:LASTEXITCODE = 1; return '' }
+                $script:installArgs = $args
+                $global:LASTEXITCODE = 0
+                return 'Installed.'
+            }
+
+            $pkg = [Package]@{ Name='Test'; Installer='winget'; Id='Test.Id'; Scope='user' }
+            $r = & $script:Engine -Package $pkg
+            $r.State | Should -Be 'Installed'
+
+            # Find the --scope flag and assert its value.
+            $scopeIdx = [Array]::IndexOf([object[]]$script:installArgs, '--scope')
+            $scopeIdx | Should -BeGreaterThan -1
+            $script:installArgs[$scopeIdx + 1] | Should -Be 'user'
+            # Belt and suspenders: 'machine' must not appear anywhere in argv.
+            $script:installArgs | Should -Not -Contain 'machine'
+        }
+
         It 'does not stop retries as permanent for exit -1978334972 (missing dependency)' {
             # -1978334972 = APPINSTALLER_CLI_ERROR_INSTALL_MISSING_DEPENDENCY.
             # Retrying won't recover, so we treat it as permanent (no retry loop).


### PR DESCRIPTION
## Summary

Fixes `Install-Package -Name Todoist` hard-failing on the `Todoist CLI` (Sachaos.Todoist) winget step with:

```
winget install --id Sachaos.Todoist ... --scope machine ... exited with -1978335212 (permanent; no retry).
```

Exit code `-1978335212` = `APPINSTALLER_CLI_ERROR_NO_APPLICABLE_INSTALLER`. `Install-WingetPackage` already classifies it as a permanent failure (no retry).

## Root cause

The upstream `sachaos/todoist` winget manifest is a portable .exe published from GitHub Releases that **only declares user scope**. `Install-WingetPackage` defaults to `--scope machine` for every non-msstore winget package unless `Package.Scope='user'`. The `Todoist CLI` `[Package]` entry in `bucket/ClientBasePackages.ps1` didn't set `Scope`, so it defaulted to machine, no installer matched, and winget hard-failed.

## Fix

Add `Scope = 'user'` to the `Todoist CLI` `[Package]` entry. One-field change. `Install-WingetPackage` default-scope logic is intentionally unchanged (it's correct -- machine is the right default for the vast majority of packages).

## Behavior-first regression guards

| Test | File | Asserts |
|---|---|---|
| `declares Scope=user (Sachaos.Todoist winget manifest has no machine-scope installer) (#213)` | `bucket/ClientBasePackages.Tests.ps1` | `(Get-Package | Where Name -EQ 'Todoist CLI').Scope -eq 'user'` |
| `passes --scope user (not --scope machine) when Package.Scope=user (#213)` | `bucket/PackageInstall.Tests.ps1` (`Install-WingetPackage` Context) | Mock-captured winget argv contains `--scope user` and NOT `--scope machine` |

Both fail with assertion failures (not parse/load errors) when the production fix is reverted -- confirmed by manually reverting and re-running.

## Test results

`
Invoke-Pester -Path .\bucket\ClientBasePackages.Tests.ps1, .\bucket\PackageInstall.Tests.ps1, .\bucket\InstallPackageFilter.Tests.ps1, .\bucket\Bundles.Tests.ps1
=> Tests Passed: 849, Failed: 0, Skipped: 1
`

(The full-suite Pester run also surfaces pre-existing, environment-dependent failures in `CliAvailabilityPinned.Tests.ps1` for `bw`/`devenv`/`BComp.com` and `GitConfig*.Tests.ps1` -- those reproduce identically on `main` and are unrelated to this change.)

## Evidence

Captured at `.evidence/phase-5b-*` (gitignored). Before/after:

- **Before** (no fix): `(Get-Package | Where Name -EQ 'Todoist CLI').Scope` -> `global` -> argv `--scope machine` -> `winget` exits `-1978335212`.
- **After** (this PR): `(Get-Package | Where Name -EQ 'Todoist CLI').Scope` -> `user` -> argv `--scope user` -> `winget` succeeds.

AI-verified: artifact visibly confirms the intent given the diff, and no new problem is introduced (other bundle / install tests still pass).

## Out of scope

- `Install-WingetPackage` default-scope logic unchanged.
- Desktop `Todoist` (`9MWF2DWS5Z9N` msstore) entry untouched (its install succeeded).

## Field propagation

`Scope` is an existing field. Verified it still propagates through both the `Get-BundlePackages` child-runspace probe (`module/MarkMichaelis.ScoopBucket/Private/Get-BundlePackages.ps1` line 100) and the `Get-Package` flattener (`module/MarkMichaelis.ScoopBucket/Public/Get-Package.ps1` line 98), so the CI `Test-Installs.ps1` path will see `Scope='user'` for Todoist CLI.

Closes #213
