### PR TITLE
test(completions): bump v3 sentinel assertions to v4 and fix idempotency test

### DIFF
--- a/bucket/CompletionIdempotency.Tests.ps1
+++ b/bucket/CompletionIdempotency.Tests.ps1
@@ -66,7 +66,15 @@ Describe 'CliCompletion idempotency' -Tag 'Heavy','Idempotency' {
     It '-Force:$false preserves a manually-modified block' {
         Invoke-FixtureRegistration -ProfilePath $script:profilePath -Names @('gh') -Force
         $content = Get-Content -Raw -Path $script:profilePath
-        $mutated = $content -replace 'Register-ArgumentCompleter -CommandName gh','Register-ArgumentCompleter -CommandName gh # USER MUTATION'
+        # Inject a marker comment immediately after the BEGIN sentinel for
+        # 'gh'. This is layout-stable across sentinel-format bumps: v3
+        # inlined the registration text inside the block; v4 emits a
+        # one-line dot-source to a sidecar. Asserting only that *some*
+        # in-block mutation survives a non-Force re-registration captures
+        # the real contract -- "do not overwrite an existing block unless
+        # -Force is passed" -- without re-encoding the block's payload.
+        $mutated = $content -replace '(?m)(^# ScoopBucket:CliCompletion:gh:BEGIN [^\r\n]+\r?\n)', "`$1# USER MUTATION`r`n"
+        $mutated | Should -Match 'USER MUTATION' -Because 'sanity: the test fixture must actually mutate the block before re-registering'
         [System.IO.File]::WriteAllText($script:profilePath, $mutated, [System.Text.UTF8Encoding]::new($false))
         Invoke-FixtureRegistration -ProfilePath $script:profilePath -Names @('gh')   # no -Force
         $after = Get-Content -Raw -Path $script:profilePath

--- a/bucket/CompletionPinned.Tests.ps1
+++ b/bucket/CompletionPinned.Tests.ps1
@@ -58,7 +58,7 @@ Describe 'CliCompletion pinned contract -- per-bundle native registration' -Tag 
         @($pkg.ExpectedCompletions[$Cli]).Count | Should -BeGreaterThan 0 -Because "ExpectedCompletions['$Cli'] must list at least one expected subcommand"
     }
 
-    It 'uses sentinel version v3' {
+    It 'uses sentinel version v4' {
         # $script:CompletionSentinelVersion lives inside the module and is not
         # visible from this test runspace; assert against the source instead so
         # any bump of the sentinel format requires updating this guard too.
@@ -69,8 +69,11 @@ Describe 'CliCompletion pinned contract -- per-bundle native registration' -Tag 
         # emit a leading `using namespace System.Management.Automation` which
         # the parser only accepts as the FIRST statement of a script file --
         # never inside an if/Action scriptblock (v2's regression).
+        # v4 (#221) collapses the per-block OnIdle handler into a single
+        # batched OnIdle bootstrap that drains a queue of registered CLIs,
+        # cutting profile-load Register-ObjectEvent calls from O(n) to 1.
         $src = Get-Content -Raw -Path (Join-Path $PSScriptRoot '..\module\MarkMichaelis.ScoopBucket\Private\Register-PackageCompletion.ps1')
-        $src | Should -Match "(?m)^\s*\`$script:CompletionSentinelVersion\s*=\s*'v3'\s*$" -Because 'Register-PackageCompletion.ps1 must pin sentinel version v3'
+        $src | Should -Match "(?m)^\s*\`$script:CompletionSentinelVersion\s*=\s*'v4'\s*$" -Because 'Register-PackageCompletion.ps1 must pin sentinel version v4'
     }
 
     It 'Register-CliCompletion exposes the -NativeCommand parameter' {

--- a/bucket/CompletionPinned.Tests.ps1
+++ b/bucket/CompletionPinned.Tests.ps1
@@ -71,7 +71,7 @@ Describe 'CliCompletion pinned contract -- per-bundle native registration' -Tag 
         # never inside an if/Action scriptblock (v2's regression).
         # v4 (#221) collapses the per-block OnIdle handler into a single
         # batched OnIdle bootstrap that drains a queue of registered CLIs,
-        # cutting profile-load Register-ObjectEvent calls from O(n) to 1.
+        # cutting profile-load Register-EngineEvent calls from O(n) to 1.
         $src = Get-Content -Raw -Path (Join-Path $PSScriptRoot '..\module\MarkMichaelis.ScoopBucket\Private\Register-PackageCompletion.ps1')
         $src | Should -Match "(?m)^\s*\`$script:CompletionSentinelVersion\s*=\s*'v4'\s*$" -Because 'Register-PackageCompletion.ps1 must pin sentinel version v4'
     }


### PR DESCRIPTION
## Summary

PR #221 bumped `$script:CompletionSentinelVersion` from `v3` to `v4` but two bucket tests still encoded v3 assumptions and have been red on `main` since the merge. This PR fixes both (test-only changes, no implementation regression).

## Changes

### `bucket\CompletionPinned.Tests.ps1`

- Assertion regex now pins `v4` instead of `v3`.
- Comment refreshed to mention the v4 batched OnIdle bootstrap (#221) on top of the v3 sidecar layout (#216), so the next bump still has a single point of truth.

### `bucket\CompletionIdempotency.Tests.ps1`

The `-Force:$false preserves a manually-modified block` test mutated the literal string `Register-ArgumentCompleter -CommandName gh` in the profile content. Under v4 that line lives in the per-CLI sidecar `.ps1`, not in the in-profile block (the profile now contains only `if (Get-Command gh ...) { . sidecar }`). So the `-replace` was a no-op, `$mutated == $content`, and `USER MUTATION` was never present.

Switched to a layout-stable mutation: inject `# USER MUTATION` immediately after the BEGIN sentinel for `gh`. This expresses the real contract -- "do not overwrite an existing block unless -Force is passed" -- without re-encoding the block payload, so the test will survive future sentinel-format bumps. Added a sanity `Should -Match` on `$mutated` to prevent silent regressions where the fixture itself fails to mutate.

## Root-cause analysis (idempotency)

Investigated `Register-CliCompletion` in `module\MarkMichaelis.ScoopBucket\Private\Legacy.ps1`. Lines 807-813:

```
$existed = [regex]::IsMatch($content, "...:BEGIN \w+")
if ($existed -and -not $Force) {
    return [pscustomobject]@{ Action = 'Preserved'; ... }
}
```

The `-Force:$false` contract is correctly honored: when an existing block is detected and `-Force` is not passed, the function returns `Action=Preserved` without rewriting the profile or touching the sidecar. The v4 bump did not regress this contract; only the test's mutation strategy needed updating.

## Verification

```
Invoke-Pester -Path bucket\CompletionPinned.Tests.ps1, bucket\CompletionIdempotency.Tests.ps1
# Tests Passed: 10, Failed: 0

.\bucket\Invoke-Tests.ps1 -Tag Light
# Tests Passed: 1081, Failed: 1, Skipped: 3 (the 1 failure is
# ImportPerformance.Tests.ps1 -- a perf flake on a loaded dev box,
# median 2364 ms vs 1800 ms threshold; unrelated to this change)
```

Closes #234