### PR TITLE
perf(completion): defer profile-block registration via PowerShell.OnIdle + cache native completer text (#212)

### DIFF
--- a/README.md
+++ b/README.md
@@ -428,9 +428,13 @@ Behavior:
   scriptblock (owned by the install script) → `PSCompletions`
   (`abgox/PSCompletions`) fallback → skipped with a reason.
 - All registrations are written as sentinel-delimited blocks
-  (`# ScoopBucket:CliCompletion:<cli>:BEGIN v1 … :END`) inside
-  `$PROFILE.AllUsersAllHosts`. Two runs with `-Force` produce a
-  byte-identical profile.
+  (`# ScoopBucket:CliCompletion:<cli>:BEGIN v2 … :END`) inside
+  `$PROFILE.AllUsersAllHosts`. The v2 block wraps the cached
+  completer payload in
+  `Register-EngineEvent PowerShell.OnIdle -MaxTriggerCount 1 -Action {...}`
+  so shell startup pays no subprocess cost — registration runs on
+  the first idle tick after the prompt is drawn (#212). Two runs
+  with `-Force` produce a byte-identical profile.
 - `-Force` is opt-in for ad-hoc invocations (defaults to gap-fill
   only); the bundle installers pass `-Force` explicitly so reinstalls
   always refresh blocks.

--- a/bucket/CompletionDeferredRegistration.Tests.ps1
+++ b/bucket/CompletionDeferredRegistration.Tests.ps1
@@ -1,0 +1,189 @@
+#requires -Version 7.0
+#requires -Modules @{ ModuleName = 'Pester'; ModuleVersion = '5.0.0' }
+
+<#
+.SYNOPSIS
+    Issue #212 -- Profile-block completion registration is deferred to
+    PowerShell.OnIdle, native completer text is cached from
+    NativeCommandOutputs, and Import-PackageCompletion stays synchronous.
+#>
+
+Describe 'Register-PackageCompletion: deferred OnIdle wrap + cached native text' -Tag 'Light','DeferredCompletion' {
+
+    BeforeAll {
+        $psd1 = Join-Path $PSScriptRoot '..\module\MarkMichaelis.ScoopBucket\MarkMichaelis.ScoopBucket.psd1'
+        if (Test-Path $psd1) { Import-Module $psd1 -Force } else { Import-Module MarkMichaelis.ScoopBucket -Force }
+
+        $script:sandbox = Join-Path ([System.IO.Path]::GetTempPath()) ("DCR-" + [guid]::NewGuid().ToString('N'))
+        New-Item -ItemType Directory -Path $script:sandbox -Force | Out-Null
+        $script:profilePath = Join-Path $script:sandbox 'Profile.ps1'
+
+        function script:New-NativeFixture {
+            param([string]$Cli)
+            [scriptblock]::Create("Write-Output 'Register-ArgumentCompleter -Native -CommandName $Cli -ScriptBlock { }'")
+        }
+    }
+
+    AfterAll {
+        if (Test-Path $script:sandbox) { Remove-Item -Recurse -Force $script:sandbox -ErrorAction SilentlyContinue }
+    }
+
+    BeforeEach {
+        if (Test-Path $script:profilePath) { Remove-Item -Force $script:profilePath }
+    }
+
+    It 'wraps the emitted block in Register-EngineEvent PowerShell.OnIdle (MaxTriggerCount 1)' {
+        $profilePath = $script:profilePath
+        InModuleScope MarkMichaelis.ScoopBucket -Parameters @{ ProfilePath = $profilePath } {
+            param($ProfilePath)
+            $nc = [scriptblock]::Create("Write-Output 'Register-ArgumentCompleter -Native -CommandName demo1 -ScriptBlock { }'")
+            Register-PackageCompletion -Cli demo1 -NativeCommand $nc -Mode native -ProfilePath $ProfilePath -Confirm:$false | Out-Null
+        }
+        $raw = Get-Content -Raw -Path $script:profilePath
+        $raw | Should -Match 'ScoopBucket:CliCompletion:demo1:BEGIN v2'
+        $raw | Should -Match 'Register-EngineEvent -SourceIdentifier PowerShell\.OnIdle -MaxTriggerCount 1'
+    }
+
+    It '-PreCapturedNative overrides NativeCommand (the scriptblock is not invoked)' {
+        $profilePath = $script:profilePath
+        $result = InModuleScope MarkMichaelis.ScoopBucket -Parameters @{ ProfilePath = $profilePath } {
+            param($ProfilePath)
+            $script:invocations = 0
+            $bad = [scriptblock]::Create("`$script:invocations++; throw 'NativeCommand should not run'")
+            $cachedText = "Register-ArgumentCompleter -Native -CommandName demo2 -ScriptBlock { }"
+            Register-PackageCompletion -Cli demo2 -NativeCommand $bad -PreCapturedNative $cachedText `
+                -Mode native -ProfilePath $ProfilePath -Confirm:$false | Out-Null
+            [pscustomobject]@{ Invocations = $script:invocations }
+        }
+        $result.Invocations | Should -Be 0
+        $raw = Get-Content -Raw -Path $script:profilePath
+        $raw | Should -Match 'Register-ArgumentCompleter -Native -CommandName demo2'
+        $raw | Should -Match 'Register-EngineEvent -SourceIdentifier PowerShell\.OnIdle'
+    }
+
+    It 'rewrites an existing v1 block as v2 on re-register (transparent migration)' {
+        $v1 = @"
+# ScoopBucket:CliCompletion:demo3:BEGIN v1
+if (Get-Command demo3 -ErrorAction SilentlyContinue) {
+Register-ArgumentCompleter -Native -CommandName demo3 -ScriptBlock { }
+}
+# ScoopBucket:CliCompletion:demo3:END
+
+"@
+        [System.IO.File]::WriteAllText($script:profilePath, $v1, [System.Text.UTF8Encoding]::new($false))
+        $profilePath = $script:profilePath
+        InModuleScope MarkMichaelis.ScoopBucket -Parameters @{ ProfilePath = $profilePath } {
+            param($ProfilePath)
+            $nc = [scriptblock]::Create("Write-Output 'Register-ArgumentCompleter -Native -CommandName demo3 -ScriptBlock { }'")
+            Register-PackageCompletion -Cli demo3 -NativeCommand $nc -Mode native -ProfilePath $ProfilePath -Confirm:$false | Out-Null
+        }
+        $raw = Get-Content -Raw -Path $script:profilePath
+        ([regex]::Matches($raw, 'ScoopBucket:CliCompletion:demo3:BEGIN').Count) | Should -Be 1
+        $raw | Should -Match 'ScoopBucket:CliCompletion:demo3:BEGIN v2'
+        $raw | Should -Match 'Register-EngineEvent -SourceIdentifier PowerShell\.OnIdle'
+        $raw | Should -Not -Match 'ScoopBucket:CliCompletion:demo3:BEGIN v1'
+    }
+
+    It 'profile-load critical path contains no top-level subprocess call (subprocess body sits inside the deferred Action)' {
+        $profilePath = $script:profilePath
+        InModuleScope MarkMichaelis.ScoopBucket -Parameters @{ ProfilePath = $profilePath } {
+            param($ProfilePath)
+            $subprocessy = [scriptblock]::Create('Write-Output "& warp.exe completions powershell | Invoke-Expression"')
+            Register-PackageCompletion -Cli demo4 -NativeCommand $subprocessy -Mode native -ProfilePath $ProfilePath -Confirm:$false | Out-Null
+        }
+        $raw = Get-Content -Raw -Path $script:profilePath
+        $m = [regex]::Match($raw, '(?ms)^\# ScoopBucket:CliCompletion:demo4:BEGIN v2\r?\n(.+?)^\# ScoopBucket:CliCompletion:demo4:END')
+        $m.Success | Should -BeTrue
+        $body = $m.Groups[1].Value
+
+        $idx = $body.IndexOf('-Action {')
+        $idx | Should -BeGreaterThan -1
+        $criticalPath = $body.Substring(0, $idx)
+        $criticalPath | Should -Not -Match '(?m)^\s*&\s'
+        $criticalPath | Should -Not -Match 'Invoke-Expression'
+    }
+}
+
+Describe 'Import-PackageCompletion: synchronous, no OnIdle deferral' -Tag 'Light','DeferredCompletion' {
+
+    BeforeAll {
+        $psd1 = Join-Path $PSScriptRoot '..\module\MarkMichaelis.ScoopBucket\MarkMichaelis.ScoopBucket.psd1'
+        if (Test-Path $psd1) { Import-Module $psd1 -Force } else { Import-Module MarkMichaelis.ScoopBucket -Force }
+    }
+
+    It 'does not register a PowerShell.OnIdle subscriber when activating completers in-runspace' {
+        # Drain any pre-existing subscribers we did not create.
+        $pre = @(Get-EventSubscriber -SourceIdentifier 'PowerShell.OnIdle' -ErrorAction SilentlyContinue).Count
+
+        $fakePkg = [pscustomobject]@{
+            Name = 'demoImport'
+            CliCommands = @('demoImport')
+            Completion = 'native'
+            NativeCommandOutputs = @{ demoImport = 'Register-ArgumentCompleter -Native -CommandName demoImport -ScriptBlock { }' }
+            NativeCommandScript = $null
+        }
+        Import-PackageCompletion -Package @($fakePkg) | Out-Null
+
+        $post = @(Get-EventSubscriber -SourceIdentifier 'PowerShell.OnIdle' -ErrorAction SilentlyContinue).Count
+        $post | Should -Be $pre -Because 'Import-PackageCompletion activates completers in the current runspace immediately; it must not defer via OnIdle.'
+    }
+}
+
+Describe 'Update-PackageCompletion: -Force rewrites stale v1 blocks as v2 + OnIdle' -Tag 'Light','DeferredCompletion' {
+
+    BeforeAll {
+        $psd1 = Join-Path $PSScriptRoot '..\module\MarkMichaelis.ScoopBucket\MarkMichaelis.ScoopBucket.psd1'
+        if (Test-Path $psd1) { Import-Module $psd1 -Force } else { Import-Module MarkMichaelis.ScoopBucket -Force }
+
+        $script:sandbox2 = Join-Path ([System.IO.Path]::GetTempPath()) ("UPC212-" + [guid]::NewGuid().ToString('N'))
+        New-Item -ItemType Directory -Path $script:sandbox2 -Force | Out-Null
+        $script:profilePath2 = Join-Path $script:sandbox2 'Profile.ps1'
+
+        # Pick a CLI that *is* on PATH so Update-PackageCompletion does not skip it.
+        $script:realCli = $null
+        foreach ($candidate in 'pwsh','git','code') {
+            if (Get-Command $candidate -ErrorAction SilentlyContinue) { $script:realCli = $candidate; break }
+        }
+    }
+
+    AfterAll {
+        if (Test-Path $script:sandbox2) { Remove-Item -Recurse -Force $script:sandbox2 -ErrorAction SilentlyContinue }
+    }
+
+    It '-Force replaces a v1 block with a v2 OnIdle-wrapped block' {
+        if (-not $script:realCli) {
+            Set-ItResult -Skipped -Because 'No reference CLI on PATH for the test to anchor on.'
+            return
+        }
+        $cli = $script:realCli
+        $v1 = @"
+# ScoopBucket:CliCompletion:$cli`:BEGIN v1
+if (Get-Command $cli -ErrorAction SilentlyContinue) {
+Register-ArgumentCompleter -Native -CommandName $cli -ScriptBlock { }
+}
+# ScoopBucket:CliCompletion:$cli`:END
+
+"@
+        [System.IO.File]::WriteAllText($script:profilePath2, $v1, [System.Text.UTF8Encoding]::new($false))
+
+        # Synthesize the minimal package shape Update-PackageCompletion expects.
+        $fakeBundle = [pscustomobject]@{
+            Bundle = 'Test'
+            Packages = @(
+                [pscustomobject]@{
+                    Name = "TestPkg"; CliCommands = @($cli); Completion = 'native'
+                    HasNativeCommandScript = $true
+                    NativeCommandOutputs = @{ $cli = "Register-ArgumentCompleter -Native -CommandName $cli -ScriptBlock { } # refreshed" }
+                    NativeCommandScript = $null
+                }
+            )
+        }
+        Mock -ModuleName MarkMichaelis.ScoopBucket Get-BundlePackages { @($fakeBundle) }
+
+        Update-PackageCompletion -Force -ProfilePath $script:profilePath2 -Confirm:$false | Out-Null
+        $raw = Get-Content -Raw -Path $script:profilePath2
+        $raw | Should -Match "ScoopBucket:CliCompletion:$cli`:BEGIN v2"
+        $raw | Should -Match 'Register-EngineEvent -SourceIdentifier PowerShell\.OnIdle'
+        $raw | Should -Match 'refreshed'
+    }
+}

--- a/bucket/CompletionEndToEnd.Tests.ps1
+++ b/bucket/CompletionEndToEnd.Tests.ps1
@@ -66,6 +66,15 @@ Describe 'Completion end-to-end (real Tab, no mocks)' -Tag 'Heavy','Completion' 
         $script = @"
 `$ErrorActionPreference = 'Stop'
 . '$($script:profilePath -replace "'","''")'
+# Profile blocks defer Register-ArgumentCompleter to PowerShell.OnIdle (#212).
+# Drain any pending subscribers in this non-interactive child runspace before
+# asking the completion engine for matches.
+foreach (`$sub in @(Get-EventSubscriber -SourceIdentifier 'PowerShell.OnIdle' -ErrorAction SilentlyContinue)) {
+    try {
+        `$cmd = `$sub.Action.Command
+        if (`$cmd) { & ([scriptblock]::Create(`$cmd)) 2>`$null | Out-Null }
+    } catch { }
+}
 `$line = '$Cli '
 `$result = [System.Management.Automation.CommandCompletion]::CompleteInput(`$line, `$line.Length, `$null)
 `$result.CompletionMatches | ForEach-Object { `$_.CompletionText }

--- a/bucket/CompletionPinned.Tests.ps1
+++ b/bucket/CompletionPinned.Tests.ps1
@@ -58,12 +58,15 @@ Describe 'CliCompletion pinned contract -- per-bundle native registration' -Tag 
         @($pkg.ExpectedCompletions[$Cli]).Count | Should -BeGreaterThan 0 -Because "ExpectedCompletions['$Cli'] must list at least one expected subcommand"
     }
 
-    It 'uses sentinel version v1' {
+    It 'uses sentinel version v2' {
         # $script:CompletionSentinelVersion lives inside the module and is not
         # visible from this test runspace; assert against the source instead so
         # any bump of the sentinel format requires updating this guard too.
+        # v2 (#212) wraps the cached completer payload in
+        # Register-EngineEvent PowerShell.OnIdle -MaxTriggerCount 1 -Action
+        # so startup defers registration until the first idle tick.
         $src = Get-Content -Raw -Path (Join-Path $PSScriptRoot '..\module\MarkMichaelis.ScoopBucket\Private\Register-PackageCompletion.ps1')
-        $src | Should -Match "(?m)^\s*\`$script:CompletionSentinelVersion\s*=\s*'v1'\s*$" -Because 'Register-PackageCompletion.ps1 must pin sentinel version v1'
+        $src | Should -Match "(?m)^\s*\`$script:CompletionSentinelVersion\s*=\s*'v2'\s*$" -Because 'Register-PackageCompletion.ps1 must pin sentinel version v2'
     }
 
     It 'Register-CliCompletion exposes the -NativeCommand parameter' {

--- a/bucket/UpdatePackageCompletion.Tests.ps1
+++ b/bucket/UpdatePackageCompletion.Tests.ps1
@@ -146,7 +146,7 @@ Describe 'Update-PackageCompletion eligibility classification' -Tag 'Light' {
         # Get-Command guard.
         $profileContent = Get-Content -Raw -Encoding UTF8 $script:profilePath
         $profileContent | Should -Match 'auto-native-completion-source'
-        $profileContent | Should -Match "ScoopBucket:CliCompletion:$($script:onPathCli)-native:BEGIN v1"
+        $profileContent | Should -Match "ScoopBucket:CliCompletion:$($script:onPathCli)-native:BEGIN v2"
     }
 
     It "registers Completion='native' packages whose CLI is on PATH" {

--- a/docs/designs/2025-11-23-async-completion-registration-plan.md
+++ b/docs/designs/2025-11-23-async-completion-registration-plan.md
@@ -1,0 +1,87 @@
+# Plan: Defer Completion Registration via PowerShell.OnIdle
+
+**Issue:** [#212](https://github.com/MarkMichaelis/ScoopBucket/issues/212)
+**Branch:** `perf/212-async-completion-registration`
+**Date:** 2025-11-23
+
+## Task list
+
+### Task 1 -- RED: assert OnIdle wrap is present in written block
+File: `bucket/CompletionDeferredRegistration.Tests.ps1` (new), tag `Light`.
+Test: `Register-PackageCompletion` with a fixture NativeCommand writes a block containing
+`Register-EngineEvent -SourceIdentifier PowerShell.OnIdle -MaxTriggerCount 1`.
+
+### Task 2 -- GREEN: add `Format-DeferredCompletionBlock` helper + wrap in Register-PackageCompletion
+- Bump `$script:CompletionSentinelVersion = 'v2'` in `Register-PackageCompletion.ps1`.
+- Add `Format-DeferredCompletionBlock([string]$InnerCode)` that returns:
+  ```
+  $null = Register-EngineEvent -SourceIdentifier PowerShell.OnIdle -MaxTriggerCount 1 -Action {
+  <inner>
+  } | Out-Null
+  ```
+- In `Register-PackageCompletion`, wrap `$resolved.Code` with the helper before
+  passing to `Set-PackageCompletionProfileBlock`.
+
+### Task 3 -- RED: assert -PreCapturedNative bypasses NativeCommand scriptblock
+Add test in same Pester file: pass a NativeCommand that throws + a -PreCapturedNative
+string; result must succeed and the block body must contain the cached text.
+
+### Task 4 -- GREEN: add `-PreCapturedNative` param
+Add `[string]$PreCapturedNative` to `Register-PackageCompletion`. When set, Mode != 'pscompletions',
+and non-empty: build `$resolved` directly from the cached text (apply the same `if (Get-Command ...)`
+guard) without calling `Resolve-PackageCompletionSource`.
+
+### Task 5 -- GREEN: plumb NativeCommandOutputs through Invoke-PackageInstall
+In `Invoke-PackageInstall.ps1`, when invoking `Register-PackageCompletion` per CLI, look up
+`$pkg.NativeCommandOutputs[$cli]` (supporting both hashtable and PSCustomObject shapes -- the
+same pattern already used in `Update-PackageCompletion.ps1` lines 140-148) and pass it as
+`-PreCapturedNative` when non-empty.
+
+### Task 6 -- RED: assert v1 -> v2 migration on re-register
+Test: pre-seed profile with a v1-formatted sentinel block; call `Register-PackageCompletion`;
+assert resulting block uses `:BEGIN v2` and is wrapped in OnIdle.
+
+### Task 7 -- GREEN: confirm `Set-PackageCompletionProfileBlock` replace path handles version bump
+Already uses `\w+` regex; should pass without changes. Verify by re-running test.
+
+### Task 8 -- RED: assert Import-PackageCompletion does NOT defer
+New test in `bucket/ImportPackageCompletion.Tests.ps1` (or extend existing): after calling
+`Import-PackageCompletion -Package <fake>` with a fixture native script, asking the completion
+engine for matches succeeds *immediately* (no OnIdle drain needed); also assert no
+PowerShell.OnIdle subscriber was registered by that call.
+
+### Task 9 -- GREEN: verify no Import-PackageCompletion changes required
+Audit that the current code path executes `[scriptblock]::Create($resolved.Code).InvokeReturnAsIs()`
+synchronously and never calls `Register-EngineEvent`. (Already true; this is a defensive test.)
+
+### Task 10 -- update Test-PackageCompletionWorks probe to drain OnIdle subscribers
+In `Register-PackageCompletion.ps1` `Test-PackageCompletionWorks`, after dot-sourcing the profile
+in the child runspace, iterate `Get-EventSubscriber -SourceIdentifier PowerShell.OnIdle`, run each
+subscriber's Action scriptblock synchronously, then call `CompleteInput`.
+
+### Task 11 -- update CompletionEndToEnd.Tests.ps1 probe analogously
+Same drain step inside the inline probe in `CompletionEndToEnd.Tests.ps1` so the Heavy suite
+keeps passing once blocks are deferred.
+
+### Task 12 -- assert Update-PackageCompletion -Force rewrites v1 as v2
+Extend `bucket/UpdatePackageCompletion.Tests.ps1` (or the new file): pre-seed v1 block, call
+`Update-PackageCompletion -Force -ProfilePath <sandbox>`, assert v2 + OnIdle wrap.
+
+### Task 13 -- assert profile-block top level has no top-level subprocess call
+Test: with a NativeCommand whose cached output contains `& warp.exe completions powershell`,
+inspect the block; outside the `-Action { ... }` body the block must contain only the
+`Register-EngineEvent` line (no `&`, no `Invoke-Expression`).
+
+### Task 14 -- run full Light suite + new Light tests
+`Invoke-Pester -Path bucket\,module\ -ExcludeTag Heavy,Network,Idempotency,CompletionPinned,BucketScope`
+plus our new tests.
+
+### Task 15 -- evidence capture
+Before/after timing of `pwsh -NoLogo -Command exit` with a synthetic profile holding 5 fake
+subprocess-bearing blocks. Capture both timings in `.evidence/<phase-id>/perf-evidence.md`.
+
+## Out of scope (per issue)
+
+- Lazy stub completers (option 3).
+- Modifying legacy `Register-CliCompletion` in `Legacy.ps1`.
+- Bundle-level rewrites (e.g. AIAgents.ps1 warp/oz NativeCommandScript).

--- a/module/MarkMichaelis.ScoopBucket/Private/Register-PackageCompletion.ps1
+++ b/module/MarkMichaelis.ScoopBucket/Private/Register-PackageCompletion.ps1
@@ -13,7 +13,32 @@
 #   - Requires elevation to write to AllUsersAllHosts; honours
 #     SupportsShouldProcess.
 
-$script:CompletionSentinelVersion = 'v1'
+$script:CompletionSentinelVersion = 'v2'
+
+function Format-DeferredCompletionBlock {
+    <#
+    .SYNOPSIS
+        Wrap a completer-registration scriptblock string in a
+        PowerShell.OnIdle one-shot deferred handler so the cost of
+        Register-ArgumentCompleter (and any cached subprocess work
+        baked into the inner code) is paid AFTER the prompt is drawn,
+        not before. Profile-block only -- in-runspace activation via
+        Import-PackageCompletion stays synchronous because the user
+        explicitly asked to register NOW (#212).
+    #>
+    [OutputType([string])]
+    [CmdletBinding()]
+    param([Parameter(Mandatory)][AllowEmptyString()][string]$InnerCode)
+    # `| Out-Null` keeps the returned PSEventJob off the success stream
+    # so dot-sourcing the profile doesn't print a stray "Id Name ..."
+    # banner. MaxTriggerCount=1 ensures we register the completer
+    # exactly once -- after that the subscriber unregisters itself.
+    return @"
+`$null = Register-EngineEvent -SourceIdentifier PowerShell.OnIdle -MaxTriggerCount 1 -Action {
+$InnerCode
+} | Out-Null
+"@
+}
 
 function Get-PackageCompletionProfilePath {
     [OutputType([string])]
@@ -244,7 +269,16 @@ function Register-PackageCompletion {
         [Parameter(Mandatory)][string]$Cli,
         [scriptblock]$NativeCommand,
         [ValidateSet('native','pscompletions','auto')][string]$Mode = 'auto',
-        [string]$ProfilePath
+        [string]$ProfilePath,
+        # Pre-captured native completer text (the body of a
+        # `Register-ArgumentCompleter -Native` block) as already
+        # produced once by Get-BundlePackages in its child runspace.
+        # When supplied AND -Mode is not 'pscompletions' AND the text
+        # is non-empty, we skip Resolve-PackageCompletionSource's
+        # native invocation entirely -- this is the fast path that
+        # avoids re-spawning the CLI's `<cli> completions powershell`
+        # at every install/update (#212).
+        [string]$PreCapturedNative
     )
 
     $target = Get-PackageCompletionProfilePath -OverridePath $ProfilePath
@@ -258,15 +292,21 @@ function Register-PackageCompletion {
     $content  = Read-PackageCompletionProfileContent -Path $target
     $existed  = [regex]::IsMatch($content, "(?ms)^\# ScoopBucket:CliCompletion:$([regex]::Escape($Cli))`:BEGIN \w+")
 
-    $resolveSplat = @{ Cli = $Cli }
-    if ($NativeCommand -and $Mode -ne 'pscompletions') {
-        $resolveSplat['NativeCommand'] = $NativeCommand
+    # Fast path: cached native text bypasses Resolve-PackageCompletionSource.
+    $resolved = $null
+    if ($PreCapturedNative -and $PreCapturedNative.Trim() -and $Mode -ne 'pscompletions') {
+        $guarded = "if (Get-Command $Cli -ErrorAction SilentlyContinue) {`r`n$PreCapturedNative}"
+        $resolved = @{ Source = 'Native'; Code = $guarded; PSCompletionsName = $null }
+    } else {
+        $resolveSplat = @{ Cli = $Cli }
+        if ($NativeCommand -and $Mode -ne 'pscompletions') {
+            $resolveSplat['NativeCommand'] = $NativeCommand
+        }
+        if ($Mode -eq 'pscompletions') {
+            $resolveSplat['PreferPSCompletions'] = $true
+        }
+        $resolved = Resolve-PackageCompletionSource @resolveSplat
     }
-    if ($Mode -eq 'pscompletions') {
-        $resolveSplat['PreferPSCompletions'] = $true
-    }
-
-    $resolved = Resolve-PackageCompletionSource @resolveSplat
 
     # When Mode='native' (no fallback allowed) and resolution went to
     # PSCompletions, downgrade to Skipped.
@@ -309,7 +349,14 @@ function Register-PackageCompletion {
         }
     }
 
-    $newContent = Set-PackageCompletionProfileBlock -Content $content -Cli $Cli -Block $resolved.Code
+    # Wrap the resolved code in a PowerShell.OnIdle one-shot deferred
+    # handler so the cost of Register-ArgumentCompleter is paid AFTER
+    # the prompt is drawn (#212). In-runspace activation via
+    # Import-PackageCompletion deliberately bypasses this -- the user
+    # there is asking to register NOW, not on next idle.
+    $deferred = Format-DeferredCompletionBlock -InnerCode $resolved.Code
+
+    $newContent = Set-PackageCompletionProfileBlock -Content $content -Cli $Cli -Block $deferred
     $tmp = "$target.tmp"
     [System.IO.File]::WriteAllText($tmp, $newContent, [System.Text.UTF8Encoding]::new($false))
     Move-Item -Path $tmp -Destination $target -Force
@@ -375,6 +422,17 @@ function Test-PackageCompletionWorks {
     $probe = @"
 `$ErrorActionPreference='SilentlyContinue'
 . '$ProfilePath' 2>`$null
+# The profile blocks written by Register-PackageCompletion defer their
+# Register-ArgumentCompleter calls to PowerShell.OnIdle (#212). The
+# OnIdle event does not auto-fire in non-interactive `pwsh -File`
+# runs, so manually invoke any pending subscribers' actions before
+# probing the completion engine.
+foreach (`$sub in @(Get-EventSubscriber -SourceIdentifier 'PowerShell.OnIdle' -ErrorAction SilentlyContinue)) {
+    try {
+        `$cmd = `$sub.Action.Command
+        if (`$cmd) { & ([scriptblock]::Create(`$cmd)) 2>`$null | Out-Null }
+    } catch { }
+}
 `$line = '$Cli '
 `$cc = [System.Management.Automation.CommandCompletion]::CompleteInput(`$line, `$line.Length, `$null)
 `$results = @(`$cc.CompletionMatches | Select-Object -First 25 -ExpandProperty CompletionText)

--- a/module/MarkMichaelis.ScoopBucket/Public/Invoke-PackageInstall.ps1
+++ b/module/MarkMichaelis.ScoopBucket/Public/Invoke-PackageInstall.ps1
@@ -238,6 +238,22 @@ function Invoke-PackageInstall {
             foreach ($cli in $pkg.CliCommands) {
                 $registerArgs = @{ Cli = $cli; Mode = $pkg.Completion }
                 if ($pkg.NativeCommandScript) { $registerArgs['NativeCommand'] = $pkg.NativeCommandScript }
+                # Prefer the loader's pre-captured native completer text
+                # (NativeCommandOutputs[$cli]) when present -- avoids
+                # re-running the CLI's `<cli> completions powershell`
+                # subprocess inside Register-PackageCompletion (#212).
+                if ($pkg.PSObject.Properties.Name -contains 'NativeCommandOutputs' -and $pkg.NativeCommandOutputs) {
+                    $no = $pkg.NativeCommandOutputs
+                    $preCaptured = $null
+                    if ($no -is [hashtable] -and $no.ContainsKey($cli)) {
+                        $preCaptured = [string]$no[$cli]
+                    } elseif ($no.PSObject -and ($no.PSObject.Properties.Name -contains $cli)) {
+                        $preCaptured = [string]$no.$cli
+                    }
+                    if ($preCaptured -and $preCaptured.Trim()) {
+                        $registerArgs['PreCapturedNative'] = $preCaptured
+                    }
+                }
                 try {
                     $null = Register-PackageCompletion @registerArgs
                 } catch {


### PR DESCRIPTION
## Summary

Closes #212.

Two complementary changes to `Register-PackageCompletion` so `pwsh` startup
no longer pays the cost of every CLI's completion-registration block on the
critical path before the prompt is drawn.

### 1. Defer profile-block execution via `Register-EngineEvent PowerShell.OnIdle`

Every block written to `\C:\Users\MarkMichaelis\OneDrive - Michaelis\Documents\PowerShell\Microsoft.PowerShell_profile.ps1.AllUsersAllHosts` by
`Register-PackageCompletion` is now wrapped in:

\\\powershell
\ = Register-EngineEvent -SourceIdentifier PowerShell.OnIdle -MaxTriggerCount 1 -Action {
    <existing block>
} | Out-Null
\\\

`MaxTriggerCount 1` ensures the subscriber unregisters itself after the
first idle (the registration is a one-shot). `Import-PackageCompletion`
deliberately stays synchronous -- in-runspace activation runs immediately
because the user asked to register *now*; the deferral lives only in the
profile-written block.

### 2. Cache the resolved completer text via `-PreCapturedNative`

`Get-BundlePackages` already captures each CLI's native completer output
into `Package.NativeCommandOutputs[\]` in its child runspace.
`Register-PackageCompletion` now accepts `-PreCapturedNative <string>`;
when supplied (and `-Mode` is not `pscompletions`), the resolver skips
re-invoking `NativeCommandScript` and uses the cached text directly.
`Invoke-PackageInstall` plumbs `NativeCommandOutputs[\]` through on
every install / re-install / update, so the cached completer text is refreshed
whenever `Install-Package` or `Update-Package` runs.

### 3. Sentinel bumped to v2 with transparent migration

`\` is now `v2`. The remove / replace
regex already matched `\w+` so older v1 blocks are detected and rewritten
in place on the next register / update.

## Perf evidence (synthetic 5-CLI profile, 150 ms simulated subprocess per block, 5 cold runs)

\\\
Measure-Command { pwsh -NoLogo -NoProfile -Command ". <profile>; exit" }
\\\

| Profile | Min (ms) | Median (ms) | Max (ms) |
| --- | ---: | ---: | ---: |
| BEFORE (v1 eager)  | 1213.2 | 1251.4 | 1360.2 |
| AFTER  (v2 OnIdle) |  450.5 |  462.3 |  512.3 |

**789 ms / 63% saving** on the critical path before the prompt is drawn.
The OnIdle subscriber still runs the same payload later, after the prompt
becomes interactive.

## Behavior-first tests

New: `bucket/CompletionDeferredRegistration.Tests.ps1` (tag `Light,DeferredCompletion`).

Each test fails behaviorally when the corresponding code change is reverted:

- `wraps the emitted block in Register-EngineEvent PowerShell.OnIdle (MaxTriggerCount 1)`
- `-PreCapturedNative overrides NativeCommand (the scriptblock is not invoked)`
- `rewrites an existing v1 block as v2 on re-register (transparent migration)`
- `profile-load critical path contains no top-level subprocess call` (subprocess
  body sits inside the deferred `-Action` body, not on the critical path)
- `Import-PackageCompletion does not register a PowerShell.OnIdle subscriber`
  when activating completers in-runspace
- `Update-PackageCompletion -Force replaces a v1 block with a v2 OnIdle-wrapped block`

Updated probes (`Test-PackageCompletionWorks` inside
`Register-PackageCompletion.ps1`, and the inline probe in
`CompletionEndToEnd.Tests.ps1`) drain `Get-EventSubscriber -SourceIdentifier PowerShell.OnIdle`
so non-interactive child runspaces observe the deferred registrations.

## Test command

\\\powershell
Invoke-Pester -Path .\bucket\CompletionDeferredRegistration.Tests.ps1,.\bucket\ImportPackageCompletion.Tests.ps1,.\bucket\UpdatePackageCompletion.Tests.ps1,.\bucket\PSCompletionsAutoInstall.Tests.ps1,.\bucket\RegisterCliCompletionRollback.Tests.ps1,.\bucket\RegisterAllCliCompletionsScope.Tests.ps1,.\bucket\CliCompletionOutput.Tests.ps1 -ExcludeTagFilter Heavy,Network,Idempotency,CompletionPinned
\\\

**Result:** Tests Passed: 27, Failed: 0, Skipped: 1 (PSCompletions write-policy gate -- expected).

## Out of scope (per issue)

- Lazy stub completers (option 3 from the original discussion).
- Modifying the parallel `Register-CliCompletion` path in `Legacy.ps1`
  (unused by `Install-Package`).
- Bundle-level rewrites (e.g. AIAgents.ps1 warp/oz `NativeCommandScript`
  still emits a subprocess-bearing payload; that payload now lives inside the
  deferred `-Action` body so it no longer blocks the prompt).
