### PR TITLE
feat(completions): add native PowerShell completion script for wt (Windows Terminal)

### DIFF
--- a/bucket/OSBasePackages.json
+++ b/bucket/OSBasePackages.json
@@ -1,6 +1,6 @@
 {
     "$schema": "https://raw.githubusercontent.com/lukesampson/scoop/master/schema.json",
-    "version": "1.28.000",
+    "version": "1.29.000",
     "url": [
         "https://raw.githubusercontent.com/MarkMichaelis/ScoopBucket/master/bucket/OSBasePackages.ps1"
     ],

--- a/bucket/OSBasePackages.ps1
+++ b/bucket/OSBasePackages.ps1
@@ -13,8 +13,23 @@ $Packages = [Package[]]@(
         Installer   = 'winget'
         Id          = 'Microsoft.WindowsTerminal'
         CliCommands = @('wt')
-        Completion  = 'pscompletions'
-        ExpectedCompletions = @{ wt = @('new-tab','split-pane','focus-tab') }
+        Completion  = 'auto'
+        Notes       = 'Phase 2: converted from pscompletions to a native in-tree completer (#232). wt has no upstream PowerShell completion command; documented CLI surface is small and stable (https://learn.microsoft.com/en-us/windows/terminal/command-line-arguments).'
+        ExpectedCompletions = @{ wt = @('new-tab','split-pane','focus-tab','move-focus','swap-pane','--window','-w','--maximized','-M','--fullscreen','-F','--focus','-f') }
+        NativeCommandScript = {
+            @"
+Register-ArgumentCompleter -Native -CommandName wt -ScriptBlock {
+    param(`$wordToComplete, `$commandAst, `$cursorPosition)
+    @(
+        'new-tab','split-pane','focus-tab','move-focus','swap-pane',
+        '--window','-w','--maximized','-M','--fullscreen','-F','--focus','-f',
+        '--help','-h','--version','-v'
+    ) | Where-Object { `$_ -like "`$wordToComplete*" } | ForEach-Object {
+        [System.Management.Automation.CompletionResult]::new(`$_, `$_, 'ParameterValue', `$_)
+    }
+}
+"@
+        }
     }
     [Package]@{
         Name        = '7-Zip'

--- a/bucket/OSBasePackagesWtNativeCompletion.Tests.ps1
+++ b/bucket/OSBasePackagesWtNativeCompletion.Tests.ps1
@@ -1,0 +1,50 @@
+# ----------------------------------------------------------------------------
+# Behavior-first pin: Windows Terminal (wt) ships native PowerShell tab
+# completion in-tree, not via PSCompletions.
+#
+# Phase 2 of the pscompletions -> native conversion (Issue #232). Reference
+# Phase 2 conversions: bucket\AIAgents.ps1 (Node.js), bucket\DeveloperBasePackages.ps1
+# (devenv). Earlier OSBasePackages native-completion siblings: code, bat, fzf,
+# gcloud, es.
+#
+# Each assertion fails for a behavioral reason if the production change is
+# reverted (Completion flips back to 'pscompletions' -> auto goes false;
+# NativeCommandScript dropped -> HasNativeCommandScript goes false;
+# ExpectedCompletions reverted -> '--window'/'--maximized' missing).
+# ----------------------------------------------------------------------------
+
+Describe 'OSBasePackages -- wt native completion (Phase 2)' -Tag 'Light' {
+
+    BeforeAll {
+        $scoopBucketPsd1 = Join-Path $PSScriptRoot '..\module\MarkMichaelis.ScoopBucket\MarkMichaelis.ScoopBucket.psd1'
+        if (Test-Path $scoopBucketPsd1) { Import-Module $scoopBucketPsd1 -Force } else { Import-Module MarkMichaelis.ScoopBucket -Force }
+        $script:wt = @(Get-Package -BucketPath $PSScriptRoot |
+            Where-Object { $_.Bundle -eq 'OSBasePackages' -and ($_.CliCommands -contains 'wt') })
+        $script:wt.Count | Should -Be 1 -Because 'exactly one OSBasePackages [Package] must own the wt CLI'
+    }
+
+    It "wt Package uses Completion='auto' (no longer pscompletions)" {
+        $script:wt[0].Completion | Should -Be 'auto'
+    }
+
+    It 'wt Package supplies a NativeCommandScript' {
+        # Get-Package marshalls Packages across runspaces; the actual
+        # scriptblock cannot round-trip, so assert HasNativeCommandScript
+        # (the cross-runspace-safe boolean projection).
+        $script:wt[0].HasNativeCommandScript | Should -BeTrue
+    }
+
+    It 'wt ExpectedCompletions contains documented subcommands and global flags' {
+        $expected = $script:wt[0].ExpectedCompletions
+        $expected | Should -Not -BeNullOrEmpty
+        $expected.ContainsKey('wt') | Should -BeTrue
+        $entries = @($expected['wt'])
+        $entries.Count | Should -BeGreaterThan 0
+        # Sample the documented surface: at least one subcommand AND at least
+        # one global flag must be advertised so Tab demonstrably surfaces both.
+        $entries | Should -Contain 'new-tab'
+        $entries | Should -Contain 'split-pane'
+        $entries | Should -Contain '--window'
+        $entries | Should -Contain '--maximized'
+    }
+}


### PR DESCRIPTION
## Summary
Closes #232. Phase 2 of the pscompletions -> native conversion. Converts the Windows Terminal (`wt`) entry in `bucket\OSBasePackages.ps1` from `Completion='pscompletions'` to a native in-tree PowerShell completer, matching the established pattern used by `code`, `bat`, `fzf`, `gcloud`, and `es`.

Reference Phase 2 conversions: `bucket\AIAgents.ps1` (Node.js), `bucket\DeveloperBasePackages.ps1` (devenv).

## Production change (single [Package])
`bucket\OSBasePackages.ps1` -- Windows Terminal entry:
- `Completion='pscompletions'` -> `Completion='auto'`.
- New `NativeCommandScript` emits `Register-ArgumentCompleter -Native -CommandName wt` with the documented CLI surface:
  - subcommands: `new-tab`, `split-pane`, `focus-tab`, `move-focus`, `swap-pane`
  - global flags: `--window`/`-w`, `--maximized`/`-M`, `--fullscreen`/`-F`, `--focus`/`-f`, `--help`/`-h`, `--version`/`-v`
  - Reference: https://learn.microsoft.com/en-us/windows/terminal/command-line-arguments
- `ExpectedCompletions` broadened to include both subcommands and global flags so `CompletionEndToEnd` can verify Tab demonstrably surfaces both surfaces.

## Tests
New `bucket\OSBasePackagesWtNativeCompletion.Tests.ps1` (Tag 'Light'), 3 behavior-first assertions, each fails for a behavioral reason if the production change is reverted:

| # | Behavior pinned | Reverted-state failure |
|---|---|---|
| T1 | `wt` Package uses `Completion='auto'` | `Expected 'auto' / But was 'pscompletions'` |
| T2 | `wt` Package supplies a `NativeCommandScript` (asserted via cross-runspace-safe `HasNativeCommandScript`) | `Expected True / got False` |
| T3 | `ExpectedCompletions['wt']` advertises both subcommands and global flags (sample: `new-tab`, `split-pane`, `--window`, `--maximized`) | `Expected '--window' to be found in @('new-tab','split-pane','focus-tab')` |

RED -> GREEN was confirmed live (RED on the unmodified entry; GREEN after applying the production change).

## Verification
Focused suite (the test files most exercised by this change -- new wt suite, Bundles, CompletionPinned, Package, ManifestInstall, OSBasePackagesCompanions, PackageNameCompletion, CompletionEndToEnd, UpdatePackageCompletion, UpdatePackageCompletionPscUpdate, ResolvePscAdd):

```
Passed=864 Failed=0 Skipped=1
```

## Out of scope
- Other pscompletions entries (`dotnet`, `python`, `7z`, `ffmpeg`) -- separate Phase 2 issues.
- Module-level resolver changes.

Co-authored-by: Copilot <copilot@github.com>
