### PR TITLE
fix(completions): Resolve-PackageCompletionSource auto-runs psc add when catalog entry missing

### DIFF
--- a/bucket/ResolvePscAdd.Tests.ps1
+++ b/bucket/ResolvePscAdd.Tests.ps1
@@ -95,20 +95,21 @@ Describe 'Resolve-PackageCompletionSource auto psc add (issue #226)' -Tag 'Light
         $script:fakePscModule.SessionState.PSVariable.Set('PscAddSucceeds', $false)
         $script:fakePscModule.SessionState.PSVariable.Set('PscAddThrows',   $true)
 
-        $warnings = $null
-        $result = InModuleScope MarkMichaelis.ScoopBucket {
-            Resolve-PackageCompletionSource -Cli 'unobtainium' -PreferPSCompletions -WarningVariable w -WarningAction SilentlyContinue
-            $script:CapturedW = $w
+        # Single invocation: capture both result and warnings together
+        # so PscAddCalls reflects exactly one resolver call (no doubled
+        # side effects) and so the result/warnings asserted are the
+        # same ones produced by that call (no risk of masking a
+        # regression on the first invocation).
+        $captured = InModuleScope MarkMichaelis.ScoopBucket {
+            $r = Resolve-PackageCompletionSource -Cli 'unobtainium' -PreferPSCompletions -WarningVariable w -WarningAction SilentlyContinue
+            [pscustomobject]@{ Result = $r; Warnings = $w }
         }
-        $warnings = InModuleScope MarkMichaelis.ScoopBucket { $script:CapturedW }
-        $result   = InModuleScope MarkMichaelis.ScoopBucket {
-            Resolve-PackageCompletionSource -Cli 'unobtainium' -PreferPSCompletions -WarningAction SilentlyContinue
-        }
+        $result   = $captured.Result
+        $warnings = @($captured.Warnings)
 
         $result.Source | Should -Be 'Skipped'
         $result.Reason | Should -Match 'psc add'
-        $script:fakePscModule.SessionState.PSVariable.GetValue('PscAddCalls') | Should -BeGreaterOrEqual 1
-        $warnings = @($warnings)
+        $script:fakePscModule.SessionState.PSVariable.GetValue('PscAddCalls') | Should -Be 1
         $warnings.Count | Should -BeGreaterOrEqual 1
         ($warnings | ForEach-Object { [string]$_ }) -join "`n" | Should -Match 'psc add'
     }
@@ -129,5 +130,39 @@ Describe 'Resolve-PackageCompletionSource auto psc add (issue #226)' -Tag 'Light
         } 6>&1 | Out-String
 
         $captured | Should -Not -Match ([regex]::Escape($banner))
+    }
+
+    It 'T5: emits exactly one Write-Warning when psc add fails (no duplicate noise)' {
+        $script:fakePscModule.SessionState.PSVariable.Set('PscAddSucceeds', $false)
+        $script:fakePscModule.SessionState.PSVariable.Set('PscAddThrows',   $true)
+
+        $warnings = InModuleScope MarkMichaelis.ScoopBucket {
+            $null = Resolve-PackageCompletionSource -Cli 'unobtainium-once' -PreferPSCompletions -WarningVariable w -WarningAction SilentlyContinue
+            $w
+        }
+        @($warnings).Count | Should -Be 1
+    }
+
+    It 'T6: does not propagate when caller sets -WarningAction Stop ($WarningPreference=Stop)' {
+        # If the resolver did not pin its own $WarningPreference to
+        # 'Continue', a caller passing -WarningAction Stop would turn
+        # the inner Write-Warning into a terminating exception that
+        # short-circuits the function and drops to the bottom Skipped
+        # return WITHOUT a Reason -- regressing the new diagnostic.
+        $script:fakePscModule.SessionState.PSVariable.Set('PscAddSucceeds', $false)
+        $script:fakePscModule.SessionState.PSVariable.Set('PscAddThrows',   $true)
+
+        $threw = $false
+        $result = $null
+        try {
+            $result = InModuleScope MarkMichaelis.ScoopBucket {
+                Resolve-PackageCompletionSource -Cli 'unobtainium-stop' -PreferPSCompletions -WarningAction Stop
+            }
+        } catch {
+            $threw = $true
+        }
+        $threw          | Should -BeFalse
+        $result.Source  | Should -Be 'Skipped'
+        $result.Reason  | Should -Match 'psc add'
     }
 }

--- a/bucket/ResolvePscAdd.Tests.ps1
+++ b/bucket/ResolvePscAdd.Tests.ps1
@@ -1,0 +1,133 @@
+#requires -Version 7.0
+#requires -Modules @{ ModuleName = 'Pester'; ModuleVersion = '5.0.0' }
+
+<#
+.SYNOPSIS
+    Issue #226: Resolve-PackageCompletionSource auto-runs `psc add` when
+    the requested CLI is absent from the local PSCompletions catalog.
+
+    Before this fix the resolver checked `psc list` (LOCAL catalog) and
+    returned 'Skipped' on a miss -- the downstream `psc add` block was
+    therefore unreachable. These tests pin the corrected order:
+
+      list miss -> psc add -> list re-check -> Source decision.
+#>
+
+BeforeAll {
+    $script:repoRoot   = Split-Path -Parent $PSScriptRoot
+    $script:moduleRoot = Join-Path $script:repoRoot 'module\MarkMichaelis.ScoopBucket'
+    $script:psd1       = Join-Path $script:moduleRoot 'MarkMichaelis.ScoopBucket.psd1'
+
+    Import-Module $script:psd1 -Force
+}
+
+Describe 'Resolve-PackageCompletionSource auto psc add (issue #226)' -Tag 'Light' {
+
+    BeforeEach {
+        # Fresh fake PSCompletions module per test so the in-process
+        # state machine (PscListEntries, PscAddCalls, PscAddSucceeds,
+        # PscAddThrows) starts from a known baseline. The production
+        # resolver verifies `psc.ModuleName -eq 'PSCompletions'`, so we
+        # cannot just inject a script-scoped function -- it must come
+        # from a module literally named PSCompletions.
+        $script:fakePscModule = New-Module -Name PSCompletions -ScriptBlock {
+            $script:PscListEntries  = @()      # CLI names visible to `psc list`
+            $script:PscAddCalls     = 0
+            $script:PscLastAddArg   = $null
+            $script:PscAddSucceeds  = $true    # if true, add appends to PscListEntries
+            $script:PscAddThrows    = $false
+            $script:PscAddBanner    = $null    # written via Write-Host -- must NOT leak
+
+            function psc {
+                param()
+                if ($args.Count -ge 1 -and $args[0] -eq 'list') {
+                    foreach ($e in $script:PscListEntries) { $e }
+                    return
+                }
+                if ($args.Count -ge 1 -and $args[0] -eq 'add') {
+                    $script:PscAddCalls++
+                    if ($args.Count -ge 2) { $script:PscLastAddArg = [string]$args[1] }
+                    if ($script:PscAddBanner) { Write-Host $script:PscAddBanner }
+                    if ($script:PscAddThrows) { throw 'simulated psc add throw' }
+                    if ($script:PscAddSucceeds -and $args.Count -ge 2) {
+                        $script:PscListEntries = @($script:PscListEntries) + [string]$args[1]
+                    }
+                    return
+                }
+            }
+            Export-ModuleMember -Function psc -Variable PscListEntries,PscAddCalls,PscLastAddArg,PscAddSucceeds,PscAddThrows,PscAddBanner
+        } | Import-Module -PassThru
+    }
+
+    AfterEach {
+        if ($script:fakePscModule) {
+            Remove-Module -ModuleInfo $script:fakePscModule -Force -ErrorAction Ignore
+            $script:fakePscModule = $null
+        }
+    }
+
+    It 'T1: catalog miss + psc add succeeds -> Source=PSCompletions (not Skipped)' {
+        # Initial PscListEntries = @() so `psc list` is empty for this CLI.
+        $script:fakePscModule.SessionState.PSVariable.Set('PscAddSucceeds', $true)
+
+        $result = InModuleScope MarkMichaelis.ScoopBucket {
+            Resolve-PackageCompletionSource -Cli 'dotnet' -PreferPSCompletions
+        }
+
+        $result.Source | Should -Be 'PSCompletions'
+        $result.PSCompletionsName | Should -Be 'dotnet'
+        $script:fakePscModule.SessionState.PSVariable.GetValue('PscAddCalls') | Should -Be 1
+        $script:fakePscModule.SessionState.PSVariable.GetValue('PscLastAddArg') | Should -Be 'dotnet'
+    }
+
+    It 'T2: catalog already present -> psc add is NOT invoked (no-op fast path)' {
+        $script:fakePscModule.SessionState.PSVariable.Set('PscListEntries', @('python'))
+
+        $result = InModuleScope MarkMichaelis.ScoopBucket {
+            Resolve-PackageCompletionSource -Cli 'python' -PreferPSCompletions
+        }
+
+        $result.Source | Should -Be 'PSCompletions'
+        $script:fakePscModule.SessionState.PSVariable.GetValue('PscAddCalls') | Should -Be 0
+    }
+
+    It 'T3: catalog miss + psc add fails -> Source=Skipped, Reason mentions `psc add`, Write-Warning emitted' {
+        $script:fakePscModule.SessionState.PSVariable.Set('PscAddSucceeds', $false)
+        $script:fakePscModule.SessionState.PSVariable.Set('PscAddThrows',   $true)
+
+        $warnings = $null
+        $result = InModuleScope MarkMichaelis.ScoopBucket {
+            Resolve-PackageCompletionSource -Cli 'unobtainium' -PreferPSCompletions -WarningVariable w -WarningAction SilentlyContinue
+            $script:CapturedW = $w
+        }
+        $warnings = InModuleScope MarkMichaelis.ScoopBucket { $script:CapturedW }
+        $result   = InModuleScope MarkMichaelis.ScoopBucket {
+            Resolve-PackageCompletionSource -Cli 'unobtainium' -PreferPSCompletions -WarningAction SilentlyContinue
+        }
+
+        $result.Source | Should -Be 'Skipped'
+        $result.Reason | Should -Match 'psc add'
+        $script:fakePscModule.SessionState.PSVariable.GetValue('PscAddCalls') | Should -BeGreaterOrEqual 1
+        $warnings = @($warnings)
+        $warnings.Count | Should -BeGreaterOrEqual 1
+        ($warnings | ForEach-Object { [string]$_ }) -join "`n" | Should -Match 'psc add'
+    }
+
+    It 'T4: psc add invocation redirects all streams (banner does not leak to host)' {
+        # PscAddBanner triggers Write-Host inside the fake `psc add`.
+        # Production code must use `*>&1 | Out-Null` (or equivalent) so
+        # the banner never reaches the caller's pipeline / host stream.
+        $banner = "PSC-ADD-BANNER-$([guid]::NewGuid().ToString('N'))"
+        $script:fakePscModule.SessionState.PSVariable.Set('PscAddBanner', $banner)
+        $script:fakePscModule.SessionState.PSVariable.Set('PscAddSucceeds', $true)
+
+        # 6>&1 lifts Information/Host stream into success so we can
+        # inspect it. If the resolver swallowed it correctly, the
+        # banner string will be absent from $captured.
+        $captured = InModuleScope MarkMichaelis.ScoopBucket {
+            Resolve-PackageCompletionSource -Cli 'leakcheck' -PreferPSCompletions -WarningAction SilentlyContinue
+        } 6>&1 | Out-String
+
+        $captured | Should -Not -Match ([regex]::Escape($banner))
+    }
+}

--- a/module/MarkMichaelis.ScoopBucket/Private/Invoke-PscCatalogUpdate.ps1
+++ b/module/MarkMichaelis.ScoopBucket/Private/Invoke-PscCatalogUpdate.ps1
@@ -68,9 +68,18 @@ function Invoke-PscCatalogUpdate {
         return
     }
     if ($pscCmd.ModuleName -ne 'PSCompletions') {
-        $resolved = if ($pscCmd.ModuleName) { "module '$($pscCmd.ModuleName)'" } else { "$($pscCmd.CommandType) '$($pscCmd.Source)'" }
-        Write-Warning "Invoke-PscCatalogUpdate: 'psc' resolves to $resolved (expected PSCompletions module function); skipping catalog refresh."
-        return
+        # PSCompletions actually exports `psc` as an Alias -> Function
+        # PSCompletions (whose ModuleName is 'PSCompletions'); follow
+        # the alias chain so the ownership guard matches reality.
+        $resolvedCmd = $pscCmd
+        while ($resolvedCmd -and $resolvedCmd.CommandType -eq 'Alias' -and $resolvedCmd.ResolvedCommand) {
+            $resolvedCmd = $resolvedCmd.ResolvedCommand
+        }
+        if (-not ($resolvedCmd -and $resolvedCmd.ModuleName -eq 'PSCompletions')) {
+            $resolved = if ($pscCmd.ModuleName) { "module '$($pscCmd.ModuleName)'" } else { "$($pscCmd.CommandType) '$($pscCmd.Source)'" }
+            Write-Warning "Invoke-PscCatalogUpdate: 'psc' resolves to $resolved (expected PSCompletions module function); skipping catalog refresh."
+            return
+        }
     }
 
     try {

--- a/module/MarkMichaelis.ScoopBucket/Private/Register-PackageCompletion.ps1
+++ b/module/MarkMichaelis.ScoopBucket/Private/Register-PackageCompletion.ps1
@@ -213,12 +213,69 @@ function Resolve-PackageCompletionSource {
         }
     }
 
-    $pscModule = Get-Module -ListAvailable -Name PSCompletions | Select-Object -First 1
+    $pscModule = Get-Module -Name PSCompletions
+    if (-not $pscModule) {
+        $pscModule = Get-Module -ListAvailable -Name PSCompletions | Select-Object -First 1
+    }
     if ($pscModule) {
         try {
-            Import-Module PSCompletions -ErrorAction Stop
-            $listOutput = & psc list 2>$null | Out-String
-            if ($listOutput -match "(?im)^\s*$([regex]::Escape($Cli))(\s|$)") {
+            if (-not (Get-Module -Name PSCompletions)) {
+                # Suppress every output stream during Import-Module:
+                # PSCompletions prints its update banner via
+                # Write-Host / Write-Information at import time on
+                # some versions. Plain `2>&1 | Out-Null` would still
+                # leak it.
+                Import-Module PSCompletions -ErrorAction Stop *>&1 | Out-Null
+            }
+            # Confirm `psc` resolves to a command from the
+            # PSCompletions module -- not an unrelated executable on
+            # PATH that happened to win command resolution. PSCompletions
+            # actually exports `psc` as an Alias -> Function PSCompletions
+            # (whose ModuleName is 'PSCompletions'); follow the alias
+            # chain so the ownership check matches reality.
+            $pscCmd = Get-Command psc -ErrorAction SilentlyContinue
+            $resolvedCmd = $pscCmd
+            while ($resolvedCmd -and $resolvedCmd.CommandType -eq 'Alias' -and $resolvedCmd.ResolvedCommand) {
+                $resolvedCmd = $resolvedCmd.ResolvedCommand
+            }
+            if ($resolvedCmd -and $resolvedCmd.ModuleName -eq 'PSCompletions') {
+                $pattern = "(?im)^\s*$([regex]::Escape($Cli))(\s|$)"
+                $listOutput = & psc list 2>$null | Out-String
+                $hasEntry   = $listOutput -match $pattern
+
+                if (-not $hasEntry) {
+                    # Issue #226: previously the resolver returned
+                    # 'Skipped' on a list miss, leaving the upstream
+                    # PSCompletions catalog entry unfetched. Attempt
+                    # `psc add <Cli>` first so declared
+                    # Completion='pscompletions' CLIs get their
+                    # catalog entry pulled on demand. Failures must
+                    # NEVER propagate.
+                    $addFailureReason = $null
+                    try {
+                        # `*>&1 | Out-Null` swallows ALL streams
+                        # (success, error, warning, verbose, debug,
+                        # information, host). PSCompletions emits
+                        # download / banner chatter via Write-Host;
+                        # plain `2>&1 | Out-Null` would still leak it.
+                        & psc add $Cli *>&1 | Out-Null
+                    } catch {
+                        $addFailureReason = $_.Exception.Message
+                        Write-Warning "psc add ${Cli} threw: $addFailureReason"
+                    }
+                    $listOutput = & psc list 2>$null | Out-String
+                    $hasEntry   = $listOutput -match $pattern
+                    if (-not $hasEntry) {
+                        $reason = if ($addFailureReason) {
+                            "psc add ${Cli} failed: $addFailureReason"
+                        } else {
+                            "psc add ${Cli} did not populate the local catalog (entry missing from PSCompletions upstream catalog)."
+                        }
+                        Write-Warning "Resolve-PackageCompletionSource: $reason"
+                        return @{ Source = 'Skipped'; Code = $null; PSCompletionsName = $null; Reason = $reason }
+                    }
+                }
+
                 $code = "if (Get-Command psc -ErrorAction SilentlyContinue) {`r`n    Import-Module PSCompletions -ErrorAction SilentlyContinue`r`n}"
                 return @{ Source = 'PSCompletions'; Code = $code; PSCompletionsName = $Cli }
             }
@@ -454,12 +511,14 @@ function Register-PackageCompletion {
     }
 
     if ($resolved.Source -eq 'Skipped') {
-        $reason = if ($NativeCommand) {
+        $reason = if ($resolved.Reason) {
+            $resolved.Reason
+        } elseif ($NativeCommand) {
             "Native command produced no output for '$Cli' and PSCompletions has no catalog entry."
         } else {
             "No -NativeCommand supplied and PSCompletions has no catalog entry for '$Cli'."
         }
-        if ($NativeCommand -and $Mode -ne 'pscompletions') {
+        if ($NativeCommand -and $Mode -ne 'pscompletions' -and -not $resolved.Reason) {
             Write-Warning "Register-PackageCompletion: $reason"
         }
         return [pscustomobject]@{

--- a/module/MarkMichaelis.ScoopBucket/Private/Register-PackageCompletion.ps1
+++ b/module/MarkMichaelis.ScoopBucket/Private/Register-PackageCompletion.ps1
@@ -195,6 +195,16 @@ function Resolve-PackageCompletionSource {
         [switch]$PreferPSCompletions
     )
 
+    # The PSCompletions branch below emits Write-Warning on `psc add`
+    # failures. Callers that pass -WarningAction Stop or set
+    # $WarningPreference='Stop' would otherwise turn those warnings
+    # into terminating exceptions, short-circuiting the try/catch and
+    # dropping us into the bottom Skipped return WITHOUT a Reason
+    # (which regresses the new diagnostic). Force non-terminating
+    # warnings for the duration of this function -- same pattern as
+    # Invoke-PscCatalogUpdate.
+    $WarningPreference = 'Continue'
+
     if ($NativeCommand -and -not $PreferPSCompletions) {
         $native = $null
         # Pass $Cli so multi-CLI packages (e.g. Sysinternals Suite) can emit
@@ -260,8 +270,14 @@ function Resolve-PackageCompletionSource {
                         # plain `2>&1 | Out-Null` would still leak it.
                         & psc add $Cli *>&1 | Out-Null
                     } catch {
+                        # Capture the failure but defer the Write-Warning
+                        # until AFTER the re-check, so success-after-throw
+                        # (rare but possible if `psc add` partially
+                        # populated the catalog before throwing) does not
+                        # surface a misleading warning, and conversely a
+                        # genuine failure produces exactly one warning
+                        # rather than two.
                         $addFailureReason = $_.Exception.Message
-                        Write-Warning "psc add ${Cli} threw: $addFailureReason"
                     }
                     $listOutput = & psc list 2>$null | Out-String
                     $hasEntry   = $listOutput -match $pattern


### PR DESCRIPTION
## Summary

Closes #226. Final Phase 1 issue (after #221, #224, #225).

Resolve-PackageCompletionSource previously checked the LOCAL PSCompletions catalog (`psc list`) first and returned `Source='Skipped'` on a miss -- the downstream `psc add ` block was therefore unreachable. Declared `Completion='pscompletions'` CLIs (dotnet, python, wt, 7z, ffmpeg) never had their upstream catalog entries pulled, even though they exist at `abgox/PSCompletions/completions/`.

## Fix

Invert the resolver:

1. `psc list` -> fast-path return `PSCompletions` if entry present.
2. Else `psc add ` (all streams swallowed via `*>&1 | Out-Null` so PSCompletions banner chatter does not leak to host).
3. Re-check `psc list`. If now present -> return `PSCompletions`; if still absent -> return `Skipped` with a `Reason` mentioning `psc add` and emit one `Write-Warning`. Failures NEVER propagate.

Plumb `\.Reason` through `Register-PackageCompletion` so callers see the precise psc-add diagnosis instead of the generic "no catalog entry" string.

## Drive-by fix discovered during real-host verification

PSCompletions 6.7.0 actually exports `psc` as `Alias -> Function PSCompletions` (CommandType=Alias, ModuleName empty). The strict ownership guard `pscCmd.ModuleName -eq 'PSCompletions'` rejected real `psc`. The same defect existed in `Invoke-PscCatalogUpdate` from PR #224 -- meaning Issue F's catalog refresh helper would have been silently dormant in real (non-mock) use too. Both call sites now follow the alias chain via `\.ResolvedCommand` before checking `ModuleName`.

## Tests

New `bucket/ResolvePscAdd.Tests.ps1` (Tag 'Light'):

| # | Behavior pinned |
|---|---|
| T1 | list miss + `psc add` succeeds -> Source=PSCompletions |
| T2 | list hit -> `psc add` NOT invoked (no-op fast path) |
| T3 | list miss + `psc add` throws -> Source=Skipped, Reason matches /psc add/, Write-Warning emitted |
| T4 | banner from `psc add` does not leak to host (full-stream redirect) |

Each test fails for a behavioral reason if the production fix is reverted (T1 returned 'Skipped'; T3 returned an empty Reason).

Focused suite (the four files most exercised by this change):

```
Tests Passed: 24, Failed: 0, Skipped: 0
```

The two pre-existing failures elsewhere in `bucket\` (`CompletionPinned` 'uses sentinel version v3' and `CompletionIdempotency` '-Force:false preserves a manually-modified block') reproduce on `main` and are unrelated to this PR. They look like stale fallout from PR #221's sentinel bump to v4.

## Real-host verification

Captured by invoking `Resolve-PackageCompletionSource` directly against PSCompletions 6.7.0 on the agent host. Real `Update-PackageCompletion -Force` is gated by an elevation check that the agent context cannot satisfy; the resolver is the surface the bug lives on.

```
=== Get-Command psc ===
psc  Alias  ModuleName=''  -> Resolved: PSCompletions Function ModuleName='PSCompletions'

=== psc list BEFORE ===
Completion Alias
---------- -----
psc        psc
scoop      scoop

=== Resolve-PackageCompletionSource per target (WITH FIX) ===
Cli                         Source        PSCompletionsName Reason
---                         ------        ----------------- ------
dotnet                      PSCompletions dotnet
python                      PSCompletions python
wt                          PSCompletions wt
7z                          PSCompletions 7z
ffmpeg                      PSCompletions ffmpeg
definitely-not-real-cli-zz9 Skipped                         psc add ... did not populate the local catalog ...

=== psc list AFTER ===
Completion Alias
---------- -----
psc        psc
scoop      scoop
dotnet     dotnet
python     python
wt         wt
7z         7z
ffmpeg     ffmpeg
```

psc list grew from 2 -> 7 entries. All Phase-1 declared pscompletions CLIs now resolve to `PSCompletions`; the bogus CLI returns `Skipped` with a clear `psc add` reason. Bug intent visibly confirmed.