### PR TITLE
feat(completions): add native PowerShell completion script for python

### DIFF
--- a/bucket/DeveloperBasePackages.json
+++ b/bucket/DeveloperBasePackages.json
@@ -1,6 +1,6 @@
 {
     "$schema": "https://raw.githubusercontent.com/lukesampson/scoop/master/schema.json",
-    "version": "1.22.000",
+    "version": "1.23.000",
     "url": [
         "https://raw.githubusercontent.com/MarkMichaelis/ScoopBucket/master/bucket/DeveloperBasePackages.ps1"
     ],

--- a/bucket/DeveloperBasePackages.ps1
+++ b/bucket/DeveloperBasePackages.ps1
@@ -136,8 +136,23 @@ Register-ArgumentCompleter -Native -CommandName copilot -ScriptBlock {
         Installer   = 'winget'
         Id          = 'Python.Python.3.14'
         CliCommands = @('python')
-        Completion  = 'pscompletions'
-        ExpectedCompletions = @{ python = @('--help','--version','-m') }
+        Completion  = 'auto'
+        Notes       = 'CPython ships no native PowerShell completion provider and the PSCompletions catalog entry is opaque (depends on a network catalog fetch). Hand-curated CPython CLI flag list -- deterministic, hermetic, and consistent with devenv/code/copilot/aspire in the same bundle (#229).'
+        ExpectedCompletions = @{ python = @('-c','-m','-V','--version','-h','--help') }
+        NativeCommandScript = {
+            @"
+Register-ArgumentCompleter -Native -CommandName python -ScriptBlock {
+    param(`$wordToComplete, `$commandAst, `$cursorPosition)
+    @(
+        '-c','-m','-i','-u','-V','--version','-h','--help',
+        '-O','-OO','-q','-s','-S','-v','-W','-x',
+        '-b','-B','-d','-E','-I','-P','-R'
+    ) | Where-Object { `$_ -like "`$wordToComplete*" } | ForEach-Object {
+        [System.Management.Automation.CompletionResult]::new(`$_, `$_, 'ParameterValue', `$_)
+    }
+}
+"@
+        }
     }
 
     [Package]@{

--- a/bucket/DeveloperBasePackagesPython.Tests.ps1
+++ b/bucket/DeveloperBasePackagesPython.Tests.ps1
@@ -1,0 +1,66 @@
+#requires -Version 7.0
+#requires -Modules @{ ModuleName = 'Pester'; ModuleVersion = '5.0.0' }
+
+<#
+.SYNOPSIS
+    Behavior-first tests for the Python entry in DeveloperBasePackages
+    (issue #229: pscompletions -> native conversion, Phase 2).
+
+.DESCRIPTION
+    Locks in the contract that `python` ships a hand-curated native
+    PowerShell argument completer instead of relying on the
+    `pscompletions` catalog. Mirrors the pattern already in place for
+    `devenv`, `code`, `copilot`, and `aspire` in the same bundle.
+
+    These tests fail if the entry is reverted to `Completion = pscompletions`
+    (no NativeCommandScript) -- providing the regression guard.
+#>
+
+BeforeAll {
+    $scoopBucketPsd1 = Join-Path $PSScriptRoot '..\module\MarkMichaelis.ScoopBucket\MarkMichaelis.ScoopBucket.psd1'
+    if (Test-Path $scoopBucketPsd1) { Import-Module $scoopBucketPsd1 -Force } else { Import-Module MarkMichaelis.ScoopBucket -Force }
+    $script:pkgs = @(Get-Package -BucketPath $PSScriptRoot)
+    $script:python = @($script:pkgs | Where-Object Name -EQ 'Python')
+}
+
+Describe 'DeveloperBasePackages: Python uses native completion (issue #229)' -Tag 'Light','Bundle','Completion' {
+
+    It 'declares exactly one Python entry in DeveloperBasePackages' {
+        $script:python.Count | Should -Be 1
+        $script:python[0].Bundle | Should -Be 'DeveloperBasePackages'
+    }
+
+    It 'declares CliCommands=python' {
+        @($script:python[0].CliCommands) | Should -Be @('python')
+    }
+
+    It "uses Completion='auto' (no longer pscompletions)" {
+        $script:python[0].Completion | Should -Be 'auto'
+    }
+
+    It 'ships a NativeCommandScript' {
+        $script:python[0].HasNativeCommandScript | Should -BeTrue
+    }
+
+    It 'declares non-empty ExpectedCompletions for python' {
+        $script:python[0].ExpectedCompletions.ContainsKey('python') | Should -BeTrue
+        @($script:python[0].ExpectedCompletions['python']).Count | Should -BeGreaterThan 0
+        foreach ($expected in '--help','--version','-m') {
+            $script:python[0].ExpectedCompletions['python'] | Should -Contain $expected
+        }
+    }
+
+    It 'NativeCommandScript renders a Register-ArgumentCompleter -Native for python' {
+        $rendered = $script:python[0].NativeCommandOutputs['python']
+        $rendered | Should -Not -BeNullOrEmpty
+        $rendered | Should -Match 'Register-ArgumentCompleter\s+-Native'
+        $rendered | Should -Match '-CommandName\s+python'
+    }
+
+    It 'NativeCommandScript exposes the canonical CPython flags' {
+        $rendered = $script:python[0].NativeCommandOutputs['python']
+        foreach ($flag in "'-c'","'-m'","'-V'","'--version'","'-h'","'--help'") {
+            $rendered | Should -BeLike "*$flag*"
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Phase 2 of the pscompletions -> native conversion (follow-on to #221, #224, #225, #227). Converts the `python` entry in `bucket\DeveloperBasePackages.ps1` from `Completion='pscompletions'` to `Completion='auto'` with a hand-curated `NativeCommandScript`, matching the pattern already shipped for `devenv`, `code`, `copilot`, `bcomp/bcompare`, and `aspire` in the same bundle.

## Why

CPython ships no native PowerShell completion provider. The `pscompletions` catalog entry is opaque (depends on a network fetch and an external module catalog). A hand-curated static CPython flag list is faster, hermetic, deterministic, and keeps `python` consistent with the other dev-tool CLIs in this bundle.

## Changes

- `bucket\DeveloperBasePackages.ps1` -- Python entry: `Completion='auto'`, `Notes` rationale, expanded `ExpectedCompletions`, `NativeCommandScript` that registers `Register-ArgumentCompleter -Native -CommandName python` returning the documented CPython flags (`-c`, `-m`, `-i`, `-u`, `-V`, `--version`, `-h`, `--help`, `-O`, `-OO`, `-q`, `-s`, `-S`, `-v`, `-W`, `-x`, `-b`, `-B`, `-d`, `-E`, `-I`, `-P`, `-R`).
- `bucket\DeveloperBasePackagesPython.Tests.ps1` -- new behavior-first guards: 7 tests covering CliCommands, Completion='auto', HasNativeCommandScript, ExpectedCompletions membership, and the rendered completer source. Tests fail if the entry is reverted to `pscompletions`.

## Out of scope

- Dynamic module-name completion after `-m` (deferred; flags-only is the v1 contract).
- A separate `python3` shim (winget Python.Python.3.14 ships only `python`; revisit if/when `python3` becomes a first-class CLI).

## Test results

Targeted Light suites (Bundles, CompletionPinned, Package, DeveloperBasePackagesPython, PackageOrder, InstallPackageFilter, ImportPackageCompletion): 861 passed, 0 failed, 1 skipped.

Live-fire evidence: in a fresh pwsh session, importing the module and dot-sourcing the rendered completer makes `python -<TAB>` return all 23 CPython flags via `TabExpansion2`:

```
-c, -m, -i, -u, -V, --version, -h, --help, -O, -OO, -q, -s, -S, -v,
-W, -x, -b, -B, -d, -E, -I, -P, -R
```

Closes #229