### PR TITLE
refactor(bucket): remove duplicate Node.js entry from DeveloperBasePackages

### DIFF
--- a/bucket/AIAgents.json
+++ b/bucket/AIAgents.json
@@ -1,6 +1,6 @@
 {
     "$schema": "https://raw.githubusercontent.com/lukesampson/scoop/master/schema.json",
-    "version": "1.20.000",
+    "version": "1.21.000",
     "url": [
         "https://raw.githubusercontent.com/MarkMichaelis/ScoopBucket/master/bucket/AIAgents.ps1"
     ],

--- a/bucket/AIAgents.ps1
+++ b/bucket/AIAgents.ps1
@@ -28,6 +28,13 @@ $Packages = [Package[]]@(
     # Runtime prerequisites first so MCP-server entries written below
     # actually resolve at agent start-up. DependsOn pulls these in
     # transitively when -Name selects an agent.
+    #
+    # AIAgents is the AUTHORITATIVE completion source for node/npm/npx
+    # across every bundle in this repo. The hand-curated NativeCommandScript
+    # below registers all three CLIs uniformly. Do NOT add a Node.js entry
+    # to any other bundle (e.g. DeveloperBasePackages) -- a duplicate
+    # would write a competing profile block for the same CLIs and the
+    # registration outcome would become order-dependent. See issue #222.
     [Package]@{
         Name        = 'Node.js'
         Installer   = 'choco'

--- a/bucket/Bundles.Tests.ps1
+++ b/bucket/Bundles.Tests.ps1
@@ -333,6 +333,42 @@ Describe 'Specific cross-bundle placement contracts' -Tag 'Light','Bundle' {
         $collisions | Should -BeNullOrEmpty -Because "within-bundle CLI duplicates: $(($collisions | ForEach-Object { "$($_.Bundle):$($_.Cli) -> $($_.Packages -join '+')" }) -join '; ')"
     }
 
+    It 'node, npm, and npx are claimed as a completion source by exactly one bundle entry' {
+        # Regression guard for issue #222: a stale Node.js entry in
+        # DeveloperBasePackages declared CliCommands=@('node','npm') with
+        # Completion='pscompletions' while AIAgents already owns
+        # node/npm/npx via Completion='auto' + a hand-curated
+        # NativeCommandScript. With the resolver chicken-and-egg masking
+        # the pscompletions branch the duplication was inert today, but
+        # once that resolver bug is fixed both entries would write
+        # profile blocks for the same CLIs and the outcome becomes
+        # order-dependent.
+        #
+        # Some CLIs (e.g. 'code', 'devenv') are *intentionally* declared
+        # in more than one bundle because the Visual Studio install
+        # workflow needs them visible from multiple bundles. Those are
+        # validated by their own dedicated tests. Here we narrowly
+        # assert the node/npm/npx ownership contract: AIAgents alone
+        # owns the Node.js runtime CLIs because it ships the only
+        # NativeCommandScript that registers all three uniformly.
+        $targets = @('node','npm','npx')
+        $ownership = @{}
+        foreach ($p in $script:allPkgs) {
+            $mode = if ($p.Completion) { [string]$p.Completion } else { '' }
+            if ([string]::IsNullOrWhiteSpace($mode) -or $mode -eq 'none') { continue }
+            foreach ($cli in @($p.CliCommands)) {
+                if ($targets -notcontains $cli) { continue }
+                if (-not $ownership.ContainsKey($cli)) { $ownership[$cli] = @() }
+                $ownership[$cli] += "$($p.Bundle)/$($p.Name)[$mode]"
+            }
+        }
+        foreach ($cli in $targets) {
+            $claimers = @($ownership[$cli])
+            $claimers.Count | Should -Be 1 -Because "exactly one bundle entry must claim '$cli' as a completion source; got: $($claimers -join ', ')"
+            $claimers[0] | Should -BeLike 'AIAgents/Node.js*' -Because "AIAgents is the authoritative source for node/npm/npx completion (see comment near the AIAgents.ps1 Node.js entry)"
+        }
+    }
+
     It 'Claude Desktop is owned by the AIAgents bundle' {
         $script:byBundle.AIAgents.Name           | Should -Contain 'Claude Desktop'
         $script:byBundle.ClientBasePackages.Name | Should -Not -Contain 'Claude Desktop'

--- a/bucket/DeveloperBasePackages.json
+++ b/bucket/DeveloperBasePackages.json
@@ -1,6 +1,6 @@
 {
     "$schema": "https://raw.githubusercontent.com/lukesampson/scoop/master/schema.json",
-    "version": "1.21.000",
+    "version": "1.22.000",
     "url": [
         "https://raw.githubusercontent.com/MarkMichaelis/ScoopBucket/master/bucket/DeveloperBasePackages.ps1"
     ],

--- a/bucket/DeveloperBasePackages.ps1
+++ b/bucket/DeveloperBasePackages.ps1
@@ -7,18 +7,6 @@ if (Test-Path $scoopBucketPsd1) { Import-Module $scoopBucketPsd1 -Force } else {
 
 $Packages = [Package[]]@(
     [Package]@{
-        Name        = 'Node.js'
-        Installer   = 'choco'
-        Id          = 'nodejs'
-        CliCommands = @('node','npm')
-        Completion  = 'pscompletions'
-        ExpectedCompletions = @{
-            node = @('--help','--version','--eval')
-            npm  = @('install','run','version')
-        }
-    }
-
-    [Package]@{
         Name        = 'dotnet'
         Installer   = 'scoop'
         Id          = 'main/dotnet'


### PR DESCRIPTION
## Summary

Removes the stale duplicate `Node.js` entry from `bucket\DeveloperBasePackages.ps1` and marks `bucket\AIAgents.ps1` as the authoritative source for `node`/`npm`/`npx` completion across every bundle in this repo.

## Problem

`bucket\AIAgents.ps1` declares Node.js with `Completion='auto'` plus a hand-curated `NativeCommandScript` that registers completions for `node`, `npm`, and `npx` uniformly. This works today.

`bucket\DeveloperBasePackages.ps1` ALSO declared a Node.js entry, but with `Completion='pscompletions'` and no `NativeCommandScript`. It was a stale duplicate. Today it is masked by the resolver chicken-and-egg (Issue A) which causes pscompletions-mode entries to return `Skipped` when the catalog entry is not yet locally installed. Once Issue A is fixed, both entries would write profile blocks for the same CLIs and the registration outcome would become order-dependent / non-deterministic.

## Fix

1. Removed the duplicate Node.js entry from `bucket\DeveloperBasePackages.ps1` (12 lines).
2. Added a 6-line comment block above the Node.js entry in `bucket\AIAgents.ps1` declaring it the authoritative cross-bundle owner of `node`/`npm`/`npx` completion, with a pointer to this issue.
3. Added a behavior-first cross-bundle test in `bucket\Bundles.Tests.ps1` that asserts: across ALL bundles, exactly one entry claims `node`, `npm`, or `npx` as a completion source, and that the sole claimer is `AIAgents/Node.js`.

## Behavior-first test

The new test in `bucket\Bundles.Tests.ps1` is the regression guard. When the duplicate entry is restored, the test fails with a behavioral message:

```
[-] node, npm, and npx are claimed as a completion source by exactly one bundle entry
   Expected 1, because exactly one bundle entry must claim 'node' as a
   completion source; got: AIAgents/Node.js[auto],
   DeveloperBasePackages/Node.js[pscompletions], but got 2.
```

After the fix:

```
[+] node, npm, and npx are claimed as a completion source by exactly one bundle entry
Tests Passed: 1, Failed: 0
```

## Cross-check

Searched `bucket\` and `module\` for references to the DeveloperBasePackages Node.js entry specifically. Nothing depends on it. `ManifestInstall.Tests.ps1`, `UninstallPackage.Tests.ps1`, and `PackageInstall.Tests.ps1` reference `'npm'` only as a generic CLI string in mock filters; none reference the bundle-specific entry.

## Tests run locally

`Invoke-Pester` over eight bundle/package-related test files:

```
Tests Passed: 873, Failed: 0, Skipped: 1, Inconclusive: 0, NotRun: 0
```

Files exercised: `Bundles.Tests.ps1`, `Package.Tests.ps1`, `PackageOrder.Tests.ps1`, `InstallPackageFilter.Tests.ps1`, `AIAgents.Tests.ps1`, `ClientBasePackages.Tests.ps1`, `OSBasePackagesCompanions.Tests.ps1`, `PackageNameCompletion.Tests.ps1`.

## Out of scope

- Issue A (resolver chicken-and-egg).
- Issue C (PSReadLine `buffer` error).
- Migrating other `Completion='pscompletions'` entries to native scripts.

Closes #222

Co-authored-by: Copilot <copilot@github.com>