### PR TITLE
feat(completions): add native PowerShell completion script for 7z

### DIFF
--- a/bucket/OSBasePackages.json
+++ b/bucket/OSBasePackages.json
@@ -1,6 +1,6 @@
 {
     "$schema": "https://raw.githubusercontent.com/lukesampson/scoop/master/schema.json",
-    "version": "1.27.000",
+    "version": "1.28.000",
     "url": [
         "https://raw.githubusercontent.com/MarkMichaelis/ScoopBucket/master/bucket/OSBasePackages.ps1"
     ],

--- a/bucket/OSBasePackages.json
+++ b/bucket/OSBasePackages.json
@@ -1,6 +1,6 @@
 {
     "$schema": "https://raw.githubusercontent.com/lukesampson/scoop/master/schema.json",
-    "version": "1.26.000",
+    "version": "1.27.000",
     "url": [
         "https://raw.githubusercontent.com/MarkMichaelis/ScoopBucket/master/bucket/OSBasePackages.ps1"
     ],

--- a/bucket/OSBasePackages.ps1
+++ b/bucket/OSBasePackages.ps1
@@ -21,8 +21,26 @@ $Packages = [Package[]]@(
         Installer   = 'winget'
         Id          = '7Zip.7Zip'
         CliCommands = @('7z')
-        Completion  = 'pscompletions'
-        ExpectedCompletions = @{ '7z' = @('a','x','l') }
+        Completion  = 'auto'
+        Notes       = '7z has no `7z completion powershell` subcommand; the PSCompletions catalog entry is third-party. Phase 2 of the native-completion migration replaces it with a hand-curated NativeCommandScript covering 7z''s small/stable CLI surface (commands a/b/d/e/h/i/l/rn/t/u/x and the common switches). See #233.'
+        ExpectedCompletions = @{ '7z' = @('a','x','l','t','-y') }
+        NativeCommandScript = {
+            @"
+Register-ArgumentCompleter -Native -CommandName 7z -ScriptBlock {
+    param(`$wordToComplete, `$commandAst, `$cursorPosition)
+    @(
+        'a','b','d','e','h','i','l','rn','t','u','x',
+        '-y','-r','-p','-o','-mx','-mx0','-mx1','-mx3','-mx5','-mx7','-mx9',
+        '-t7z','-tzip','-tgzip','-tbzip2','-ttar','-txz','-twim','-tiso',
+        '-aoa','-aos','-aou','-aot','-bd','-bb','-bso','-bse','-bsp',
+        '-sdel','-sfx','-si','-so','-spd','-spe','-spf','-ssc','-ssw',
+        '-stl','-stx','-slp','-snh','-snl','-snr','-stm','-w','-x','-i'
+    ) | Where-Object { `$_ -like "`$wordToComplete*" } | ForEach-Object {
+        [System.Management.Automation.CompletionResult]::new(`$_, `$_, 'ParameterValue', `$_)
+    }
+}
+"@
+        }
     }
     [Package]@{ Name = 'Everything';                    Installer = 'winget'; Id = 'voidtools.Everything'
                 Companions = @('Everything CLI') }

--- a/bucket/OSBasePackages.ps1
+++ b/bucket/OSBasePackages.ps1
@@ -30,7 +30,7 @@ Register-ArgumentCompleter -Native -CommandName 7z -ScriptBlock {
     param(`$wordToComplete, `$commandAst, `$cursorPosition)
     @(
         'a','b','d','e','h','i','l','rn','t','u','x',
-        '-y','-r','-p','-o','-mx','-mx0','-mx1','-mx3','-mx5','-mx7','-mx9',
+        '-y','-r','-p','-o','-mx','-mx0','-mx1','-mx2','-mx3','-mx4','-mx5','-mx6','-mx7','-mx8','-mx9',
         '-t7z','-tzip','-tgzip','-tbzip2','-ttar','-txz','-twim','-tiso',
         '-aoa','-aos','-aou','-aot','-bd','-bb','-bso','-bse','-bsp',
         '-sdel','-sfx','-si','-so','-spd','-spe','-spf','-ssc','-ssw',

--- a/bucket/OSBasePackages7z.Tests.ps1
+++ b/bucket/OSBasePackages7z.Tests.ps1
@@ -1,0 +1,63 @@
+#requires -Version 7.0
+#requires -Modules @{ ModuleName = 'Pester'; ModuleVersion = '5.0.0' }
+
+<#
+.SYNOPSIS
+    Behavior-first regression for OSBasePackages 7-Zip entry: native
+    PowerShell completion via Completion='auto' + NativeCommandScript
+    (Phase 2 of the native-completion migration; replaces the
+    pscompletions catalog dependency for 7z). Closes #233.
+
+.DESCRIPTION
+    The data-driven cases in Bundles.Tests.ps1 already verify the
+    NativeCommandScript emits Register-ArgumentCompleter for every
+    declared CliCommand. This focused test pins the bundle-specific
+    contract for 7-Zip so a revert to Completion='pscompletions' fails
+    here with a clear, named diagnostic instead of getting absorbed
+    into a generic data-driven failure.
+#>
+
+BeforeAll {
+    $scoopBucketPsd1 = Join-Path $PSScriptRoot '..\module\MarkMichaelis.ScoopBucket\MarkMichaelis.ScoopBucket.psd1'
+    if (Test-Path $scoopBucketPsd1) {
+        Import-Module $scoopBucketPsd1 -Force
+    } else {
+        Import-Module MarkMichaelis.ScoopBucket -Force
+    }
+    $script:sevenZip = Get-Package -BucketPath $PSScriptRoot -Name '7-Zip'
+}
+
+Describe 'OSBasePackages: 7-Zip native PowerShell completion' -Tag 'Light','Bundle' {
+
+    It 'declares the 7-Zip package exactly once' {
+        @($script:sevenZip).Count | Should -Be 1
+    }
+
+    It "uses Completion='auto' (no longer depends on PSCompletions catalog)" {
+        $script:sevenZip.Completion | Should -Be 'auto'
+    }
+
+    It 'ships a non-null NativeCommandScript so a Register-ArgumentCompleter block is emitted' {
+        $script:sevenZip.HasNativeCommandScript | Should -BeTrue
+    }
+
+    It 'declares 7z as the only CliCommand (matches the shim shipped by 7Zip.7Zip)' {
+        @($script:sevenZip.CliCommands) | Should -Be @('7z')
+    }
+
+    It 'declares ExpectedCompletions for 7z covering at least one CLI command and one switch' {
+        $script:sevenZip.ExpectedCompletions               | Should -Not -BeNullOrEmpty
+        $script:sevenZip.ExpectedCompletions.ContainsKey('7z') | Should -BeTrue
+        $expected = @($script:sevenZip.ExpectedCompletions['7z'])
+        $expected.Count | Should -BeGreaterThan 0
+        # Pin a representative subset: 7z CLI command (a/x/l/t) + a switch (-y).
+        ($expected | Where-Object { $_ -in 'a','x','l','t' }) |
+            Should -Not -BeNullOrEmpty -Because 'expected completions must include at least one 7z CLI command (a/x/l/t)'
+        $expected | Should -Contain '-y' -Because 'expected completions must include at least one 7z switch'
+    }
+
+    It "NativeCommandScript output for 7z names the 7z CLI in Register-ArgumentCompleter" {
+        $out = [string]$script:sevenZip.NativeCommandOutputs['7z']
+        $out | Should -Match 'Register-ArgumentCompleter\s+-Native\s+-CommandName\s+7z'
+    }
+}


### PR DESCRIPTION
## Summary

Closes #233. Phase 2 of the native-completion migration.

The `7-Zip` entry in `bucket/OSBasePackages.ps1` switches from
`Completion='pscompletions'` to `Completion='auto'` with a hand-curated
`NativeCommandScript`. Pattern matches the `Node.js` reference entry in
`bucket/AIAgents.ps1` and the converted entries shipped in PRs
#221/#224/#225/#227 (fzf, bat, gcloud, code, es).

7-Zip's CLI surface is small and stable, so a hand-curated completer is
both more accurate than the third-party PSCompletions catalog entry and
removes the install-time network/module dependency for `7z` from the
OSBasePackages bundle.

## Change

`bucket/OSBasePackages.ps1` -- 7-Zip entry only:

- `Completion = 'auto'` (was `'pscompletions'`).
- `NativeCommandScript` registers `7z` via
  `Register-ArgumentCompleter -Native -CommandName 7z`. Completer offers:
  - 11 CLI commands: `a` (add), `b` (benchmark), `d` (delete),
    `e` (extract no paths), `h` (hash), `i` (info), `l` (list),
    `rn` (rename), `t` (test), `u` (update), `x` (extract with paths).
  - Common switches: `-y`, `-r`, `-p`, `-o`, `-mx`/`-mx0..9`,
    `-t7z`/`-tzip`/`-tgzip`/`-tbzip2`/`-ttar`/`-txz`/`-twim`/`-tiso`,
    `-aoa`/`-aos`/`-aou`/`-aot`, `-bd`/`-bb`/`-bso`/`-bse`/`-bsp`,
    `-sdel`/`-sfx`/`-si`/`-so`/`-spd`/`-spe`/`-spf`/`-ssc`/`-ssw`,
    `-stl`/`-stx`/`-slp`/`-snh`/`-snl`/`-snr`/`-stm`, `-w`, `-x`, `-i`.
- `ExpectedCompletions` expanded from `@('a','x','l')` to
  `@('a','x','l','t','-y')` so the data-driven Bundles tests verify both
  a CLI-command and a switch round-trip through the completer output.
- `Notes` documents the migration rationale.

## Behavior-first tests

New `bucket/OSBasePackages7z.Tests.ps1` (Tag `Light,Bundle`):

| # | Behavior pinned |
|---|---|
| T1 | 7-Zip package is declared exactly once |
| T2 | `Completion='auto'` (no longer `pscompletions`) |
| T3 | `HasNativeCommandScript` is true |
| T4 | `CliCommands = @('7z')` (matches the shim shipped by `7Zip.7Zip`) |
| T5 | `ExpectedCompletions['7z']` covers >=1 CLI command (`a`/`x`/`l`/`t`) AND the `-y` switch |
| T6 | `NativeCommandOutputs['7z']` matches `Register-ArgumentCompleter -Native -CommandName 7z` |

Each assertion fails for a behavioral reason if the entry is reverted to
`pscompletions` (T2/T3/T5/T6 all flip; T1/T4 stay green as they pin the
unchanged shape). RED was confirmed before GREEN -- 4 of 6 failed against
the unchanged entry, then all 6 passed after the diff was applied.

The data-driven cases in `bucket/Bundles.Tests.ps1` already validate that
any `Completion='auto'` entry has a `NativeCommandScript` emitting
`Register-ArgumentCompleter` for every declared CliCommand; that case
picks up the new entry automatically.

## Test results

Focused suite (the seven files most exercised by this change):

```
OSBasePackages7z.Tests.ps1            6 passed
Bundles.Tests.ps1                   all passed
OSBasePackagesCompanions.Tests.ps1  all passed
Package.Tests.ps1                   all passed
PackageNameCompletion.Tests.ps1     all passed
CompletionPinned.Tests.ps1          1 pre-existing failure*
CliCompletionOutput.Tests.ps1       all passed

Tests Passed: 851, Failed: 1, Skipped: 1
```

*The single failure (`CompletionPinned -- uses sentinel version v3`) is
the same pre-existing failure called out as unrelated in PR #227's body
and reproduces on `main`. It is not introduced by this PR.

## Out of scope

- Other PSCompletions consumers (none remain in OSBasePackages after
  this PR; `dotnet`/`python`/`ffmpeg`/`wt` migrations live in their own
  Phase 2 issues #228/#229/#230/#232).
- Adding a `7za` shim. The `7Zip.7Zip` winget package only puts `7z` on
  PATH; `7za` is the legacy stand-alone build and is not shipped here.

Co-authored-by: Copilot <copilot@github.com>
