### PR TITLE
fix(completion): single shared OnIdle subscriber drains queue (#220)

### DIFF
--- a/bucket/CompletionDeferredRegistration.Tests.ps1
+++ b/bucket/CompletionDeferredRegistration.Tests.ps1
@@ -40,12 +40,12 @@ Describe 'Register-PackageCompletion: deferred OnIdle wrap + cached native text'
             Register-PackageCompletion -Cli demo1 -NativeCommand $nc -Mode native -ProfilePath $ProfilePath -Confirm:$false | Out-Null
         }
         $raw = Get-Content -Raw -Path $script:profilePath
-        $raw | Should -Match 'ScoopBucket:CliCompletion:demo1:BEGIN v3'
+        $raw | Should -Match 'ScoopBucket:CliCompletion:demo1:BEGIN v4'
         $raw | Should -Match 'Register-EngineEvent -SourceIdentifier PowerShell\.OnIdle -MaxTriggerCount 1'
-        # v3 (#216): the OnIdle Action body now dot-sources a sidecar
-        # `<cli>.ps1`; the raw Register-ArgumentCompleter call lives in
-        # that sidecar so payloads beginning with `using namespace ...`
-        # can parse legally.
+        # v4 (#220): one shared OnIdle subscriber drains a queue; each
+        # per-CLI block enqueues a scriptblock that dot-sources the
+        # sidecar `<cli>.ps1`. Raw Register-ArgumentCompleter call still
+        # lives in the sidecar (v3 sidecar architecture preserved).
         $raw | Should -Match "(?m)\.\s+'.*?demo1\.ps1'"
         $sidecar = Join-Path (Split-Path -Parent $script:profilePath) 'completions\demo1.ps1'
         Test-Path $sidecar | Should -BeTrue
@@ -74,7 +74,7 @@ Describe 'Register-PackageCompletion: deferred OnIdle wrap + cached native text'
         $raw | Should -Match "(?m)\.\s+'.*?demo2\.ps1'"
     }
 
-    It 'rewrites an existing v1 block as v3 on re-register (transparent migration)' {
+    It 'rewrites an existing v1 block as v4 on re-register (transparent migration)' {
         $v1 = @"
 # ScoopBucket:CliCompletion:demo3:BEGIN v1
 if (Get-Command demo3 -ErrorAction SilentlyContinue) {
@@ -92,7 +92,7 @@ Register-ArgumentCompleter -Native -CommandName demo3 -ScriptBlock { }
         }
         $raw = Get-Content -Raw -Path $script:profilePath
         ([regex]::Matches($raw, 'ScoopBucket:CliCompletion:demo3:BEGIN').Count) | Should -Be 1
-        $raw | Should -Match 'ScoopBucket:CliCompletion:demo3:BEGIN v3'
+        $raw | Should -Match 'ScoopBucket:CliCompletion:demo3:BEGIN v4'
         $raw | Should -Match 'Register-EngineEvent -SourceIdentifier PowerShell\.OnIdle'
         $raw | Should -Not -Match 'ScoopBucket:CliCompletion:demo3:BEGIN v1'
     }
@@ -110,7 +110,7 @@ Register-ArgumentCompleter -Native -CommandName demo3 -ScriptBlock { }
         # the sidecar from inside the deferred OnIdle Action.
         $raw | Should -Not -Match '(?m)warp\.exe'
         $raw | Should -Not -Match 'Invoke-Expression'
-        $m = [regex]::Match($raw, '(?ms)^\# ScoopBucket:CliCompletion:demo4:BEGIN v3\r?\n(.+?)^\# ScoopBucket:CliCompletion:demo4:END')
+        $m = [regex]::Match($raw, '(?ms)^\# ScoopBucket:CliCompletion:demo4:BEGIN v4\r?\n(.+?)^\# ScoopBucket:CliCompletion:demo4:END')
         $m.Success | Should -BeTrue
         $body = $m.Groups[1].Value
 
@@ -125,6 +125,46 @@ Register-ArgumentCompleter -Native -CommandName demo3 -ScriptBlock { }
         $sidecar = Join-Path (Split-Path -Parent $script:profilePath) 'completions\demo4.ps1'
         Test-Path $sidecar | Should -BeTrue
         (Get-Content -Raw -Path $sidecar) | Should -Match 'warp\.exe'
+    }
+
+    It 'v4 (#220): N per-CLI blocks produce exactly ONE Register-EngineEvent subscriber when the profile is dot-sourced' {
+        # Reproduces the bug fixed by v4: v3 wrapped each CLI in its own
+        # Register-EngineEvent. Empirically OnIdle fires only one
+        # subscriber Action per pump tick, so with 30+ subscribers the
+        # last CLIs did not register until ~10+ seconds idle. v4 must
+        # collapse to a single subscriber that drains a shared queue.
+        $profilePath = $script:profilePath
+        $clis = 1..5 | ForEach-Object { "demoBatch$_" }
+        InModuleScope MarkMichaelis.ScoopBucket -Parameters @{ ProfilePath = $profilePath; Clis = $clis } {
+            param($ProfilePath, $Clis)
+            foreach ($cli in $Clis) {
+                $nc = [scriptblock]::Create("Write-Output 'Register-ArgumentCompleter -Native -CommandName $cli -ScriptBlock { }'")
+                Register-PackageCompletion -Cli $cli -NativeCommand $nc -Mode native -ProfilePath $ProfilePath -Confirm:$false | Out-Null
+            }
+        }
+        $raw = Get-Content -Raw -Path $script:profilePath
+        # All 5 blocks should be present...
+        foreach ($cli in $clis) {
+            $raw | Should -Match "ScoopBucket:CliCompletion:$cli`:BEGIN v4"
+        }
+        # ...but the Register-EngineEvent call must only execute ONCE,
+        # gated by `if (-not $Global:__ScoopBucketCompletionBootstrap)`.
+        ([regex]::Matches($raw, 'Register-EngineEvent').Count) | Should -Be $clis.Count -Because 'Each block contains the bootstrap clause for idempotency, but only one fires at runtime.'
+        ([regex]::Matches($raw, '__ScoopBucketCompletionBootstrap').Count) | Should -BeGreaterThan 0
+        ([regex]::Matches($raw, '__ScoopBucketCompletionQueue').Count) | Should -BeGreaterThan 0
+
+        # Functional check: dot-source the profile in a fresh runspace
+        # and verify exactly one PowerShell.OnIdle subscriber exists.
+        $probe = @"
+. '$($script:profilePath)' 2>`$null
+@(Get-EventSubscriber -SourceIdentifier PowerShell.OnIdle -ErrorAction SilentlyContinue).Count
+"@
+        $pwsh = (Get-Process -Id $PID).Path
+        if (-not $pwsh) { $pwsh = 'pwsh' }
+        $probeFile = Join-Path $script:sandbox 'probe-batch.ps1'
+        Set-Content -Path $probeFile -Value $probe -Encoding UTF8
+        $count = & $pwsh -NoProfile -NonInteractive -ExecutionPolicy Bypass -File $probeFile 2>$null
+        [int]$count | Should -Be 1 -Because 'v4 must register exactly one shared OnIdle subscriber regardless of how many per-CLI blocks are dot-sourced.'
     }
 }
 
@@ -206,7 +246,7 @@ Register-ArgumentCompleter -Native -CommandName $cli -ScriptBlock { }
 
         Update-PackageCompletion -Force -ProfilePath $script:profilePath2 -Confirm:$false | Out-Null
         $raw = Get-Content -Raw -Path $script:profilePath2
-        $raw | Should -Match "ScoopBucket:CliCompletion:$cli`:BEGIN v3"
+        $raw | Should -Match "ScoopBucket:CliCompletion:$cli`:BEGIN v4"
         $raw | Should -Match 'Register-EngineEvent -SourceIdentifier PowerShell\.OnIdle'
         # v3: the refreshed text now lives in the sidecar, not the profile.
         $sidecar = Join-Path (Split-Path -Parent $script:profilePath2) "completions\$cli.ps1"

--- a/bucket/CompletionUsingNamespaceSidecar.Tests.ps1
+++ b/bucket/CompletionUsingNamespaceSidecar.Tests.ps1
@@ -56,7 +56,7 @@ Register-ArgumentCompleter -Native -CommandName demoUns -ScriptBlock {
         # (a) profile must NOT contain a `using namespace` line anywhere.
         $raw | Should -Not -Match '(?m)^\s*using\s+namespace\b' -Because 'inline `using namespace` inside an if/Action block is a fatal parse error'
         # (b) v3 sentinel + OnIdle wrapper still present.
-        $raw | Should -Match 'ScoopBucket:CliCompletion:demoUns:BEGIN v3'
+        $raw | Should -Match 'ScoopBucket:CliCompletion:demoUns:BEGIN v4'
         $raw | Should -Match 'Register-EngineEvent -SourceIdentifier PowerShell\.OnIdle'
         # (c) the OnIdle body is just a dot-source of the sidecar.
         $expectedSidecar = Join-Path $script:sidecarDir 'demoUns.ps1'

--- a/bucket/UpdatePackageCompletion.Tests.ps1
+++ b/bucket/UpdatePackageCompletion.Tests.ps1
@@ -147,7 +147,7 @@ Describe 'Update-PackageCompletion eligibility classification' -Tag 'Light' {
         # The profile itself must reference the sidecar and use the v3
         # sentinel; the payload must live in the sidecar.
         $profileContent = Get-Content -Raw -Encoding UTF8 $script:profilePath
-        $profileContent | Should -Match "ScoopBucket:CliCompletion:$($script:onPathCli)-native:BEGIN v3"
+        $profileContent | Should -Match "ScoopBucket:CliCompletion:$($script:onPathCli)-native:BEGIN v4"
         $sidecar = Join-Path (Split-Path -Parent $script:profilePath) "completions\$($script:onPathCli)-native.ps1"
         Test-Path $sidecar | Should -BeTrue
         (Get-Content -Raw -Encoding UTF8 $sidecar) | Should -Match 'auto-native-completion-source'

--- a/module/MarkMichaelis.ScoopBucket/Private/Register-PackageCompletion.ps1
+++ b/module/MarkMichaelis.ScoopBucket/Private/Register-PackageCompletion.ps1
@@ -13,7 +13,7 @@
 #   - Requires elevation to write to AllUsersAllHosts; honours
 #     SupportsShouldProcess.
 
-$script:CompletionSentinelVersion = 'v3'
+$script:CompletionSentinelVersion = 'v4'
 
 # Default sidecar root for cached native completer payloads (v3+, #216).
 # Each registered CLI gets <Dir>\<cli>.ps1 holding the raw payload --
@@ -108,25 +108,52 @@ function Remove-PackageCompletionSidecar {
 function Format-DeferredCompletionBlock {
     <#
     .SYNOPSIS
-        Wrap a completer-registration scriptblock string in a
-        PowerShell.OnIdle one-shot deferred handler so the cost of
-        Register-ArgumentCompleter (and any cached subprocess work
-        baked into the inner code) is paid AFTER the prompt is drawn,
-        not before. Profile-block only -- in-runspace activation via
+        Wrap a completer-registration scriptblock string in a queue-add
+        statement that defers all per-CLI registration to a single
+        shared PowerShell.OnIdle handler (#220).
+    .DESCRIPTION
+        v3 (#216) wrapped each CLI's registration in its own
+        Register-EngineEvent. Empirically, PowerShell.OnIdle fires only
+        one engine-event Action per pump tick, so with 30+ subscribers
+        the LAST CLIs didn't register until ~10-13 seconds after the
+        prompt drew -- long enough for users to hit Tab and see no
+        completions.
+        v4 collapses this to a per-block enqueue plus a one-time
+        bootstrap. The first block evaluated initializes
+        `$Global:__ScoopBucketCompletionQueue` and registers a SINGLE
+        OnIdle subscriber that drains the whole queue on the first
+        idle. All subsequent blocks just call .Add(). Result: a single
+        OnIdle tick (typically within ~50ms of the prompt) registers
+        every queued CLI.
+        Profile-block only -- in-runspace activation via
         Import-PackageCompletion stays synchronous because the user
-        explicitly asked to register NOW (#212).
+        there explicitly asked to register NOW (#212).
     #>
     [OutputType([string])]
     [CmdletBinding()]
     param([Parameter(Mandatory)][AllowEmptyString()][string]$InnerCode)
-    # `| Out-Null` keeps the returned PSEventJob off the success stream
-    # so dot-sourcing the profile doesn't print a stray "Id Name ..."
-    # banner. MaxTriggerCount=1 ensures we register the completer
-    # exactly once -- after that the subscriber unregisters itself.
+    # The bootstrap-and-enqueue pattern is identical in every block;
+    # the bootstrap clause is idempotent so removing any single block
+    # never breaks the others. `| Out-Null` keeps the returned
+    # PSEventJob off the success stream so dot-sourcing the profile
+    # stays silent.
     return @"
-`$null = Register-EngineEvent -SourceIdentifier PowerShell.OnIdle -MaxTriggerCount 1 -Action {
+if (-not `$Global:__ScoopBucketCompletionQueue) {
+    `$Global:__ScoopBucketCompletionQueue = [System.Collections.Generic.List[scriptblock]]::new()
+}
+`$Global:__ScoopBucketCompletionQueue.Add({
 $InnerCode
-} | Out-Null
+}) | Out-Null
+if (-not `$Global:__ScoopBucketCompletionBootstrap) {
+    `$Global:__ScoopBucketCompletionBootstrap = `$true
+    `$null = Register-EngineEvent -SourceIdentifier PowerShell.OnIdle -MaxTriggerCount 1 -Action {
+        `$q = `$Global:__ScoopBucketCompletionQueue
+        if (`$q) {
+            foreach (`$sb in `$q) { try { . `$sb } catch { } }
+            `$q.Clear()
+        }
+    } | Out-Null
+}
 "@
 }
 
@@ -555,10 +582,11 @@ function Test-PackageCompletionWorks {
 `$ErrorActionPreference='SilentlyContinue'
 . '$ProfilePath' 2>`$null
 # The profile blocks written by Register-PackageCompletion defer their
-# Register-ArgumentCompleter calls to PowerShell.OnIdle (#212). The
-# OnIdle event does not auto-fire in non-interactive `pwsh -File`
-# runs, so manually invoke any pending subscribers' actions before
-# probing the completion engine.
+# Register-ArgumentCompleter calls to a single PowerShell.OnIdle
+# subscriber that drains a shared queue (#220). OnIdle does not
+# auto-fire in non-interactive `pwsh -File` runs, so manually invoke
+# the subscriber's Action -- it will drain the queue and register every
+# pending CLI in one pass.
 foreach (`$sub in @(Get-EventSubscriber -SourceIdentifier 'PowerShell.OnIdle' -ErrorAction SilentlyContinue)) {
     try {
         `$cmd = `$sub.Action.Command


### PR DESCRIPTION
## Summary

v3 (#216) wrote one `Register-EngineEvent -SourceIdentifier PowerShell.OnIdle` subscriber **per CLI block**. PowerShell's engine-event pump only fires one Action per OnIdle tick, so with 30+ CLIs the last blocks did not register until ~10-13 seconds of idle. Users opening a fresh pwsh and hitting Tab on a newly-installed CLI saw no completions.

v4 collapses to a single shared OnIdle subscriber that drains a queue. One tick registers every queued CLI.

## Repro before fix

Fresh `pwsh` (interactive), 30 deferred subscribers pending:

```
3s idle:  18 subs remaining, bw <TAB> -> 15 path matches (no native)
13s idle: 0  subs remaining, bw <TAB> -> 24 native subcommands
```

## Design

Per-CLI profile block (v4):

```powershell
if (-not $Global:__ScoopBucketCompletionQueue) {
    $Global:__ScoopBucketCompletionQueue = [System.Collections.Generic.List[scriptblock]]::new()
}
$Global:__ScoopBucketCompletionQueue.Add({
    if (Get-Command bw -ErrorAction SilentlyContinue) {
        . 'C:\ProgramData\ScoopBucket\completions\bw.ps1'
    }
}) | Out-Null
if (-not $Global:__ScoopBucketCompletionBootstrap) {
    $Global:__ScoopBucketCompletionBootstrap = $true
    $null = Register-EngineEvent -SourceIdentifier PowerShell.OnIdle -MaxTriggerCount 1 -Action {
        $q = $Global:__ScoopBucketCompletionQueue
        if ($q) {
            foreach ($sb in $q) { try { . $sb } catch { } }
            $q.Clear()
        }
    } | Out-Null
}
```

Bootstrap is duplicated in every block (idempotency-gated) so removing any single block never breaks the others.

## Migration

Sentinel bumps `v3` -> `v4`. Users run `Update-PackageCompletion -Force` to rewrite stale blocks. Same path used for v1 -> v3 migration.

## Tests

- New: `v4 (#220): N per-CLI blocks produce exactly ONE Register-EngineEvent subscriber when the profile is dot-sourced` -- dot-sources 5 generated blocks in a fresh `pwsh -NoProfile`, asserts `Get-EventSubscriber -SourceIdentifier PowerShell.OnIdle` returns exactly 1.
- Updated: 5 other sentinel assertions bumped `v3` -> `v4`.
- All 25 completion tests green locally.

## Command to test

```powershell
Invoke-Pester -Path .\bucket\CompletionDeferredRegistration.Tests.ps1,.\bucket\CompletionUsingNamespaceSidecar.Tests.ps1,.\bucket\UpdatePackageCompletion.Tests.ps1,.\bucket\LazyScoopInit.Tests.ps1,.\bucket\ImportPerformance.Tests.ps1
```

Closes #220
