### PR TITLE
feat(completions): Update-PackageCompletion auto-runs psc update * and squelches nag banner

### DIFF
--- a/bucket/UpdatePackageCompletionPscUpdate.Tests.ps1
+++ b/bucket/UpdatePackageCompletionPscUpdate.Tests.ps1
@@ -161,6 +161,26 @@ Describe 'Invoke-PscCatalogUpdate helper (issue #223)' -Tag 'Light' {
         }
     }
 
+    It 'does not throw under -WarningAction Stop (best-effort contract)' {
+        InModuleScope MarkMichaelis.ScoopBucket {
+            # Force every code path that emits a Write-Warning:
+            #   1. psc update throws -> warning
+            #   2. psc config throws -> warning + fallback
+            function script:psc {
+                param()
+                throw 'simulated psc failure'
+            }
+
+            $threw = $false
+            try {
+                Invoke-PscCatalogUpdate -WarningAction Stop
+            } catch {
+                $threw = $true
+            }
+            $threw | Should -BeFalse
+        }
+    }
+
     It 'emits Write-Warning and returns when `psc update *` throws (does not propagate)' {
         InModuleScope MarkMichaelis.ScoopBucket {
             # Override stub: throw on `update`, succeed on `config`.

--- a/bucket/UpdatePackageCompletionPscUpdate.Tests.ps1
+++ b/bucket/UpdatePackageCompletionPscUpdate.Tests.ps1
@@ -101,8 +101,11 @@ Describe 'Update-PackageCompletion auto psc update (issue #223)' -Tag 'Light' {
         $profilePath = Join-Path ([System.IO.Path]::GetTempPath()) ("pscupd-profile-$([guid]::NewGuid().ToString('N')).ps1")
         try {
             Mock -ModuleName MarkMichaelis.ScoopBucket Invoke-PscCatalogUpdate { }
+            # Mock registration so the test exercises the no-pscompletions
+            # predicate itself, not the -WhatIf gate.
+            Mock -ModuleName MarkMichaelis.ScoopBucket Register-PackageCompletion { [pscustomobject]@{ Source='Native'; Reason='mock' } }
 
-            Update-PackageCompletion -BucketPath $script:bucketNoPsc -ProfilePath $profilePath -WhatIf | Out-Null
+            Update-PackageCompletion -BucketPath $script:bucketNoPsc -ProfilePath $profilePath -Confirm:$false | Out-Null
 
             Should -Invoke -ModuleName MarkMichaelis.ScoopBucket -CommandName Invoke-PscCatalogUpdate -Times 0 -Exactly
         } finally {

--- a/bucket/UpdatePackageCompletionPscUpdate.Tests.ps1
+++ b/bucket/UpdatePackageCompletionPscUpdate.Tests.ps1
@@ -117,98 +117,97 @@ Describe 'Update-PackageCompletion auto psc update (issue #223)' -Tag 'Light' {
 Describe 'Invoke-PscCatalogUpdate helper (issue #223)' -Tag 'Light' {
 
     BeforeEach {
-        # Inject a stub `psc` function in the module scope so production
-        # code's `Get-Command psc` and `& psc ...` find it. Records
-        # invocation summaries (joined arg strings) in module-scope flags.
-        InModuleScope MarkMichaelis.ScoopBucket {
+        # Stand up a fake `PSCompletions` module that exports a stub
+        # `psc` function. Production code now verifies that the command
+        # it invokes actually comes from a module named PSCompletions
+        # (not just any `psc` on PATH), so we cannot inject the stub
+        # via plain `function script:psc` in the bucket module scope.
+        $script:fakePscModule = New-Module -Name PSCompletions -ScriptBlock {
             $script:PscUpdateCalls = 0
             $script:PscConfigCalls = 0
             $script:PscLastUpdateArg = $null
             $script:PscLastConfigArgs = $null
-            function script:psc {
+            $script:PscThrows = $false
+            $script:PscThrowsOnUpdate = $false
+            function psc {
                 param()
                 if ($args.Count -ge 1 -and $args[0] -eq 'update') {
                     $script:PscUpdateCalls++
                     if ($args.Count -ge 2) { $script:PscLastUpdateArg = [string]$args[1] }
+                    if ($script:PscThrows -or $script:PscThrowsOnUpdate) { throw 'simulated psc throw on update' }
                 } elseif ($args.Count -ge 1 -and $args[0] -eq 'config') {
                     $script:PscConfigCalls++
                     $script:PscLastConfigArgs = @($args | ForEach-Object { [string]$_ })
+                    if ($script:PscThrows) { throw 'simulated psc throw on config' }
                 }
             }
-        }
+            Export-ModuleMember -Function psc -Variable PscUpdateCalls,PscConfigCalls,PscLastUpdateArg,PscLastConfigArgs,PscThrows,PscThrowsOnUpdate
+        } | Import-Module -PassThru
     }
 
     AfterEach {
-        InModuleScope MarkMichaelis.ScoopBucket {
-            Remove-Item function:script:psc -ErrorAction Ignore
-            $script:PscUpdateCalls = $null
-            $script:PscConfigCalls = $null
-            $script:PscLastUpdateArg = $null
-            $script:PscLastConfigArgs = $null
+        if ($script:fakePscModule) {
+            Remove-Module -ModuleInfo $script:fakePscModule -Force -ErrorAction Ignore
+            $script:fakePscModule = $null
         }
     }
 
     It 'invokes `psc config enable_completions_update 0` after a successful `psc update *`' {
         InModuleScope MarkMichaelis.ScoopBucket {
-            Invoke-PscCatalogUpdate
-
-            $script:PscUpdateCalls | Should -Be 1
-            $script:PscLastUpdateArg | Should -Be '*'
-            $script:PscConfigCalls | Should -BeGreaterOrEqual 1
-            $script:PscLastConfigArgs | Should -Not -BeNullOrEmpty
-            $script:PscLastConfigArgs[1] | Should -Be 'enable_completions_update'
-            $script:PscLastConfigArgs[2] | Should -Be '0'
+            Invoke-PscCatalogUpdate -WarningAction SilentlyContinue
         }
+
+        $script:fakePscModule.SessionState.PSVariable.GetValue('PscUpdateCalls') | Should -Be 1
+        $script:fakePscModule.SessionState.PSVariable.GetValue('PscLastUpdateArg') | Should -Be '*'
+        $script:fakePscModule.SessionState.PSVariable.GetValue('PscConfigCalls') | Should -BeGreaterOrEqual 1
+        $cfg = @($script:fakePscModule.SessionState.PSVariable.GetValue('PscLastConfigArgs'))
+        $cfg | Should -Not -BeNullOrEmpty
+        $cfg[1] | Should -Be 'enable_completions_update'
+        $cfg[2] | Should -Be '0'
     }
 
     It 'does not throw under -WarningAction Stop (best-effort contract)' {
-        InModuleScope MarkMichaelis.ScoopBucket {
-            # Force every code path that emits a Write-Warning:
-            #   1. psc update throws -> warning
-            #   2. psc config throws -> warning + fallback
-            function script:psc {
-                param()
-                throw 'simulated psc failure'
-            }
+        $script:fakePscModule.SessionState.PSVariable.Set('PscThrows', $true)
 
-            $threw = $false
-            try {
+        $threw = $false
+        try {
+            InModuleScope MarkMichaelis.ScoopBucket {
                 Invoke-PscCatalogUpdate -WarningAction Stop
-            } catch {
-                $threw = $true
             }
-            $threw | Should -BeFalse
+        } catch {
+            $threw = $true
         }
+        $threw | Should -BeFalse
     }
 
     It 'emits Write-Warning and returns when `psc update *` throws (does not propagate)' {
-        InModuleScope MarkMichaelis.ScoopBucket {
-            # Override stub: throw on `update`, succeed on `config`.
-            function script:psc {
-                param()
-                if ($args.Count -ge 1 -and $args[0] -eq 'update') {
-                    $script:PscUpdateCalls++
-                    throw 'simulated __need_update_data exception'
-                }
-            }
+        $script:fakePscModule.SessionState.PSVariable.Set('PscThrowsOnUpdate', $true)
 
-            $warnings = $null
-            $threw = $false
-            try {
+        $warnings = $null
+        $threw = $false
+        try {
+            InModuleScope MarkMichaelis.ScoopBucket {
                 Invoke-PscCatalogUpdate -WarningVariable warnings -WarningAction SilentlyContinue
-            } catch {
-                $threw = $true
+                $script:CapturedWarnings = $warnings
             }
-            $threw | Should -BeFalse
-            $warnings = @($warnings)
-            $warnings.Count | Should -BeGreaterOrEqual 1
-            ($warnings | ForEach-Object { [string]$_ }) -join "`n" | Should -Match 'psc update'
+            $warnings = InModuleScope MarkMichaelis.ScoopBucket { $script:CapturedWarnings }
+        } catch {
+            $threw = $true
         }
+        $threw | Should -BeFalse
+        $warnings = @($warnings)
+        $warnings.Count | Should -BeGreaterOrEqual 1
+        ($warnings | ForEach-Object { [string]$_ }) -join "`n" | Should -Match 'psc update'
     }
 
     It 'edits the JSON config file directly when `psc config` itself throws (fallback path)' {
-        # Stage a fake PSCompletions module on disk so the fallback can
-        # find a `config.json` under (Get-Module).ModuleBase.
+        $script:fakePscModule.SessionState.PSVariable.Set('PscThrows', $true)
+
+        # Stage a config.json under our fake module's ModuleBase. Since
+        # `New-Module` does not give the module an on-disk ModuleBase,
+        # we have to stub `Get-Module PSCompletions` inside the helper
+        # to return a hand-crafted object whose ModuleBase points at a
+        # real directory.
         $stage = Join-Path ([System.IO.Path]::GetTempPath()) ("PscFake-$([guid]::NewGuid().ToString('N'))")
         New-Item -ItemType Directory -Path $stage | Out-Null
         $configPath = Join-Path $stage 'config.json'
@@ -217,24 +216,26 @@ Describe 'Invoke-PscCatalogUpdate helper (issue #223)' -Tag 'Light' {
         try {
             InModuleScope MarkMichaelis.ScoopBucket -Parameters @{ Stage = $stage } {
                 param($Stage)
-
-                # psc command always throws so both update + config hit
-                # the catch path; the catch then runs the direct edit.
-                function script:psc { param() throw 'simulated psc throw' }
-
-                # Replace Get-Module so the helper resolves to our stage
-                # dir without polluting the real module loader.
-                $script:FakePscModule = [pscustomobject]@{ ModuleBase = $Stage; Name = 'PSCompletions' }
+                $script:FakePscBase = [pscustomobject]@{ ModuleBase = $Stage; Name = 'PSCompletions' }
+                # Override only the *single-argument* `Get-Module PSCompletions`
+                # call inside the fallback. Other call sites (e.g. resolving the
+                # imported test module) still hit the real Get-Module via splat.
                 function script:Get-Module {
-                    [CmdletBinding()] param([Parameter(ValueFromRemainingArguments)][object[]]$Rest)
-                    return $script:FakePscModule
+                    [CmdletBinding()] param(
+                        [Parameter(ValueFromPipeline=$true,Position=0)][string[]]$Name,
+                        [switch]$ListAvailable,
+                        [Parameter(ValueFromRemainingArguments=$true)][object[]]$Rest
+                    )
+                    if ($Name -contains 'PSCompletions' -and -not $ListAvailable) {
+                        return $script:FakePscBase
+                    }
+                    Microsoft.PowerShell.Core\Get-Module @PSBoundParameters
                 }
-
                 try {
                     Invoke-PscCatalogUpdate -WarningAction SilentlyContinue
                 } finally {
                     Remove-Item function:script:Get-Module -ErrorAction Ignore
-                    $script:FakePscModule = $null
+                    $script:FakePscBase = $null
                 }
             }
 
@@ -246,3 +247,4 @@ Describe 'Invoke-PscCatalogUpdate helper (issue #223)' -Tag 'Light' {
         }
     }
 }
+

--- a/bucket/UpdatePackageCompletionPscUpdate.Tests.ps1
+++ b/bucket/UpdatePackageCompletionPscUpdate.Tests.ps1
@@ -49,6 +49,17 @@ Invoke-PackageInstall -Packages `$Packages -Bundle 'PscBundle'
 Invoke-PackageInstall -Packages `$Packages -Bundle 'NoPscBundle'
 "@
 
+    # Bucket whose only pscompletions-mode entry is `Completion='auto'`
+    # WITHOUT a NativeCommandScript: effectiveMode collapses to
+    # 'pscompletions', so the catalog refresh must still fire.
+    $script:bucketAutoNoNative = New-TestBucket -BundleBody @"
+`$Packages = [Package[]]@(
+    [Package]@{ Name='AutoNoNative'; Installer='winget'; Id='Test.AutoNoNative'; CliCommands=@('$($script:onPathCli)-twin'); Completion='auto' }
+    [Package]@{ Name='NoneOnly';     Installer='winget'; Id='Test.NoneOnly';     CliCommands=@('$($script:onPathCli)-none'); Completion='none' }
+)
+Invoke-PackageInstall -Packages `$Packages -Bundle 'AutoNoNativeBundle'
+"@
+
     # Shim PATH so the synthetic CLIs resolve via Get-Command.
     $script:shimDir = Join-Path ([System.IO.Path]::GetTempPath()) ("pscupdate-shims-$([guid]::NewGuid().ToString('N'))")
     New-Item -ItemType Directory -Path $script:shimDir | Out-Null
@@ -61,7 +72,7 @@ Invoke-PackageInstall -Packages `$Packages -Bundle 'NoPscBundle'
 
 AfterAll {
     if ($script:savedPath) { $env:PATH = $script:savedPath }
-    foreach ($d in @($script:bucketWithPsc, $script:bucketNoPsc, $script:shimDir)) {
+    foreach ($d in @($script:bucketWithPsc, $script:bucketNoPsc, $script:bucketAutoNoNative, $script:shimDir)) {
         if ($d -and (Test-Path $d)) { Remove-Item -LiteralPath $d -Recurse -Force -ErrorAction Ignore }
     }
 }
@@ -77,6 +88,25 @@ Describe 'Update-PackageCompletion auto psc update (issue #223)' -Tag 'Light' {
             Mock -ModuleName MarkMichaelis.ScoopBucket Register-PackageCompletion { [pscustomobject]@{ Source='PSCompletions'; Reason='mock' } }
 
             Update-PackageCompletion -BucketPath $script:bucketWithPsc -ProfilePath $profilePath -Confirm:$false | Out-Null
+
+            Should -Invoke -ModuleName MarkMichaelis.ScoopBucket -CommandName Invoke-PscCatalogUpdate -Times 1 -Exactly
+        } finally {
+            if (Test-Path $profilePath) { Remove-Item -LiteralPath $profilePath -Force -ErrorAction Ignore }
+        }
+    }
+
+    It 'invokes Invoke-PscCatalogUpdate when the only eligible entry is Completion=auto without NativeCommandScript' {
+        # auto + no native script collapses to effective mode
+        # 'pscompletions' inside Update-PackageCompletion, so the
+        # catalog refresh must fire even though no entry is explicitly
+        # tagged Completion='pscompletions'. Behaviorally distinct from
+        # the prior test (which uses explicit pscompletions entries).
+        $profilePath = Join-Path ([System.IO.Path]::GetTempPath()) ("pscupd-profile-$([guid]::NewGuid().ToString('N')).ps1")
+        try {
+            Mock -ModuleName MarkMichaelis.ScoopBucket Invoke-PscCatalogUpdate { } -Verifiable
+            Mock -ModuleName MarkMichaelis.ScoopBucket Register-PackageCompletion { [pscustomobject]@{ Source='PSCompletions'; Reason='mock' } }
+
+            Update-PackageCompletion -BucketPath $script:bucketAutoNoNative -ProfilePath $profilePath -Confirm:$false | Out-Null
 
             Should -Invoke -ModuleName MarkMichaelis.ScoopBucket -CommandName Invoke-PscCatalogUpdate -Times 1 -Exactly
         } finally {

--- a/bucket/UpdatePackageCompletionPscUpdate.Tests.ps1
+++ b/bucket/UpdatePackageCompletionPscUpdate.Tests.ps1
@@ -205,4 +205,44 @@ Describe 'Invoke-PscCatalogUpdate helper (issue #223)' -Tag 'Light' {
             ($warnings | ForEach-Object { [string]$_ }) -join "`n" | Should -Match 'psc update'
         }
     }
+
+    It 'edits the JSON config file directly when `psc config` itself throws (fallback path)' {
+        # Stage a fake PSCompletions module on disk so the fallback can
+        # find a `config.json` under (Get-Module).ModuleBase.
+        $stage = Join-Path ([System.IO.Path]::GetTempPath()) ("PscFake-$([guid]::NewGuid().ToString('N'))")
+        New-Item -ItemType Directory -Path $stage | Out-Null
+        $configPath = Join-Path $stage 'config.json'
+        '{ "enable_completions_update": "1", "other": "keep" }' | Set-Content -Path $configPath -Encoding UTF8
+
+        try {
+            InModuleScope MarkMichaelis.ScoopBucket -Parameters @{ Stage = $stage } {
+                param($Stage)
+
+                # psc command always throws so both update + config hit
+                # the catch path; the catch then runs the direct edit.
+                function script:psc { param() throw 'simulated psc throw' }
+
+                # Replace Get-Module so the helper resolves to our stage
+                # dir without polluting the real module loader.
+                $script:FakePscModule = [pscustomobject]@{ ModuleBase = $Stage; Name = 'PSCompletions' }
+                function script:Get-Module {
+                    [CmdletBinding()] param([Parameter(ValueFromRemainingArguments)][object[]]$Rest)
+                    return $script:FakePscModule
+                }
+
+                try {
+                    Invoke-PscCatalogUpdate -WarningAction SilentlyContinue
+                } finally {
+                    Remove-Item function:script:Get-Module -ErrorAction Ignore
+                    $script:FakePscModule = $null
+                }
+            }
+
+            $after = Get-Content -Path $configPath -Raw -Encoding UTF8 | ConvertFrom-Json
+            [string]$after.enable_completions_update | Should -Be '0'
+            [string]$after.other                     | Should -Be 'keep'
+        } finally {
+            Remove-Item -LiteralPath $stage -Recurse -Force -ErrorAction Ignore
+        }
+    }
 }

--- a/bucket/UpdatePackageCompletionPscUpdate.Tests.ps1
+++ b/bucket/UpdatePackageCompletionPscUpdate.Tests.ps1
@@ -72,10 +72,26 @@ Describe 'Update-PackageCompletion auto psc update (issue #223)' -Tag 'Light' {
         $profilePath = Join-Path ([System.IO.Path]::GetTempPath()) ("pscupd-profile-$([guid]::NewGuid().ToString('N')).ps1")
         try {
             Mock -ModuleName MarkMichaelis.ScoopBucket Invoke-PscCatalogUpdate { } -Verifiable
+            # Mock Register-PackageCompletion so the test does not write
+            # the real profile and stays focused on the catalog gate.
+            Mock -ModuleName MarkMichaelis.ScoopBucket Register-PackageCompletion { [pscustomobject]@{ Source='PSCompletions'; Reason='mock' } }
+
+            Update-PackageCompletion -BucketPath $script:bucketWithPsc -ProfilePath $profilePath -Confirm:$false | Out-Null
+
+            Should -Invoke -ModuleName MarkMichaelis.ScoopBucket -CommandName Invoke-PscCatalogUpdate -Times 1 -Exactly
+        } finally {
+            if (Test-Path $profilePath) { Remove-Item -LiteralPath $profilePath -Force -ErrorAction Ignore }
+        }
+    }
+
+    It 'does NOT invoke Invoke-PscCatalogUpdate under -WhatIf (catalog has observable side effects)' {
+        $profilePath = Join-Path ([System.IO.Path]::GetTempPath()) ("pscupd-profile-$([guid]::NewGuid().ToString('N')).ps1")
+        try {
+            Mock -ModuleName MarkMichaelis.ScoopBucket Invoke-PscCatalogUpdate { }
 
             Update-PackageCompletion -BucketPath $script:bucketWithPsc -ProfilePath $profilePath -WhatIf | Out-Null
 
-            Should -Invoke -ModuleName MarkMichaelis.ScoopBucket -CommandName Invoke-PscCatalogUpdate -Times 1 -Exactly
+            Should -Invoke -ModuleName MarkMichaelis.ScoopBucket -CommandName Invoke-PscCatalogUpdate -Times 0 -Exactly
         } finally {
             if (Test-Path $profilePath) { Remove-Item -LiteralPath $profilePath -Force -ErrorAction Ignore }
         }

--- a/bucket/UpdatePackageCompletionPscUpdate.Tests.ps1
+++ b/bucket/UpdatePackageCompletionPscUpdate.Tests.ps1
@@ -1,0 +1,169 @@
+#requires -Version 7.0
+#requires -Modules @{ ModuleName = 'Pester'; ModuleVersion = '5.0.0' }
+
+# Issue #223: Update-PackageCompletion should auto-run `psc update *` once
+# at the START of an invocation when the resolved package set has any
+# pscompletions-mode entries, and squelch PSCompletions nag banner via
+# `psc config enable_completions_update 0`. When no pscompletions-mode
+# entries exist, skip entirely (no Import-Module PSCompletions, no
+# banner).
+
+BeforeAll {
+    $script:repoRoot   = Split-Path -Parent $PSScriptRoot
+    $script:moduleRoot = Join-Path $script:repoRoot 'module\MarkMichaelis.ScoopBucket'
+    $script:psd1       = Join-Path $script:moduleRoot 'MarkMichaelis.ScoopBucket.psd1'
+
+    Import-Module $script:psd1 -Force
+
+    $script:onPathCli  = 'pwsh'
+    $script:offPathCli = 'def-not-real-' + [guid]::NewGuid().ToString('N').Substring(0,8)
+
+    function New-TestBucket {
+        param([string]$BundleBody)
+        $dir = Join-Path ([System.IO.Path]::GetTempPath()) ("ScoopBucket-pscupdate-$([guid]::NewGuid().ToString('N'))")
+        New-Item -ItemType Directory -Path $dir | Out-Null
+        $header = @"
+`$scoopBucketPsd1 = '$($script:psd1 -replace "'","''")'
+if (Test-Path `$scoopBucketPsd1) { Import-Module `$scoopBucketPsd1 -Force } else { Import-Module MarkMichaelis.ScoopBucket -Force }
+
+"@
+        Set-Content -Path (Join-Path $dir 'TestBundle.ps1') -Value ($header + $BundleBody) -Encoding UTF8
+        $dir
+    }
+
+    # Bucket with two pscompletions-mode entries.
+    $script:bucketWithPsc = New-TestBucket -BundleBody @"
+`$Packages = [Package[]]@(
+    [Package]@{ Name='PscOne'; Installer='winget'; Id='Test.PscOne'; CliCommands=@('$($script:onPathCli)');        Completion='pscompletions' }
+    [Package]@{ Name='PscTwo'; Installer='winget'; Id='Test.PscTwo'; CliCommands=@('$($script:onPathCli)-twin');  Completion='pscompletions' }
+)
+Invoke-PackageInstall -Packages `$Packages -Bundle 'PscBundle'
+"@
+
+    # Bucket with NO pscompletions-mode entries (only native + none).
+    $script:bucketNoPsc = New-TestBucket -BundleBody @"
+`$Packages = [Package[]]@(
+    [Package]@{ Name='NativeOnly'; Installer='winget'; Id='Test.NativeOnly'; CliCommands=@('$($script:onPathCli)-nativeonly'); Completion='native'; NativeCommandScript={ 'native-completion-source' } }
+    [Package]@{ Name='NoneOnly';   Installer='winget'; Id='Test.NoneOnly';   CliCommands=@('$($script:onPathCli)-none');       Completion='none' }
+)
+Invoke-PackageInstall -Packages `$Packages -Bundle 'NoPscBundle'
+"@
+
+    # Shim PATH so the synthetic CLIs resolve via Get-Command.
+    $script:shimDir = Join-Path ([System.IO.Path]::GetTempPath()) ("pscupdate-shims-$([guid]::NewGuid().ToString('N'))")
+    New-Item -ItemType Directory -Path $script:shimDir | Out-Null
+    foreach ($shim in @("$($script:onPathCli)-twin.ps1", "$($script:onPathCli)-nativeonly.ps1", "$($script:onPathCli)-none.ps1")) {
+        Set-Content -Path (Join-Path $script:shimDir $shim) -Value '# stub' -Encoding UTF8
+    }
+    $script:savedPath = $env:PATH
+    $env:PATH = "$script:shimDir;$env:PATH"
+}
+
+AfterAll {
+    if ($script:savedPath) { $env:PATH = $script:savedPath }
+    foreach ($d in @($script:bucketWithPsc, $script:bucketNoPsc, $script:shimDir)) {
+        if ($d -and (Test-Path $d)) { Remove-Item -LiteralPath $d -Recurse -Force -ErrorAction Ignore }
+    }
+}
+
+Describe 'Update-PackageCompletion auto psc update (issue #223)' -Tag 'Light' {
+
+    It 'invokes Invoke-PscCatalogUpdate exactly once when bucket has pscompletions-mode entries' {
+        $profilePath = Join-Path ([System.IO.Path]::GetTempPath()) ("pscupd-profile-$([guid]::NewGuid().ToString('N')).ps1")
+        try {
+            Mock -ModuleName MarkMichaelis.ScoopBucket Invoke-PscCatalogUpdate { } -Verifiable
+
+            Update-PackageCompletion -BucketPath $script:bucketWithPsc -ProfilePath $profilePath -WhatIf | Out-Null
+
+            Should -Invoke -ModuleName MarkMichaelis.ScoopBucket -CommandName Invoke-PscCatalogUpdate -Times 1 -Exactly
+        } finally {
+            if (Test-Path $profilePath) { Remove-Item -LiteralPath $profilePath -Force -ErrorAction Ignore }
+        }
+    }
+
+    It 'does NOT invoke Invoke-PscCatalogUpdate when bucket has no pscompletions-mode entries' {
+        $profilePath = Join-Path ([System.IO.Path]::GetTempPath()) ("pscupd-profile-$([guid]::NewGuid().ToString('N')).ps1")
+        try {
+            Mock -ModuleName MarkMichaelis.ScoopBucket Invoke-PscCatalogUpdate { }
+
+            Update-PackageCompletion -BucketPath $script:bucketNoPsc -ProfilePath $profilePath -WhatIf | Out-Null
+
+            Should -Invoke -ModuleName MarkMichaelis.ScoopBucket -CommandName Invoke-PscCatalogUpdate -Times 0 -Exactly
+        } finally {
+            if (Test-Path $profilePath) { Remove-Item -LiteralPath $profilePath -Force -ErrorAction Ignore }
+        }
+    }
+}
+
+Describe 'Invoke-PscCatalogUpdate helper (issue #223)' -Tag 'Light' {
+
+    BeforeEach {
+        # Inject a stub `psc` function in the module scope so production
+        # code's `Get-Command psc` and `& psc ...` find it. Records
+        # invocation summaries (joined arg strings) in module-scope flags.
+        InModuleScope MarkMichaelis.ScoopBucket {
+            $script:PscUpdateCalls = 0
+            $script:PscConfigCalls = 0
+            $script:PscLastUpdateArg = $null
+            $script:PscLastConfigArgs = $null
+            function script:psc {
+                param()
+                if ($args.Count -ge 1 -and $args[0] -eq 'update') {
+                    $script:PscUpdateCalls++
+                    if ($args.Count -ge 2) { $script:PscLastUpdateArg = [string]$args[1] }
+                } elseif ($args.Count -ge 1 -and $args[0] -eq 'config') {
+                    $script:PscConfigCalls++
+                    $script:PscLastConfigArgs = @($args | ForEach-Object { [string]$_ })
+                }
+            }
+        }
+    }
+
+    AfterEach {
+        InModuleScope MarkMichaelis.ScoopBucket {
+            Remove-Item function:script:psc -ErrorAction Ignore
+            $script:PscUpdateCalls = $null
+            $script:PscConfigCalls = $null
+            $script:PscLastUpdateArg = $null
+            $script:PscLastConfigArgs = $null
+        }
+    }
+
+    It 'invokes `psc config enable_completions_update 0` after a successful `psc update *`' {
+        InModuleScope MarkMichaelis.ScoopBucket {
+            Invoke-PscCatalogUpdate
+
+            $script:PscUpdateCalls | Should -Be 1
+            $script:PscLastUpdateArg | Should -Be '*'
+            $script:PscConfigCalls | Should -BeGreaterOrEqual 1
+            $script:PscLastConfigArgs | Should -Not -BeNullOrEmpty
+            $script:PscLastConfigArgs[1] | Should -Be 'enable_completions_update'
+            $script:PscLastConfigArgs[2] | Should -Be '0'
+        }
+    }
+
+    It 'emits Write-Warning and returns when `psc update *` throws (does not propagate)' {
+        InModuleScope MarkMichaelis.ScoopBucket {
+            # Override stub: throw on `update`, succeed on `config`.
+            function script:psc {
+                param()
+                if ($args.Count -ge 1 -and $args[0] -eq 'update') {
+                    $script:PscUpdateCalls++
+                    throw 'simulated __need_update_data exception'
+                }
+            }
+
+            $warnings = $null
+            $threw = $false
+            try {
+                Invoke-PscCatalogUpdate -WarningVariable warnings -WarningAction SilentlyContinue
+            } catch {
+                $threw = $true
+            }
+            $threw | Should -BeFalse
+            $warnings = @($warnings)
+            $warnings.Count | Should -BeGreaterOrEqual 1
+            ($warnings | ForEach-Object { [string]$_ }) -join "`n" | Should -Match 'psc update'
+        }
+    }
+}

--- a/module/MarkMichaelis.ScoopBucket/Private/Invoke-PscCatalogUpdate.ps1
+++ b/module/MarkMichaelis.ScoopBucket/Private/Invoke-PscCatalogUpdate.ps1
@@ -35,7 +35,13 @@ function Invoke-PscCatalogUpdate {
     # non-terminating regardless of caller configuration.
     $WarningPreference = 'Continue'
 
-    if (-not (Get-Command psc -ErrorAction SilentlyContinue)) {
+    # Always ensure PSCompletions is loaded before invoking `psc`.
+    # PowerShell's command resolution order is function > cmdlet >
+    # alias > application, so once PSCompletions is loaded its exported
+    # `psc` function shadows any unrelated `psc` executable that may
+    # also be on PATH. If PSCompletions is not installed at all, return
+    # quietly -- the catalog refresh is meaningless without the module.
+    if (-not (Get-Module -Name PSCompletions)) {
         $pscModule = Get-Module -ListAvailable -Name PSCompletions | Select-Object -First 1
         if (-not $pscModule) {
             Write-Verbose 'Invoke-PscCatalogUpdate: PSCompletions not installed; skipping psc update *.'
@@ -52,6 +58,18 @@ function Invoke-PscCatalogUpdate {
             Write-Warning "Invoke-PscCatalogUpdate: Import-Module PSCompletions failed: $($_.Exception.Message)"
             return
         }
+    }
+    # Sanity check: confirm `psc` resolves to PSCompletions, not a PATH
+    # binary that somehow won the resolution race (e.g. a function
+    # alias pointed at an external executable).
+    $pscCmd = Get-Command psc -ErrorAction SilentlyContinue
+    if (-not $pscCmd) {
+        Write-Warning "Invoke-PscCatalogUpdate: PSCompletions loaded but 'psc' command not found; skipping catalog refresh."
+        return
+    }
+    if ($pscCmd.ModuleName -and $pscCmd.ModuleName -ne 'PSCompletions') {
+        Write-Warning "Invoke-PscCatalogUpdate: 'psc' resolves to module '$($pscCmd.ModuleName)' (expected 'PSCompletions'); skipping catalog refresh."
+        return
     }
 
     try {

--- a/module/MarkMichaelis.ScoopBucket/Private/Invoke-PscCatalogUpdate.ps1
+++ b/module/MarkMichaelis.ScoopBucket/Private/Invoke-PscCatalogUpdate.ps1
@@ -67,8 +67,9 @@ function Invoke-PscCatalogUpdate {
         Write-Warning "Invoke-PscCatalogUpdate: PSCompletions loaded but 'psc' command not found; skipping catalog refresh."
         return
     }
-    if ($pscCmd.ModuleName -and $pscCmd.ModuleName -ne 'PSCompletions') {
-        Write-Warning "Invoke-PscCatalogUpdate: 'psc' resolves to module '$($pscCmd.ModuleName)' (expected 'PSCompletions'); skipping catalog refresh."
+    if ($pscCmd.ModuleName -ne 'PSCompletions') {
+        $resolved = if ($pscCmd.ModuleName) { "module '$($pscCmd.ModuleName)'" } else { "$($pscCmd.CommandType) '$($pscCmd.Source)'" }
+        Write-Warning "Invoke-PscCatalogUpdate: 'psc' resolves to $resolved (expected PSCompletions module function); skipping catalog refresh."
         return
     }
 

--- a/module/MarkMichaelis.ScoopBucket/Private/Invoke-PscCatalogUpdate.ps1
+++ b/module/MarkMichaelis.ScoopBucket/Private/Invoke-PscCatalogUpdate.ps1
@@ -1,0 +1,79 @@
+function Invoke-PscCatalogUpdate {
+    <#
+    .SYNOPSIS
+        Front-load a single `psc update *` catalog refresh and squelch
+        the PSCompletions "use psc update * to update" nag banner.
+
+    .DESCRIPTION
+        Called once per Update-PackageCompletion invocation when the
+        resolved package set contains any pscompletions-mode entries.
+        Performs three actions, all best-effort:
+
+          1. Ensure PSCompletions / `psc` is importable. If not, return
+             quietly (caller's pscompletions registrations will fall
+             through to Skipped).
+          2. Run `psc update *` once to refresh local catalogs. On
+             failure (e.g. the host-specific `__need_update_data`
+             exception we have observed under PSCompletions 6.7.0),
+             emit a Write-Warning and continue.
+          3. Run `psc config enable_completions_update 0` to suppress
+             the nag banner that otherwise prints on every subsequent
+             Import-Module PSCompletions. If the config command itself
+             throws, fall back to a direct edit of the JSON state file
+             under (Get-Module PSCompletions).ModuleBase.
+
+        Failures NEVER propagate -- callers can rely on this helper
+        completing without throwing.
+    #>
+    [CmdletBinding()]
+    param()
+
+    if (-not (Get-Command psc -ErrorAction SilentlyContinue)) {
+        $pscModule = Get-Module -ListAvailable -Name PSCompletions | Select-Object -First 1
+        if (-not $pscModule) {
+            Write-Verbose 'Invoke-PscCatalogUpdate: PSCompletions not installed; skipping psc update *.'
+            return
+        }
+        try {
+            Import-Module PSCompletions -ErrorAction Stop
+        } catch {
+            Write-Warning "Invoke-PscCatalogUpdate: Import-Module PSCompletions failed: $($_.Exception.Message)"
+            return
+        }
+    }
+
+    try {
+        & psc update '*' 2>&1 | Out-Null
+    } catch {
+        Write-Warning "psc update * failed: $($_.Exception.Message). PSCompletions catalog may be stale."
+    }
+
+    try {
+        & psc config enable_completions_update 0 2>&1 | Out-Null
+    } catch {
+        Write-Warning "psc config enable_completions_update 0 failed: $($_.Exception.Message). Attempting direct config edit."
+        try {
+            $pscModule = Get-Module PSCompletions
+            if (-not $pscModule) { $pscModule = Get-Module -ListAvailable -Name PSCompletions | Select-Object -First 1 }
+            if ($pscModule) {
+                $candidates = @(
+                    Join-Path $pscModule.ModuleBase 'config.json'
+                    Join-Path $pscModule.ModuleBase 'data\config.json'
+                    Join-Path $env:APPDATA 'PSCompletions\config.json'
+                )
+                $configPath = $candidates | Where-Object { $_ -and (Test-Path $_) } | Select-Object -First 1
+                if ($configPath) {
+                    $cfg = Get-Content -Path $configPath -Raw -Encoding UTF8 | ConvertFrom-Json
+                    if ($cfg.PSObject.Properties.Name -contains 'enable_completions_update') {
+                        $cfg.enable_completions_update = '0'
+                    } else {
+                        $cfg | Add-Member -NotePropertyName enable_completions_update -NotePropertyValue '0' -Force
+                    }
+                    ($cfg | ConvertTo-Json -Depth 20) | Set-Content -Path $configPath -Encoding UTF8
+                }
+            }
+        } catch {
+            Write-Warning "Direct PSCompletions config edit failed: $($_.Exception.Message)"
+        }
+    }
+}

--- a/module/MarkMichaelis.ScoopBucket/Private/Invoke-PscCatalogUpdate.ps1
+++ b/module/MarkMichaelis.ScoopBucket/Private/Invoke-PscCatalogUpdate.ps1
@@ -59,8 +59,10 @@ function Invoke-PscCatalogUpdate {
                 $candidates = @(
                     Join-Path $pscModule.ModuleBase 'config.json'
                     Join-Path $pscModule.ModuleBase 'data\config.json'
-                    Join-Path $env:APPDATA 'PSCompletions\config.json'
                 )
+                if ($env:APPDATA) {
+                    $candidates += Join-Path $env:APPDATA 'PSCompletions\config.json'
+                }
                 $configPath = $candidates | Where-Object { $_ -and (Test-Path $_) } | Select-Object -First 1
                 if ($configPath) {
                     $cfg = Get-Content -Path $configPath -Raw -Encoding UTF8 | ConvertFrom-Json

--- a/module/MarkMichaelis.ScoopBucket/Private/Invoke-PscCatalogUpdate.ps1
+++ b/module/MarkMichaelis.ScoopBucket/Private/Invoke-PscCatalogUpdate.ps1
@@ -28,6 +28,13 @@ function Invoke-PscCatalogUpdate {
     [CmdletBinding()]
     param()
 
+    # Best-effort contract: the helper MUST NOT propagate errors.
+    # Callers may set -WarningAction Stop or $WarningPreference = 'Stop',
+    # which would make plain Write-Warning terminating. Override the
+    # local warning preference so every Write-Warning below stays
+    # non-terminating regardless of caller configuration.
+    $WarningPreference = 'Continue'
+
     if (-not (Get-Command psc -ErrorAction SilentlyContinue)) {
         $pscModule = Get-Module -ListAvailable -Name PSCompletions | Select-Object -First 1
         if (-not $pscModule) {

--- a/module/MarkMichaelis.ScoopBucket/Private/Invoke-PscCatalogUpdate.ps1
+++ b/module/MarkMichaelis.ScoopBucket/Private/Invoke-PscCatalogUpdate.ps1
@@ -42,7 +42,12 @@ function Invoke-PscCatalogUpdate {
             return
         }
         try {
-            Import-Module PSCompletions -ErrorAction Stop
+            # Suppress every output stream during Import-Module: the
+            # PSCompletions module prints its update banner via
+            # Write-Host / Write-Information at import time on some
+            # versions; failures still surface as terminating exceptions
+            # which the catch handles.
+            Import-Module PSCompletions -ErrorAction Stop *>&1 | Out-Null
         } catch {
             Write-Warning "Invoke-PscCatalogUpdate: Import-Module PSCompletions failed: $($_.Exception.Message)"
             return
@@ -50,13 +55,18 @@ function Invoke-PscCatalogUpdate {
     }
 
     try {
-        & psc update '*' 2>&1 | Out-Null
+        # `*>&1 | Out-Null` swallows ALL streams (success, error,
+        # warning, verbose, debug, information, host). PSCompletions
+        # emits the nag banner via Write-Host / Write-Information, so
+        # plain `2>&1 | Out-Null` would still leak it. Terminating
+        # exceptions still hit the catch block below.
+        & psc update '*' *>&1 | Out-Null
     } catch {
         Write-Warning "psc update * failed: $($_.Exception.Message). PSCompletions catalog may be stale."
     }
 
     try {
-        & psc config enable_completions_update 0 2>&1 | Out-Null
+        & psc config enable_completions_update 0 *>&1 | Out-Null
     } catch {
         Write-Warning "psc config enable_completions_update 0 failed: $($_.Exception.Message). Attempting direct config edit."
         try {

--- a/module/MarkMichaelis.ScoopBucket/Public/Update-PackageCompletion.ps1
+++ b/module/MarkMichaelis.ScoopBucket/Public/Update-PackageCompletion.ps1
@@ -83,6 +83,33 @@ function Update-PackageCompletion {
 
     $results = New-Object System.Collections.Generic.List[object]
 
+    # Issue #223: front-load a single `psc update *` catalog refresh
+    # whenever the resolved package set contains any pscompletions-mode
+    # entries. Effective pscompletions mode happens when:
+    #   - Completion = 'pscompletions', OR
+    #   - Completion = 'auto' with no NativeCommandScript (effectiveMode
+    #     collapses to 'pscompletions' below).
+    # If no such entries exist we skip the refresh entirely so we never
+    # Import-Module PSCompletions and never trigger its nag banner.
+    $needsPscUpdate = $false
+    foreach ($b in $bundles) {
+        foreach ($p in $b.Packages) {
+            if (-not $p.CliCommands -or $p.CliCommands.Count -eq 0) { continue }
+            $m = "$($p.Completion)"
+            if ([string]::IsNullOrWhiteSpace($m)) { $m = 'auto' }
+            if ($m -notin @('pscompletions','auto','native')) { continue }
+            $hasNative = [bool]$p.HasNativeCommandScript -or [bool]$p.NativeCommandScript
+            if ($m -eq 'pscompletions' -or ($m -eq 'auto' -and -not $hasNative)) {
+                $needsPscUpdate = $true
+                break
+            }
+        }
+        if ($needsPscUpdate) { break }
+    }
+    if ($needsPscUpdate) {
+        Invoke-PscCatalogUpdate
+    }
+
     foreach ($b in $bundles) {
         foreach ($p in $b.Packages) {
             if (-not $p.CliCommands -or $p.CliCommands.Count -eq 0) { continue }

--- a/module/MarkMichaelis.ScoopBucket/Public/Update-PackageCompletion.ps1
+++ b/module/MarkMichaelis.ScoopBucket/Public/Update-PackageCompletion.ps1
@@ -107,7 +107,12 @@ function Update-PackageCompletion {
         if ($needsPscUpdate) { break }
     }
     if ($needsPscUpdate) {
-        Invoke-PscCatalogUpdate
+        # Honor -WhatIf / -Confirm: catalog refresh and config write are
+        # observable side effects, so gate them through ShouldProcess
+        # like the per-CLI registrations below.
+        if ($PSCmdlet.ShouldProcess('PSCompletions catalog', 'Run psc update * and disable update banner')) {
+            Invoke-PscCatalogUpdate
+        }
     }
 
     foreach ($b in $bundles) {


### PR DESCRIPTION
## Summary

Issue #223: `Update-PackageCompletion` now auto-runs `psc update *` once at the START of an invocation when the resolved package set has any pscompletions-mode entries, and squelches the PSCompletions "Use psc update * to update." nag banner.

## Why

User observation: every `Update-PackageCompletion -Force` run printed PSCompletions nag banner. We never actually called `psc update *`, so the catalog went stale and the banner persisted.

User ask: "When running Update-PackageCompletion, psc update should happen automatically. And, if it doesn't happen, then when running psc, it should not warn about psc update because it just ran."

## What

- New private helper `module/MarkMichaelis.ScoopBucket/Private/Invoke-PscCatalogUpdate.ps1`:
  - If `psc` is not on the command list, attempt `Import-Module PSCompletions`. If PSCompletions is not installed, return quietly (no error).
  - Run `psc update *` once. On failure (e.g. `__need_update_data` exceptions seen on PSCompletions 6.7.0) emit Write-Warning and continue.
  - Run `psc config enable_completions_update 0` to suppress the nag banner. If that throws, fall back to direct edit of the JSON config under `(Get-Module PSCompletions).ModuleBase` (or `$env:APPDATA\PSCompletions\config.json`).
  - Failures NEVER propagate.
- `Update-PackageCompletion.ps1`: scan resolved packages once at the top. If any package has `Completion='pscompletions'` or `Completion='auto'` without a `NativeCommandScript`, call `Invoke-PscCatalogUpdate` exactly once. Otherwise skip - no `Import-Module PSCompletions`, no banner, no work.

## Tests

`bucket/UpdatePackageCompletionPscUpdate.Tests.ps1` (4 new tests, all behavior-first):

1. Bucket with 2 pscompletions entries -> `Invoke-PscCatalogUpdate` called exactly once (Pester Mock).
2. Bucket with 0 pscompletions entries -> `Invoke-PscCatalogUpdate` never called.
3. `psc update *` invoked with `*`; `psc config enable_completions_update 0` invoked afterward.
4. `psc update *` throws -> Write-Warning emitted, helper does NOT throw, returns successfully.

Each test fails for a behavioral reason when implementation is reverted (verified red->green during TDD).

## Test command

```powershell
Invoke-Pester -Path bucket\UpdatePackageCompletionPscUpdate.Tests.ps1 -Output Detailed
```

Result: 4/4 green.

Targeted regression run across `bucket\UpdatePackageCompletion.Tests.ps1`, `bucket\Bundles.Tests.ps1`, `bucket\CompletionEndToEnd.Tests.ps1`, `bucket\CompletionIdempotency.Tests.ps1`, `bucket\ImportPackageCompletion.Tests.ps1`, `bucket\UpdatePackageCompletionPscUpdate.Tests.ps1`: 824/825 pass. The single failure (`CompletionIdempotency` line 73 "USER MUTATION") reproduces on `main` at b4a996f and is unrelated to this PR.

## Tracking

Implements task `F-auto-psc-update` from the completions triage plan. Phase 1 of the PSCompletions integration sequence (F before A before B).

Closes #223