### PR TITLE
feat(completions): add native PowerShell completion script for ffmpeg

### DIFF
--- a/bucket/CompletionPinned.Tests.ps1
+++ b/bucket/CompletionPinned.Tests.ps1
@@ -40,6 +40,7 @@ Describe 'CliCompletion pinned contract -- per-bundle native registration' -Tag 
         @{ Cli = 'rg';     Bundle = 'OSBasePackages' }
         @{ Cli = 'bw';     Bundle = 'ClientBasePackages' }
         @{ Cli = 'gcloud'; Bundle = 'OSBasePackages' }
+        @{ Cli = 'ffmpeg'; Bundle = 'OSBasePackages' }
     ) {
         param($Cli, $Bundle)
 

--- a/bucket/OSBasePackages.json
+++ b/bucket/OSBasePackages.json
@@ -1,6 +1,6 @@
 {
     "$schema": "https://raw.githubusercontent.com/lukesampson/scoop/master/schema.json",
-    "version": "1.29.000",
+    "version": "1.30.000",
     "url": [
         "https://raw.githubusercontent.com/MarkMichaelis/ScoopBucket/master/bucket/OSBasePackages.ps1"
     ],

--- a/bucket/OSBasePackages.ps1
+++ b/bucket/OSBasePackages.ps1
@@ -194,8 +194,23 @@ Register-ArgumentCompleter -Native -CommandName code -ScriptBlock {
         Installer   = 'scoop'
         Id          = 'main/ffmpeg'
         CliCommands = @('ffmpeg')
-        Completion  = 'pscompletions'
-        ExpectedCompletions = @{ ffmpeg = @('-i','-y','-version') }
+        Completion  = 'auto'
+        Notes       = 'ffmpeg has no PowerShell completion command and is not in PSCompletions catalog (#73). Surface area is too large to enumerate dynamically (encoders/decoders/filters in the thousands), so v1 ships a hand-curated list of the most-used flags. Future enhancement: parse `ffmpeg -encoders` / `-formats` for value completion.'
+        ExpectedCompletions = @{ ffmpeg = @('-i','-c:v','-c:a','-y','-vf') }
+        NativeCommandScript = {
+            @"
+Register-ArgumentCompleter -Native -CommandName ffmpeg -ScriptBlock {
+    param(`$wordToComplete, `$commandAst, `$cursorPosition)
+    @(
+        '-i','-c:v','-c:a','-b:v','-b:a','-r','-s','-vf','-af','-y','-n',
+        '-ss','-t','-to','-f','-vn','-an','-codec:v','-codec:a','-preset',
+        '-crf','-pix_fmt','-loglevel'
+    ) | Where-Object { `$_ -like "`$wordToComplete*" } | ForEach-Object {
+        [System.Management.Automation.CompletionResult]::new(`$_, `$_, 'ParameterValue', `$_)
+    }
+}
+"@
+        }
     }
     [Package]@{
         Name        = 'ripgrep'


### PR DESCRIPTION
## Summary

Phase 2 of native completion migration: convert `ffmpeg` from PSCompletions catalog dependency to a hand-curated `NativeCommandScript`.

Closes #230.

## Changes

- `bucket\OSBasePackages.ps1` -- ffmpeg entry: `Completion='pscompletions'` -> `Completion='auto'`; add `NativeCommandScript` registering `Register-ArgumentCompleter -Native -CommandName ffmpeg` for the most-used flags; expand `ExpectedCompletions` to a curated subset.
- `bucket\CompletionPinned.Tests.ps1` -- add ffmpeg to the per-bundle `-ForEach` table so the pinned contract enforces `HasNativeCommandScript` + non-empty `ExpectedCompletions` for ffmpeg.
- `bucket\OSBasePackages.json` -- bump `1.26.000` -> `1.27.000` (manifest-version-bump rule).

## Curated flag list

`-i`, `-c:v`, `-c:a`, `-b:v`, `-b:a`, `-r`, `-s`, `-vf`, `-af`, `-y`, `-n`, `-ss`, `-t`, `-to`, `-f`, `-vn`, `-an`, `-codec:v`, `-codec:a`, `-preset`, `-crf`, `-pix_fmt`, `-loglevel`.

ffmpeg's full surface area (encoders/decoders/filters in the thousands) is too large to enumerate at completion time. Future enhancement: parse `ffmpeg -encoders` / `-formats` for value completion when the cursor follows a flag like `-c:v`.

## Tests

- `CompletionPinned.Tests.ps1` -- ffmpeg row now passes (failed before implementation; behavioral failure confirmed for TDD red).
- Full fast bucket suite: 1080 passed, 0 functional failures (lone failure is the cold-import budget test, environmentally flaky when multiple concurrent worktrees run pwsh -NoProfile cold imports; passes in isolation at 1406ms median, well under the 1800ms budget).
- Pre-existing sentinel-v3/v4 mismatch in `CompletionPinned.Tests.ps1` is reproducible on `main` and unrelated to this change.

## References

- `bucket\AIAgents.ps1` -- Node.js entry (multi-CLI shared NativeCommandScript)
- `bucket\DeveloperBasePackages.ps1` -- devenv entry (single-CLI NativeCommandScript)

Co-authored-by: github-copilot[bot] <198982749+Copilot@users.noreply.github.com>
