### PR TITLE
fix(completion): route native completer payloads through v3 sidecar .ps1 files across package and public registration paths

### DIFF
--- a/bucket/CompletionDeferredRegistration.Tests.ps1
+++ b/bucket/CompletionDeferredRegistration.Tests.ps1
@@ -40,8 +40,16 @@ Describe 'Register-PackageCompletion: deferred OnIdle wrap + cached native text'
             Register-PackageCompletion -Cli demo1 -NativeCommand $nc -Mode native -ProfilePath $ProfilePath -Confirm:$false | Out-Null
         }
         $raw = Get-Content -Raw -Path $script:profilePath
-        $raw | Should -Match 'ScoopBucket:CliCompletion:demo1:BEGIN v2'
+        $raw | Should -Match 'ScoopBucket:CliCompletion:demo1:BEGIN v3'
         $raw | Should -Match 'Register-EngineEvent -SourceIdentifier PowerShell\.OnIdle -MaxTriggerCount 1'
+        # v3 (#216): the OnIdle Action body now dot-sources a sidecar
+        # `<cli>.ps1`; the raw Register-ArgumentCompleter call lives in
+        # that sidecar so payloads beginning with `using namespace ...`
+        # can parse legally.
+        $raw | Should -Match "(?m)\.\s+'.*?demo1\.ps1'"
+        $sidecar = Join-Path (Split-Path -Parent $script:profilePath) 'completions\demo1.ps1'
+        Test-Path $sidecar | Should -BeTrue
+        (Get-Content -Raw -Path $sidecar) | Should -Match 'Register-ArgumentCompleter -Native -CommandName demo1'
     }
 
     It '-PreCapturedNative overrides NativeCommand (the scriptblock is not invoked)' {
@@ -57,11 +65,16 @@ Describe 'Register-PackageCompletion: deferred OnIdle wrap + cached native text'
         }
         $result.Invocations | Should -Be 0
         $raw = Get-Content -Raw -Path $script:profilePath
-        $raw | Should -Match 'Register-ArgumentCompleter -Native -CommandName demo2'
         $raw | Should -Match 'Register-EngineEvent -SourceIdentifier PowerShell\.OnIdle'
+        # v3: cached completer text lives in the sidecar, not inline in
+        # the profile.
+        $sidecar = Join-Path (Split-Path -Parent $script:profilePath) 'completions\demo2.ps1'
+        Test-Path $sidecar | Should -BeTrue
+        (Get-Content -Raw -Path $sidecar) | Should -Match 'Register-ArgumentCompleter -Native -CommandName demo2'
+        $raw | Should -Match "(?m)\.\s+'.*?demo2\.ps1'"
     }
 
-    It 'rewrites an existing v1 block as v2 on re-register (transparent migration)' {
+    It 'rewrites an existing v1 block as v3 on re-register (transparent migration)' {
         $v1 = @"
 # ScoopBucket:CliCompletion:demo3:BEGIN v1
 if (Get-Command demo3 -ErrorAction SilentlyContinue) {
@@ -79,12 +92,12 @@ Register-ArgumentCompleter -Native -CommandName demo3 -ScriptBlock { }
         }
         $raw = Get-Content -Raw -Path $script:profilePath
         ([regex]::Matches($raw, 'ScoopBucket:CliCompletion:demo3:BEGIN').Count) | Should -Be 1
-        $raw | Should -Match 'ScoopBucket:CliCompletion:demo3:BEGIN v2'
+        $raw | Should -Match 'ScoopBucket:CliCompletion:demo3:BEGIN v3'
         $raw | Should -Match 'Register-EngineEvent -SourceIdentifier PowerShell\.OnIdle'
         $raw | Should -Not -Match 'ScoopBucket:CliCompletion:demo3:BEGIN v1'
     }
 
-    It 'profile-load critical path contains no top-level subprocess call (subprocess body sits inside the deferred Action)' {
+    It 'profile-load critical path contains no top-level subprocess call (subprocess body sits inside the sidecar, not the profile)' {
         $profilePath = $script:profilePath
         InModuleScope MarkMichaelis.ScoopBucket -Parameters @{ ProfilePath = $profilePath } {
             param($ProfilePath)
@@ -92,7 +105,12 @@ Register-ArgumentCompleter -Native -CommandName demo3 -ScriptBlock { }
             Register-PackageCompletion -Cli demo4 -NativeCommand $subprocessy -Mode native -ProfilePath $ProfilePath -Confirm:$false | Out-Null
         }
         $raw = Get-Content -Raw -Path $script:profilePath
-        $m = [regex]::Match($raw, '(?ms)^\# ScoopBucket:CliCompletion:demo4:BEGIN v2\r?\n(.+?)^\# ScoopBucket:CliCompletion:demo4:END')
+        # v3: subprocess text is persisted to the sidecar and NEVER
+        # appears in the profile itself; the profile only dot-sources
+        # the sidecar from inside the deferred OnIdle Action.
+        $raw | Should -Not -Match '(?m)warp\.exe'
+        $raw | Should -Not -Match 'Invoke-Expression'
+        $m = [regex]::Match($raw, '(?ms)^\# ScoopBucket:CliCompletion:demo4:BEGIN v3\r?\n(.+?)^\# ScoopBucket:CliCompletion:demo4:END')
         $m.Success | Should -BeTrue
         $body = $m.Groups[1].Value
 
@@ -101,6 +119,12 @@ Register-ArgumentCompleter -Native -CommandName demo3 -ScriptBlock { }
         $criticalPath = $body.Substring(0, $idx)
         $criticalPath | Should -Not -Match '(?m)^\s*&\s'
         $criticalPath | Should -Not -Match 'Invoke-Expression'
+
+        # The subprocess text lives in the sidecar -- confirm the sidecar
+        # was written, but stays off the profile critical path.
+        $sidecar = Join-Path (Split-Path -Parent $script:profilePath) 'completions\demo4.ps1'
+        Test-Path $sidecar | Should -BeTrue
+        (Get-Content -Raw -Path $sidecar) | Should -Match 'warp\.exe'
     }
 }
 
@@ -129,7 +153,7 @@ Describe 'Import-PackageCompletion: synchronous, no OnIdle deferral' -Tag 'Light
     }
 }
 
-Describe 'Update-PackageCompletion: -Force rewrites stale v1 blocks as v2 + OnIdle' -Tag 'Light','DeferredCompletion' {
+Describe 'Update-PackageCompletion: -Force rewrites stale v1/v2 blocks as v3 + OnIdle + sidecar' -Tag 'Light','DeferredCompletion' {
 
     BeforeAll {
         $psd1 = Join-Path $PSScriptRoot '..\module\MarkMichaelis.ScoopBucket\MarkMichaelis.ScoopBucket.psd1'
@@ -150,7 +174,7 @@ Describe 'Update-PackageCompletion: -Force rewrites stale v1 blocks as v2 + OnId
         if (Test-Path $script:sandbox2) { Remove-Item -Recurse -Force $script:sandbox2 -ErrorAction SilentlyContinue }
     }
 
-    It '-Force replaces a v1 block with a v2 OnIdle-wrapped block' {
+    It '-Force replaces a v1 block with a v3 OnIdle + sidecar block' {
         if (-not $script:realCli) {
             Set-ItResult -Skipped -Because 'No reference CLI on PATH for the test to anchor on.'
             return
@@ -182,8 +206,11 @@ Register-ArgumentCompleter -Native -CommandName $cli -ScriptBlock { }
 
         Update-PackageCompletion -Force -ProfilePath $script:profilePath2 -Confirm:$false | Out-Null
         $raw = Get-Content -Raw -Path $script:profilePath2
-        $raw | Should -Match "ScoopBucket:CliCompletion:$cli`:BEGIN v2"
+        $raw | Should -Match "ScoopBucket:CliCompletion:$cli`:BEGIN v3"
         $raw | Should -Match 'Register-EngineEvent -SourceIdentifier PowerShell\.OnIdle'
-        $raw | Should -Match 'refreshed'
+        # v3: the refreshed text now lives in the sidecar, not the profile.
+        $sidecar = Join-Path (Split-Path -Parent $script:profilePath2) "completions\$cli.ps1"
+        Test-Path $sidecar | Should -BeTrue
+        (Get-Content -Raw -Path $sidecar) | Should -Match 'refreshed'
     }
 }

--- a/bucket/CompletionPinned.Tests.ps1
+++ b/bucket/CompletionPinned.Tests.ps1
@@ -58,15 +58,19 @@ Describe 'CliCompletion pinned contract -- per-bundle native registration' -Tag 
         @($pkg.ExpectedCompletions[$Cli]).Count | Should -BeGreaterThan 0 -Because "ExpectedCompletions['$Cli'] must list at least one expected subcommand"
     }
 
-    It 'uses sentinel version v2' {
+    It 'uses sentinel version v3' {
         # $script:CompletionSentinelVersion lives inside the module and is not
         # visible from this test runspace; assert against the source instead so
         # any bump of the sentinel format requires updating this guard too.
-        # v2 (#212) wraps the cached completer payload in
-        # Register-EngineEvent PowerShell.OnIdle -MaxTriggerCount 1 -Action
-        # so startup defers registration until the first idle tick.
+        # v3 (#216) persists each cached native completer payload to a
+        # sidecar .ps1 file under $env:ProgramData\ScoopBucket\completions
+        # and emits a tiny `. '<sidecar>.ps1'` dot-source inside the OnIdle
+        # Action body. This is required because clap/Rust-derived completers
+        # emit a leading `using namespace System.Management.Automation` which
+        # the parser only accepts as the FIRST statement of a script file --
+        # never inside an if/Action scriptblock (v2's regression).
         $src = Get-Content -Raw -Path (Join-Path $PSScriptRoot '..\module\MarkMichaelis.ScoopBucket\Private\Register-PackageCompletion.ps1')
-        $src | Should -Match "(?m)^\s*\`$script:CompletionSentinelVersion\s*=\s*'v2'\s*$" -Because 'Register-PackageCompletion.ps1 must pin sentinel version v2'
+        $src | Should -Match "(?m)^\s*\`$script:CompletionSentinelVersion\s*=\s*'v3'\s*$" -Because 'Register-PackageCompletion.ps1 must pin sentinel version v3'
     }
 
     It 'Register-CliCompletion exposes the -NativeCommand parameter' {

--- a/bucket/CompletionUsingNamespaceSidecar.Tests.ps1
+++ b/bucket/CompletionUsingNamespaceSidecar.Tests.ps1
@@ -1,0 +1,149 @@
+#requires -Version 7.0
+#requires -Modules @{ ModuleName = 'Pester'; ModuleVersion = '5.0.0' }
+
+<#
+.SYNOPSIS
+    Issue #216 -- Native completer payloads that begin with
+    `using namespace System.Management.Automation` (clap/Rust completers
+    like `rg --generate complete-powershell`) must be persisted to a
+    sidecar .ps1 file so the leading `using` statement is legal. The
+    profile block dot-sources the sidecar from inside its OnIdle
+    Action body; the inline `using` regression that broke v2 must not
+    return.
+#>
+
+Describe 'Register-PackageCompletion: payloads with `using namespace` go to sidecar .ps1' -Tag 'Light','SidecarCompletion' {
+
+    BeforeAll {
+        $psd1 = Join-Path $PSScriptRoot '..\module\MarkMichaelis.ScoopBucket\MarkMichaelis.ScoopBucket.psd1'
+        if (Test-Path $psd1) { Import-Module $psd1 -Force } else { Import-Module MarkMichaelis.ScoopBucket -Force }
+
+        $script:sandbox = Join-Path ([System.IO.Path]::GetTempPath()) ("Sidecar-" + [guid]::NewGuid().ToString('N'))
+        New-Item -ItemType Directory -Path $script:sandbox -Force | Out-Null
+        $script:profilePath    = Join-Path $script:sandbox 'Profile.ps1'
+        $script:sidecarDir     = Join-Path $script:sandbox 'completions'
+    }
+
+    AfterAll {
+        if (Test-Path $script:sandbox) { Remove-Item -Recurse -Force $script:sandbox -ErrorAction SilentlyContinue }
+    }
+
+    BeforeEach {
+        if (Test-Path $script:profilePath) { Remove-Item -Force $script:profilePath }
+        if (Test-Path $script:sidecarDir)  { Remove-Item -Recurse -Force $script:sidecarDir }
+    }
+
+    It 'persists a payload that begins with `using namespace` to a sidecar .ps1 (no inline `using` in profile)' {
+        $profilePath = $script:profilePath
+        $sidecarDir  = $script:sidecarDir
+        InModuleScope MarkMichaelis.ScoopBucket -Parameters @{ ProfilePath = $profilePath; SidecarDir = $sidecarDir } {
+            param($ProfilePath, $SidecarDir)
+            # Synthesize the shape rg emits: leading `using namespace` then
+            # Register-ArgumentCompleter referencing [CompletionResult] without FQN.
+            $payload = @'
+using namespace System.Management.Automation
+Register-ArgumentCompleter -Native -CommandName demoUns -ScriptBlock {
+    param($wordToComplete, $commandAst, $cursorPosition)
+    @([CompletionResult]::new('help', 'help', [CompletionResultType]::ParameterValue, 'help'))
+}
+'@
+            $nc = [scriptblock]::Create("Write-Output @'`r`n$payload`r`n'@")
+            Register-PackageCompletion -Cli demoUns -NativeCommand $nc -Mode native `
+                -ProfilePath $ProfilePath -SidecarDirectory $SidecarDir -Confirm:$false | Out-Null
+        }
+
+        $raw = Get-Content -Raw -Path $script:profilePath
+        # (a) profile must NOT contain a `using namespace` line anywhere.
+        $raw | Should -Not -Match '(?m)^\s*using\s+namespace\b' -Because 'inline `using namespace` inside an if/Action block is a fatal parse error'
+        # (b) v3 sentinel + OnIdle wrapper still present.
+        $raw | Should -Match 'ScoopBucket:CliCompletion:demoUns:BEGIN v3'
+        $raw | Should -Match 'Register-EngineEvent -SourceIdentifier PowerShell\.OnIdle'
+        # (c) the OnIdle body is just a dot-source of the sidecar.
+        $expectedSidecar = Join-Path $script:sidecarDir 'demoUns.ps1'
+        $escSidecar = [regex]::Escape($expectedSidecar)
+        $raw | Should -Match "(?m)\.\s+'$escSidecar'" -Because 'the OnIdle Action must dot-source the sidecar instead of inlining the payload'
+
+        # (d) sidecar must exist and start with `using namespace`.
+        Test-Path $expectedSidecar | Should -BeTrue -Because 'Register-PackageCompletion must write a sidecar .ps1 for every Native registration'
+        $sideRaw = Get-Content -Raw -Path $expectedSidecar
+        $firstNonEmpty = ($sideRaw -split "`r?`n") | Where-Object { $_.Trim() } | Select-Object -First 1
+        $firstNonEmpty | Should -Match '^\s*using\s+namespace\s+System\.Management\.Automation\s*$' -Because 'the sidecar preserves the payload verbatim, with `using` as the first statement'
+        $sideRaw | Should -Match 'Register-ArgumentCompleter -Native -CommandName demoUns'
+    }
+
+    It 'profile written for a `using namespace` payload parses cleanly in a fresh pwsh' {
+        $profilePath = $script:profilePath
+        $sidecarDir  = $script:sidecarDir
+        InModuleScope MarkMichaelis.ScoopBucket -Parameters @{ ProfilePath = $profilePath; SidecarDir = $sidecarDir } {
+            param($ProfilePath, $SidecarDir)
+            $payload = @'
+using namespace System.Management.Automation
+Register-ArgumentCompleter -Native -CommandName demoUns2 -ScriptBlock {
+    param($w,$c,$p)
+    @([CompletionResult]::new('x','x',[CompletionResultType]::ParameterValue,'x'))
+}
+'@
+            $nc = [scriptblock]::Create("Write-Output @'`r`n$payload`r`n'@")
+            Register-PackageCompletion -Cli demoUns2 -NativeCommand $nc -Mode native `
+                -ProfilePath $ProfilePath -SidecarDirectory $SidecarDir -Confirm:$false | Out-Null
+        }
+
+        # Probe: spawn pwsh -NoProfile, dot-source the freshly written profile,
+        # report success or the parse error to stdout. v2 emit dies here with
+        # "A 'using' statement must appear before any other statements".
+        $probePath = Join-Path $script:sandbox 'probe.ps1'
+        $probe = @"
+`$ErrorActionPreference = 'Stop'
+try {
+    . '$($script:profilePath -replace "'","''")'
+    Write-Output 'OK'
+} catch {
+    Write-Output "FAIL: `$(`$_.Exception.Message)"
+}
+"@
+        Set-Content -Path $probePath -Value $probe -Encoding UTF8
+        $pwsh = (Get-Process -Id $PID).Path
+        if (-not $pwsh) { $pwsh = 'pwsh' }
+        $out = & $pwsh -NoProfile -NonInteractive -ExecutionPolicy Bypass -File $probePath 2>&1 | Out-String
+        $out | Should -Match '(?m)^OK\s*$' -Because "profile must parse without ParserError; got: $out"
+        $out | Should -Not -Match "using' statement must appear"
+    }
+}
+
+Describe 'Remove-PackageCompletionBlock: deletes the sidecar .ps1 alongside the profile block' -Tag 'Light','SidecarCompletion' {
+
+    BeforeAll {
+        $psd1 = Join-Path $PSScriptRoot '..\module\MarkMichaelis.ScoopBucket\MarkMichaelis.ScoopBucket.psd1'
+        if (Test-Path $psd1) { Import-Module $psd1 -Force } else { Import-Module MarkMichaelis.ScoopBucket -Force }
+
+        $script:sandbox2    = Join-Path ([System.IO.Path]::GetTempPath()) ("SidecarRm-" + [guid]::NewGuid().ToString('N'))
+        New-Item -ItemType Directory -Path $script:sandbox2 -Force | Out-Null
+        $script:profilePath2 = Join-Path $script:sandbox2 'Profile.ps1'
+        $script:sidecarDir2  = Join-Path $script:sandbox2 'completions'
+    }
+
+    AfterAll {
+        if (Test-Path $script:sandbox2) { Remove-Item -Recurse -Force $script:sandbox2 -ErrorAction SilentlyContinue }
+    }
+
+    It 'deletes <cli>.ps1 when Remove-PackageCompletionBlock strips the block' {
+        $profilePath = $script:profilePath2
+        $sidecarDir  = $script:sidecarDir2
+        InModuleScope MarkMichaelis.ScoopBucket -Parameters @{ ProfilePath = $profilePath; SidecarDir = $sidecarDir } {
+            param($ProfilePath, $SidecarDir)
+            $nc = [scriptblock]::Create("Write-Output 'Register-ArgumentCompleter -Native -CommandName demoRm -ScriptBlock { }'")
+            Register-PackageCompletion -Cli demoRm -NativeCommand $nc -Mode native `
+                -ProfilePath $ProfilePath -SidecarDirectory $SidecarDir -Confirm:$false | Out-Null
+        }
+        $sidecar = Join-Path $script:sidecarDir2 'demoRm.ps1'
+        Test-Path $sidecar | Should -BeTrue -Because 'sanity check: Register-PackageCompletion wrote the sidecar'
+
+        $result = InModuleScope MarkMichaelis.ScoopBucket -Parameters @{ ProfilePath = $profilePath; SidecarDir = $sidecarDir } {
+            param($ProfilePath, $SidecarDir)
+            Remove-PackageCompletionBlock -Cli demoRm -ProfilePath $ProfilePath -SidecarDirectory $SidecarDir -Confirm:$false
+        }
+        $result.Action | Should -Be 'Removed'
+        Test-Path $sidecar | Should -BeFalse -Because 'Remove-PackageCompletionBlock must delete the matching sidecar .ps1 (#216)'
+    }
+}
+

--- a/bucket/CompletionUsingNamespaceSidecar.Tests.ps1
+++ b/bucket/CompletionUsingNamespaceSidecar.Tests.ps1
@@ -155,6 +155,43 @@ Describe 'Remove-PackageCompletionBlock: deletes the sidecar .ps1 alongside the 
         if (Test-Path $script:sandbox2) { Remove-Item -Recurse -Force $script:sandbox2 -ErrorAction SilentlyContinue }
     }
 
+    It 'public Register-CliCompletion also routes Native payloads through the sidecar (#218 Copilot review)' {
+        # Regression: the legacy public path `Register-CliCompletion`
+        # (called e.g. from bucket/GitConfigure.ps1) was still using the
+        # v1 inline writer, so a manual call with a `using namespace`
+        # payload would re-introduce the parse error. The fix routes
+        # Native sources through the same sidecar logic as
+        # Register-PackageCompletion.
+        $cliProfile = Join-Path $script:sandbox2 'ProfileCli.ps1'
+        $cliSidecar = Join-Path $script:sandbox2 'completions-cli'
+        $payload = @'
+using namespace System.Management.Automation
+Register-ArgumentCompleter -Native -CommandName demoCliUns -ScriptBlock {
+    param($w,$c,$p)
+    @([CompletionResult]::new('x','x',[CompletionResultType]::ParameterValue,'x'))
+}
+'@
+        $nc = [scriptblock]::Create("Write-Output @'`r`n$payload`r`n'@")
+        Register-CliCompletion -Cli demoCliUns -NativeCommand $nc -Force `
+            -ProfilePath $cliProfile -SidecarDirectory $cliSidecar -Confirm:$false | Out-Null
+
+        $sidecar = Join-Path $cliSidecar 'demoCliUns.ps1'
+        Test-Path $sidecar | Should -BeTrue -Because 'Register-CliCompletion must persist Native payload to a sidecar (#218)'
+        $sideRaw = Get-Content -Raw -Path $sidecar
+        $firstNonEmpty = ($sideRaw -split "`r?`n") | Where-Object { $_.Trim() } | Select-Object -First 1
+        $firstNonEmpty | Should -Match '^\s*using\s+namespace\s+System\.Management\.Automation\s*$'
+
+        $raw = Get-Content -Raw -Path $cliProfile
+        $raw | Should -Not -Match '(?m)^\s*using\s+namespace\b' -Because 'inline `using namespace` would be a fatal parse error in the profile'
+        $escSidecar = [regex]::Escape($sidecar)
+        $raw | Should -Match "(?m)\.\s+'$escSidecar'" -Because 'profile block must dot-source the sidecar'
+
+        # Parse the generated profile -- must succeed with no errors.
+        $errs = $null
+        $null = [System.Management.Automation.Language.Parser]::ParseFile($cliProfile, [ref]$null, [ref]$errs)
+        $errs | Should -BeNullOrEmpty -Because "Register-CliCompletion output must parse cleanly; got: $($errs -join '; ')"
+    }
+
     It 'deletes <cli>.ps1 when Remove-PackageCompletionBlock strips the block' {
         $profilePath = $script:profilePath2
         $sidecarDir  = $script:sidecarDir2

--- a/bucket/CompletionUsingNamespaceSidecar.Tests.ps1
+++ b/bucket/CompletionUsingNamespaceSidecar.Tests.ps1
@@ -108,6 +108,35 @@ try {
         $out | Should -Match '(?m)^OK\s*$' -Because "profile must parse without ParserError; got: $out"
         $out | Should -Not -Match "using' statement must appear"
     }
+
+    It 'escapes apostrophes in the sidecar path so install dirs like ``C:\Users\O''Brien`` parse cleanly' {
+        # Regression: Copilot review on PR #218 caught that the
+        # generated `. '$sidecarPath'` was unsafe -- a sidecar dir whose
+        # path contained a literal apostrophe would break the single-
+        # quoted PowerShell string and abort profile parsing. Use a
+        # sandbox dir whose name embeds an apostrophe to prove the fix.
+        $apostropheDir = Join-Path $script:sandbox "O'Brien-completions"
+        New-Item -ItemType Directory -Path $apostropheDir -Force | Out-Null
+        $apostropheProfile = Join-Path $script:sandbox "ProfileApos.ps1"
+        InModuleScope MarkMichaelis.ScoopBucket -Parameters @{ ProfilePath = $apostropheProfile; SidecarDir = $apostropheDir } {
+            param($ProfilePath, $SidecarDir)
+            $nc = [scriptblock]::Create("Write-Output 'Register-ArgumentCompleter -Native -CommandName demoApos -ScriptBlock { ''hi'' }'")
+            Register-PackageCompletion -Cli demoApos -NativeCommand $nc -Mode native `
+                -ProfilePath $ProfilePath -SidecarDirectory $SidecarDir -Confirm:$false | Out-Null
+        }
+
+        $raw = Get-Content -Raw -Path $apostropheProfile
+        # The path contains `'` which must be doubled in the single-
+        # quoted PowerShell string literal that dot-sources the sidecar.
+        $raw | Should -Match "O''Brien-completions" -Because 'embedded apostrophes in single-quoted dot-source paths must be doubled'
+
+        # Tokenize the profile -- there must be no parse errors, and
+        # the dot-source string must round-trip back to the original
+        # path (with one apostrophe).
+        $errs = $null
+        $null = [System.Management.Automation.Language.Parser]::ParseFile($apostropheProfile, [ref]$null, [ref]$errs)
+        $errs | Should -BeNullOrEmpty -Because "profile with apostrophe in sidecar path must parse cleanly; got: $($errs -join '; ')"
+    }
 }
 
 Describe 'Remove-PackageCompletionBlock: deletes the sidecar .ps1 alongside the profile block' -Tag 'Light','SidecarCompletion' {

--- a/bucket/PackageInstall.Tests.ps1
+++ b/bucket/PackageInstall.Tests.ps1
@@ -409,8 +409,13 @@ Describe 'Completion registration' -Tag 'Light','Module' {
         $r = & $script:RegisterFn -Cli 'idem' `
             -NativeCommand { 'second' } -Mode 'native' -ProfilePath $script:profilePath -Confirm:$false
         $r.Action | Should -Be 'Replaced'
-        (Get-Content $script:profilePath -Raw) | Should -Match 'second'
-        (Get-Content $script:profilePath -Raw) | Should -Not -Match 'first'
+        # v3 (#216): native payload lives in a sidecar .ps1 next to the
+        # profile; the profile only dot-sources it. Assert the sidecar
+        # got replaced (second wins, first is gone).
+        $sidecar = Join-Path (Split-Path -Parent $script:profilePath) 'completions\idem.ps1'
+        Test-Path $sidecar | Should -BeTrue
+        (Get-Content $sidecar -Raw) | Should -Match 'second'
+        (Get-Content $sidecar -Raw) | Should -Not -Match 'first'
     }
 
     It 'rerunning with identical native output produces a byte-identical block' {

--- a/bucket/UpdatePackageCompletion.Tests.ps1
+++ b/bucket/UpdatePackageCompletion.Tests.ps1
@@ -141,12 +141,16 @@ Describe 'Update-PackageCompletion eligibility classification' -Tag 'Light' {
         $native.Source | Should -Be 'Native'
         $native.Mode   | Should -Be 'native'
 
-        # The block written to the profile must contain the captured
-        # native completion source, wrapped in the standard
-        # Get-Command guard.
+        # v3 (#216): the captured native completion source moved from the
+        # profile (inline OnIdle Action body) to a sidecar
+        # <profile-dir>\completions\<cli>.ps1 that the profile dot-sources.
+        # The profile itself must reference the sidecar and use the v3
+        # sentinel; the payload must live in the sidecar.
         $profileContent = Get-Content -Raw -Encoding UTF8 $script:profilePath
-        $profileContent | Should -Match 'auto-native-completion-source'
-        $profileContent | Should -Match "ScoopBucket:CliCompletion:$($script:onPathCli)-native:BEGIN v2"
+        $profileContent | Should -Match "ScoopBucket:CliCompletion:$($script:onPathCli)-native:BEGIN v3"
+        $sidecar = Join-Path (Split-Path -Parent $script:profilePath) "completions\$($script:onPathCli)-native.ps1"
+        Test-Path $sidecar | Should -BeTrue
+        (Get-Content -Raw -Encoding UTF8 $sidecar) | Should -Match 'auto-native-completion-source'
     }
 
     It "registers Completion='native' packages whose CLI is on PATH" {
@@ -158,8 +162,10 @@ Describe 'Update-PackageCompletion eligibility classification' -Tag 'Light' {
         $nativeOnly.Source | Should -Be 'Native'
         $nativeOnly.Mode   | Should -Be 'native'
 
-        $profileContent = Get-Content -Raw -Encoding UTF8 $script:profilePath
-        $profileContent | Should -Match 'pure-native-completion-source'
+        # v3 (#216): payload lives in the sidecar, not the profile.
+        $sidecar = Join-Path (Split-Path -Parent $script:profilePath) "completions\$($script:onPathCli)-nativeonly.ps1"
+        Test-Path $sidecar | Should -BeTrue
+        (Get-Content -Raw -Encoding UTF8 $sidecar) | Should -Match 'pure-native-completion-source'
     }
 
     It "ignores Completion='none' and packages without CliCommands" {

--- a/docs/designs/2026-05-29-completion-using-namespace-sidecar-plan.md
+++ b/docs/designs/2026-05-29-completion-using-namespace-sidecar-plan.md
@@ -1,0 +1,147 @@
+# Plan: Sidecar `.ps1` files for cached CLI completer payloads (#216)
+
+## Why
+
+The v2 profile emit wraps each cached native completer payload inside an
+`OnIdle -Action { if (Get-Command $cli) { <payload> } }` block. When the
+payload itself starts with `using namespace System.Management.Automation`
+(emitted by `rg --generate complete-powershell` and most clap/Rust
+completers) the parser rejects the entire profile because `using` is only
+legal as the FIRST statement of a script -- never inside an `if`/`Action`
+scriptblock.
+
+Fix: persist the raw cached payload to a sidecar `.ps1` file (where `using`
+at the top IS legal) and dot-source it from the OnIdle Action.
+
+## Tasks
+
+### T1. RED: bump `CompletionPinned` assertion to v3
+- Edit `bucket/CompletionPinned.Tests.ps1` -- replace the regex requiring
+  `'v2'` with one requiring `'v3'`. Update the comment.
+- Run `Invoke-Pester -Path .\bucket\CompletionPinned.Tests.ps1 -Tag CompletionPinned`
+  -> must fail with "Expected $true, but got $false" (sentinel still v2).
+
+### T2. RED: new sidecar test
+- Create `bucket/CompletionUsingNamespaceSidecar.Tests.ps1`. Synthetic
+  payload: a scriptblock that `Write-Output`s
+  `"using namespace System.Management.Automation`r`nRegister-ArgumentCompleter -Native -CommandName demoUns -ScriptBlock { }"`.
+  Call `Register-PackageCompletion` via the InModuleScope hook with
+  `-ProfilePath $sandboxProfile -SidecarDirectory $sandboxSidecarDir`.
+  Assertions:
+    1. Profile content must NOT match `using namespace`.
+    2. `<SidecarDir>\demoUns.ps1` must exist and its first non-empty line
+       must be `using namespace System.Management.Automation`.
+    3. Profile block must match `\.\s+'.*?demoUns\.ps1'` inside the
+       `OnIdle -Action {` block.
+    4. Spawn `pwsh -NoProfile -File <probe>` that dot-sources the profile
+       and writes `OK` to stdout. Must print `OK` (no parser error).
+  Run -> must fail (Register-PackageCompletion still inlines the payload).
+
+### T3. GREEN: production change in `Register-PackageCompletion.ps1`
+- Bump `$script:CompletionSentinelVersion = 'v3'`.
+- Add `Get-PackageCompletionSidecarDirectory -ProfilePath <pp>
+  -OverrideDirectory <od>` that returns:
+    * `$OverrideDirectory` when set, or
+    * `<dir of $ProfilePath>\completions` when `$ProfilePath` is non-null
+      and not equal to `$PROFILE.AllUsersAllHosts` (test path), or
+    * `Join-Path $env:ProgramData 'ScoopBucket\completions'` for prod.
+  Creates the directory if missing. Elevation check piggy-backs on the
+  profile path's elevation check -- the prod sidecar dir lives in
+  `ProgramData` which already requires admin to write to.
+- Add `Write-PackageCompletionSidecar -Cli <c> -Payload <p> -Directory <d>`
+  that atomically writes `<d>\<c>.ps1` (UTF-8 no BOM) with the raw payload.
+- Add `Remove-PackageCompletionSidecar -Cli <c> -Directory <d>` that
+  deletes `<d>\<c>.ps1` if present.
+- Change `Register-PackageCompletion`:
+    * Accept new optional `-SidecarDirectory` parameter (test hook).
+    * After resolving Native source, call
+      `Write-PackageCompletionSidecar` to persist the raw payload (the
+      `$resolved.Code` BEFORE we wrap it in the `if (Get-Command)` guard).
+    * Build the inner code as:
+      ```
+      if (Get-Command <cli> -ErrorAction SilentlyContinue) {
+          . '<sidecar-fullpath>'
+      }
+      ```
+      and pass that to `Format-DeferredCompletionBlock`.
+    * Resolve-PackageCompletionSource currently returns guarded code with
+      the payload inlined; refactor so it returns the raw payload and the
+      guard wrapper is applied at the call site that knows the sidecar
+      path. Same fast-path for `-PreCapturedNative`.
+- Change `Remove-PackageCompletionBlock`:
+    * Accept new optional `-SidecarDirectory` parameter (test hook).
+    * After stripping the block, call `Remove-PackageCompletionSidecar`.
+
+### T4. Update existing CompletionDeferredRegistration tests
+- The four tests assert `Register-ArgumentCompleter -Native -CommandName demo1`
+  appears IN the profile. With sidecars that text now lives in the sidecar
+  `.ps1`. Update each test to:
+    * Pass a `-SidecarDirectory` pointing into the sandbox.
+    * Assert the profile contains `. '<sandbox>\demoN.ps1'` (dot-source).
+    * Assert the sidecar exists and contains the `Register-ArgumentCompleter`
+      text.
+    * Update the "rewrites v1 -> vN" test to assert `v3` not `v2`.
+    * Update the critical-path test (no top-level subprocess call) to
+      check the SIDECAR for no top-level subprocess call -- the sidecar
+      is what loads on profile parse via `.` dot-source.
+
+  Wait: re-reading the critical-path test, the intent is "profile parsing
+  doesn't pay subprocess cost". The deferred-action body now is just
+  `. 'sidecar.ps1'`. Sidecar gets dot-sourced ONLY when the OnIdle action
+  fires (after first prompt). So the profile critical path is even cleaner
+  than before. The assertion should be: the OnIdle Action body does NOT
+  contain `&` or `Invoke-Expression` at top level -- still true (it's
+  just a dot-source). Keep that test largely intact but updated to check
+  the v3 sidecar pattern.
+
+### T5. Update existing UninstallPackage Remove-PackageCompletionBlock tests
+- The three Remove-tests pass `-ProfilePath` only. Add `-SidecarDirectory`
+  for the new sidecar parameter. Add an additional assertion: after
+  Remove, the sidecar file no longer exists.
+
+### T6. GREEN verify
+- Run `Invoke-Pester -Path .\bucket\,.\module\`. All must pass.
+- Specifically run `-Tag CompletionPinned,DeferredCompletion`.
+
+### T7. Refactor pass
+- Look for duplication between `Register-PackageCompletion`'s native
+  resolution and `Import-PackageCompletion`'s native resolution. The
+  sidecar concept ONLY applies to profile-block path; in-runspace
+  `Import-PackageCompletion` continues to `[scriptblock]::Create($code).
+  InvokeReturnAsIs()` directly. No change there. (Confirms "out of scope".)
+
+### T8. Commit, push, PR
+- Single commit:
+  `fix(completion): persist cached completer payloads as sidecar .ps1 files to allow leading 'using namespace' (#216)`
+- PR body: includes `Closes #216`, lists verification scenarios, mentions
+  sentinel bump v2 -> v3.
+
+## File map
+- MODIFY `module/MarkMichaelis.ScoopBucket/Private/Register-PackageCompletion.ps1`
+- MODIFY `bucket/CompletionPinned.Tests.ps1`
+- MODIFY `bucket/CompletionDeferredRegistration.Tests.ps1`
+- MODIFY `bucket/UninstallPackage.Tests.ps1`
+- CREATE `bucket/CompletionUsingNamespaceSidecar.Tests.ps1`
+- (no new fields consumed by Test-Installs.ps1 -- the per-installer probe
+  in Get-BundlePackages.ps1 and the flattener in Get-Package.ps1 are
+  untouched.)
+
+## Test command (CI mirror)
+```
+Invoke-Pester -Path .\bucket\,.\module\
+```
+Pre-push focus run:
+```
+Invoke-Pester -Path .\bucket\ -Tag CompletionPinned,DeferredCompletion
+```
+
+## Risks
+- Existing v2 blocks in users' profiles will be re-written by
+  `Register-PackageCompletion` only when called (Update-PackageCompletion
+  -Force, or a fresh Install-Package). Until then the broken v2 blocks
+  remain. Document this in PR description: users hitting #216 must run
+  `Update-PackageCompletion -Force` (the very command that exposed the
+  bug) to migrate. That command itself does not need rg present, so it
+  will succeed even when the broken profile prevents `pwsh` startup --
+  user can launch with `pwsh -NoProfile` once to run the migration.
+

--- a/module/MarkMichaelis.ScoopBucket/Private/Legacy.ps1
+++ b/module/MarkMichaelis.ScoopBucket/Private/Legacy.ps1
@@ -559,7 +559,18 @@ function Resolve-CliCompletionSource {
         try { $native = & $NativeCommand 2>$null | Out-String } catch { }
         if ($native -and $native.Trim()) {
             $guarded = "if (Get-Command $Cli -ErrorAction SilentlyContinue) {`r`n$native}"
-            return @{ Source = 'Native'; Code = $guarded; PSCompletionsName = $null }
+            # NativePayload (v3, #216): raw native completer text preserved
+            # so callers can persist it to a sidecar `.ps1`. Sidecar files
+            # are the only place a leading `using namespace ...` (clap/Rust
+            # generators) parses legally; the legacy inlined $guarded form
+            # is retained only as a fallback for legacy callers that have
+            # not opted into sidecars.
+            return @{
+                Source            = 'Native'
+                Code              = $guarded
+                NativePayload     = $native
+                PSCompletionsName = $null
+            }
         }
     }
 
@@ -708,7 +719,8 @@ function Register-CliCompletion {
         [Parameter(Mandatory)][string]$Cli,
         [scriptblock]$NativeCommand,
         [switch]$Force,
-        [string]$ProfilePath
+        [string]$ProfilePath,
+        [string]$SidecarDirectory
     )
 
     $target = Get-CompletionProfilePath -OverridePath $ProfilePath
@@ -783,7 +795,23 @@ function Register-CliCompletion {
         }
     }
 
-    $newContent = Set-CompletionProfileBlock -Content $content -Cli $Cli -Block $resolved.Code -Force:$true
+    # v3 (#216): for Native sources, persist the raw payload to a sidecar
+    # `<cli>.ps1` and emit a tiny dot-source wrapper instead of inlining
+    # the payload in the profile. `.ps1` files are the only place a
+    # leading `using namespace ...` parses legally; inlining that text
+    # inside an `if {}` block in the profile is a fatal parse error
+    # (e.g. `rg --generate complete-powershell` payloads, #216).
+    $blockCode = $resolved.Code
+    if ($resolved.Source -eq 'Native' -and $resolved.NativePayload) {
+        $sidecarDir  = Get-PackageCompletionSidecarDirectory -ProfilePath $target -OverrideDirectory $SidecarDirectory
+        $sidecarPath = Write-PackageCompletionSidecar -Cli $Cli -Payload $resolved.NativePayload -Directory $sidecarDir
+        # Escape any embedded apostrophes for the single-quoted dot-source
+        # path (PowerShell single-quote strings escape `'` as `''`). Real
+        # install paths can contain apostrophes (e.g. "C:\Users\O'Brien").
+        $escapedPath = $sidecarPath -replace "'", "''"
+        $blockCode = "if (Get-Command $Cli -ErrorAction SilentlyContinue) {`r`n    . '$escapedPath'`r`n}"
+    }
+    $newContent = Set-CompletionProfileBlock -Content $content -Cli $Cli -Block $blockCode -Force:$true
     $tmp = "$target.tmp"
     [System.IO.File]::WriteAllText($tmp, $newContent, [System.Text.UTF8Encoding]::new($false))
     Move-Item -Path $tmp -Destination $target -Force

--- a/module/MarkMichaelis.ScoopBucket/Private/Register-PackageCompletion.ps1
+++ b/module/MarkMichaelis.ScoopBucket/Private/Register-PackageCompletion.ps1
@@ -13,7 +13,97 @@
 #   - Requires elevation to write to AllUsersAllHosts; honours
 #     SupportsShouldProcess.
 
-$script:CompletionSentinelVersion = 'v2'
+$script:CompletionSentinelVersion = 'v3'
+
+# Default sidecar root for cached native completer payloads (v3+, #216).
+# Each registered CLI gets <Dir>\<cli>.ps1 holding the raw payload --
+# `.ps1` lets the payload's leading `using namespace ...` parse legally,
+# which it cannot when inlined inside an OnIdle Action scriptblock.
+$script:CompletionSidecarDirDefault = if ($env:ProgramData) {
+    Join-Path $env:ProgramData 'ScoopBucket\completions'
+} else {
+    Join-Path ([System.IO.Path]::GetTempPath()) 'ScoopBucket\completions'
+}
+
+function Get-PackageCompletionSidecarDirectory {
+    <#
+    .SYNOPSIS
+        Resolve the directory that holds cached native completer payloads
+        (one `<cli>.ps1` per registered CLI). v3+ (#216).
+    .DESCRIPTION
+        Resolution order:
+          1. -OverrideDirectory wins (test hook).
+          2. When -ProfilePath is supplied AND differs from
+             $PROFILE.AllUsersAllHosts, use `<dir-of-ProfilePath>\completions`.
+             This keeps Pester sandboxes self-contained without an
+             additional explicit hook.
+          3. Otherwise return $script:CompletionSidecarDirDefault
+             ($env:ProgramData\ScoopBucket\completions).
+        Creates the directory on demand. Elevation is enforced upstream by
+        Get-PackageCompletionProfilePath -- the prod sidecar lives in
+        ProgramData which already requires admin to write to, and test
+        overrides bypass elevation.
+    #>
+    [OutputType([string])]
+    [CmdletBinding()]
+    param(
+        [string]$ProfilePath,
+        [string]$OverrideDirectory
+    )
+
+    $dir = $OverrideDirectory
+    if (-not $dir) {
+        if ($ProfilePath -and $ProfilePath -ne $PROFILE.AllUsersAllHosts) {
+            $dir = Join-Path (Split-Path -Parent $ProfilePath) 'completions'
+        } else {
+            $dir = $script:CompletionSidecarDirDefault
+        }
+    }
+    if (-not (Test-Path $dir)) {
+        New-Item -ItemType Directory -Path $dir -Force | Out-Null
+    }
+    return $dir
+}
+
+function Write-PackageCompletionSidecar {
+    <#
+    .SYNOPSIS
+        Atomically write the raw native completer payload for $Cli to
+        `<Directory>\<Cli>.ps1` as UTF-8 (no BOM).
+    #>
+    [OutputType([string])]
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)][string]$Cli,
+        [Parameter(Mandatory)][AllowEmptyString()][string]$Payload,
+        [Parameter(Mandatory)][string]$Directory
+    )
+    $target = Join-Path $Directory ($Cli + '.ps1')
+    $tmp = "$target.tmp"
+    [System.IO.File]::WriteAllText($tmp, $Payload, [System.Text.UTF8Encoding]::new($false))
+    Move-Item -Path $tmp -Destination $target -Force
+    return $target
+}
+
+function Remove-PackageCompletionSidecar {
+    <#
+    .SYNOPSIS
+        Delete `<Directory>\<Cli>.ps1` if it exists. Inverse of
+        Write-PackageCompletionSidecar. Silent no-op when absent.
+    #>
+    [OutputType([bool])]
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)][string]$Cli,
+        [Parameter(Mandatory)][string]$Directory
+    )
+    $target = Join-Path $Directory ($Cli + '.ps1')
+    if (Test-Path $target) {
+        Remove-Item -LiteralPath $target -Force -ErrorAction Stop
+        return $true
+    }
+    return $false
+}
 
 function Format-DeferredCompletionBlock {
     <#
@@ -87,7 +177,12 @@ function Resolve-PackageCompletionSource {
         try { $native = & $NativeCommand $Cli 2>$null | Out-String } catch { }
         if ($native -and $native.Trim()) {
             $guarded = "if (Get-Command $Cli -ErrorAction SilentlyContinue) {`r`n$native}"
-            return @{ Source = 'Native'; Code = $guarded; PSCompletionsName = $null }
+            # NativePayload is the RAW completer text (may start with
+            # `using namespace ...`); callers that persist to a sidecar
+            # .ps1 use it verbatim. `Code` is the legacy in-runspace form
+            # wrapped in a Get-Command guard, still used by
+            # Import-PackageCompletion's synchronous execution path.
+            return @{ Source = 'Native'; Code = $guarded; PSCompletionsName = $null; NativePayload = $native }
         }
     }
 
@@ -171,7 +266,10 @@ function Remove-PackageCompletionBlock {
     [OutputType([pscustomobject])]
     param(
         [Parameter(Mandatory)][string]$Cli,
-        [string]$ProfilePath
+        [string]$ProfilePath,
+        # Test hook: read/delete sidecars from here instead of
+        # $env:ProgramData\ScoopBucket\completions. v3+ (#216).
+        [string]$SidecarDirectory
     )
 
     $target = Get-PackageCompletionProfilePath -OverridePath $ProfilePath
@@ -207,6 +305,17 @@ function Remove-PackageCompletionBlock {
     $tmp = "$target.tmp"
     [System.IO.File]::WriteAllText($tmp, $stripped.Content, [System.Text.UTF8Encoding]::new($false))
     Move-Item -Path $tmp -Destination $target -Force
+
+    # v3 (#216): also delete the matching sidecar `<cli>.ps1` so we
+    # don't leave orphaned cached payloads behind when a CLI is
+    # uninstalled. Silent no-op if no sidecar exists (e.g. PSCompletions
+    # source, or never registered under v3).
+    try {
+        $sidecarDir = Get-PackageCompletionSidecarDirectory -ProfilePath $target -OverrideDirectory $SidecarDirectory
+        Remove-PackageCompletionSidecar -Cli $Cli -Directory $sidecarDir | Out-Null
+    } catch {
+        Write-Warning "Remove-PackageCompletionBlock: failed to remove sidecar for '$Cli': $($_.Exception.Message)"
+    }
 
     return [pscustomobject]@{
         Cli = $Cli; Action = 'Removed'; ProfilePath = $target; Reason = $null
@@ -278,7 +387,10 @@ function Register-PackageCompletion {
         # native invocation entirely -- this is the fast path that
         # avoids re-spawning the CLI's `<cli> completions powershell`
         # at every install/update (#212).
-        [string]$PreCapturedNative
+        [string]$PreCapturedNative,
+        # Test hook: write `<dir>\<cli>.ps1` sidecars here instead of
+        # $env:ProgramData\ScoopBucket\completions. v3+ (#216).
+        [string]$SidecarDirectory
     )
 
     $target = Get-PackageCompletionProfilePath -OverridePath $ProfilePath
@@ -296,7 +408,7 @@ function Register-PackageCompletion {
     $resolved = $null
     if ($PreCapturedNative -and $PreCapturedNative.Trim() -and $Mode -ne 'pscompletions') {
         $guarded = "if (Get-Command $Cli -ErrorAction SilentlyContinue) {`r`n$PreCapturedNative}"
-        $resolved = @{ Source = 'Native'; Code = $guarded; PSCompletionsName = $null }
+        $resolved = @{ Source = 'Native'; Code = $guarded; PSCompletionsName = $null; NativePayload = $PreCapturedNative }
     } else {
         $resolveSplat = @{ Cli = $Cli }
         if ($NativeCommand -and $Mode -ne 'pscompletions') {
@@ -354,7 +466,21 @@ function Register-PackageCompletion {
     # the prompt is drawn (#212). In-runspace activation via
     # Import-PackageCompletion deliberately bypasses this -- the user
     # there is asking to register NOW, not on next idle.
-    $deferred = Format-DeferredCompletionBlock -InnerCode $resolved.Code
+    #
+    # v3 (#216): for Native sources, persist the raw payload to a
+    # sidecar `<cli>.ps1` and make the deferred body a tiny dot-source.
+    # `.ps1` files are the only place a leading `using namespace ...`
+    # parses legally; inlining the payload inside the OnIdle Action
+    # block (as v2 did) is a fatal parse error for clap/Rust completers
+    # whose first line IS `using namespace System.Management.Automation`.
+    if ($resolved.Source -eq 'Native' -and $resolved.NativePayload) {
+        $sidecarDir  = Get-PackageCompletionSidecarDirectory -ProfilePath $target -OverrideDirectory $SidecarDirectory
+        $sidecarPath = Write-PackageCompletionSidecar -Cli $Cli -Payload $resolved.NativePayload -Directory $sidecarDir
+        $innerCode = "if (Get-Command $Cli -ErrorAction SilentlyContinue) {`r`n    . '$sidecarPath'`r`n}"
+    } else {
+        $innerCode = $resolved.Code
+    }
+    $deferred = Format-DeferredCompletionBlock -InnerCode $innerCode
 
     $newContent = Set-PackageCompletionProfileBlock -Content $content -Cli $Cli -Block $deferred
     $tmp = "$target.tmp"

--- a/module/MarkMichaelis.ScoopBucket/Private/Register-PackageCompletion.ps1
+++ b/module/MarkMichaelis.ScoopBucket/Private/Register-PackageCompletion.ps1
@@ -476,7 +476,13 @@ function Register-PackageCompletion {
     if ($resolved.Source -eq 'Native' -and $resolved.NativePayload) {
         $sidecarDir  = Get-PackageCompletionSidecarDirectory -ProfilePath $target -OverrideDirectory $SidecarDirectory
         $sidecarPath = Write-PackageCompletionSidecar -Cli $Cli -Payload $resolved.NativePayload -Directory $sidecarDir
-        $innerCode = "if (Get-Command $Cli -ErrorAction SilentlyContinue) {`r`n    . '$sidecarPath'`r`n}"
+        # Single-quote the dot-source path and escape any embedded
+        # apostrophes (PowerShell single-quote strings escape `'` as
+        # `''`). Real-world install paths can contain apostrophes
+        # (e.g. drives mapped under "C:\Users\O'Brien\..."); without
+        # this the generated profile would be a parse error.
+        $escapedPath = $sidecarPath -replace "'", "''"
+        $innerCode = "if (Get-Command $Cli -ErrorAction SilentlyContinue) {`r`n    . '$escapedPath'`r`n}"
     } else {
         $innerCode = $resolved.Code
     }


### PR DESCRIPTION
## Summary

v2 inline completion blocks could crash profile parsing when a cached native payload began with `using namespace System.Management.Automation` (common in clap/Rust-derived completers). PowerShell requires `using` to be first in a script file, so inlining inside `OnIdle` action blocks was invalid and could abort downstream registration blocks.

This PR now closes that failure mode for both:
- `Register-PackageCompletion` (module path), and
- public `Register-CliCompletion` (legacy/exported path).

## Approach

- Bump sentinel to `v3`.
- For `Native` sources, persist raw payloads (verbatim, including leading `using`) to sidecar `<cli>.ps1` files under the completion sidecar directory.
- Emit a minimal deferred wrapper that dot-sources the sidecar on `PowerShell.OnIdle`.
- Escape apostrophes in generated single-quoted sidecar paths (`'` -> `''`) to avoid parse errors in paths like `O'Brien`.
- `Remove-PackageCompletionBlock` deletes matching sidecars alongside profile block removal.
- `-Force` rewrites stale v1/v2 blocks on next registration.
- Keep test sandboxes self-contained via sidecar directory inference from `-ProfilePath`.

## Tests

- Added sidecar regression tests for:
  - `using namespace`-leading payload persistence to sidecar,
  - profile parse success via child `pwsh`,
  - sidecar deletion on block removal,
  - public `Register-CliCompletion` sidecar routing,
  - apostrophe-safe dot-source path generation.
- Updated deferred-registration tests to assert sidecar dot-source behavior and v1->v3 migration semantics.
- Updated pinned sentinel assertions to `v3`.

## Evidence

Before fix, profile parse errors were reproducible with native completers that start with `using namespace ...`.

After this PR:
- no inline native payload bodies are written for affected paths,
- sidecar `.ps1` files are dot-sourced from deferred blocks,
- profile parsing remains clean, including apostrophe-containing sidecar paths.

## Files

- `module/MarkMichaelis.ScoopBucket/Private/Register-PackageCompletion.ps1` (v3 sidecar + escaped path handling)
- `module/MarkMichaelis.ScoopBucket/Private/Legacy.ps1` (public `Register-CliCompletion` routed through sidecar logic)
- `bucket/CompletionUsingNamespaceSidecar.Tests.ps1` (expanded coverage, including public-path regression)
- `bucket/CompletionDeferredRegistration.Tests.ps1` (sidecar-aware assertions)
- `bucket/CompletionPinned.Tests.ps1` (v3 sentinel assertion)
- `docs/designs/2026-05-29-completion-using-namespace-sidecar-plan.md` (design)

Co-authored-by: Copilot &lt;223556219+Copilot@users.noreply.github.com&gt;