### PR TITLE
feat(completions): replace dotnet pscompletions with dotnet complete native script

### DIFF
--- a/bucket/DeveloperBasePackages.json
+++ b/bucket/DeveloperBasePackages.json
@@ -1,6 +1,6 @@
 {
     "$schema": "https://raw.githubusercontent.com/lukesampson/scoop/master/schema.json",
-    "version": "1.23.000",
+    "version": "1.24.000",
     "url": [
         "https://raw.githubusercontent.com/MarkMichaelis/ScoopBucket/master/bucket/DeveloperBasePackages.ps1"
     ],

--- a/bucket/DeveloperBasePackages.ps1
+++ b/bucket/DeveloperBasePackages.ps1
@@ -11,8 +11,20 @@ $Packages = [Package[]]@(
         Installer   = 'scoop'
         Id          = 'main/dotnet'
         CliCommands = @('dotnet')
-        Completion  = 'pscompletions'
-        ExpectedCompletions = @{ dotnet = @('build','run','test') }
+        Completion  = 'auto'
+        Notes       = 'Sources tab completion from the official `dotnet complete` API (https://learn.microsoft.com/en-us/dotnet/core/tools/enable-tab-autocomplete) instead of the third-party PSCompletions catalog so completions track whatever subcommands the installed SDK ships. Hand-curated ExpectedCompletions covers the canonical top-level verbs the test harness validates.'
+        ExpectedCompletions = @{ dotnet = @('add','build','clean','pack','publish','restore','run','test') }
+        NativeCommandScript = {
+            @"
+Register-ArgumentCompleter -Native -CommandName dotnet -ScriptBlock {
+    param(`$wordToComplete, `$commandAst, `$cursorPosition)
+    dotnet complete --position `$cursorPosition "`$commandAst" |
+        ForEach-Object {
+            [System.Management.Automation.CompletionResult]::new(`$_, `$_, 'ParameterValue', `$_)
+        }
+}
+"@
+        }
     }
     [Package]@{
         Name        = 'Visual Studio'

--- a/bucket/DotnetNativeCompletion.Tests.ps1
+++ b/bucket/DotnetNativeCompletion.Tests.ps1
@@ -1,0 +1,51 @@
+#requires -Version 7.0
+#requires -Modules @{ ModuleName = 'Pester'; ModuleVersion = '5.0.0' }
+
+<#
+.SYNOPSIS
+    Regression tests for issue #228: the `dotnet` entry in
+    DeveloperBasePackages must source tab completion from the native
+    `dotnet complete` API via Completion='auto' + NativeCommandScript,
+    NOT from the third-party PSCompletions catalog.
+
+.DESCRIPTION
+    Asserts the migration away from Completion='pscompletions' for
+    `dotnet`. These tests must fail if the entry is reverted to
+    Completion='pscompletions' or loses its NativeCommandScript.
+#>
+
+BeforeAll {
+    $scoopBucketPsd1 = Join-Path $PSScriptRoot '..\module\MarkMichaelis.ScoopBucket\MarkMichaelis.ScoopBucket.psd1'
+    if (Test-Path $scoopBucketPsd1) { Import-Module $scoopBucketPsd1 -Force } else { Import-Module MarkMichaelis.ScoopBucket -Force }
+    $script:dotnet = @(Get-Package -BucketPath $PSScriptRoot) |
+        Where-Object { $_.Bundle -eq 'DeveloperBasePackages' -and $_.Name -eq 'dotnet' } |
+        Select-Object -First 1
+}
+
+Describe 'DeveloperBasePackages dotnet native completion (issue #228)' -Tag 'Light','Bundle','Completion' {
+
+    It 'declares the dotnet package' {
+        $script:dotnet | Should -Not -BeNullOrEmpty
+    }
+
+    It "uses Completion='auto' (not 'pscompletions')" {
+        $script:dotnet.Completion | Should -Be 'auto'
+    }
+
+    It 'ships a NativeCommandScript' {
+        $script:dotnet.HasNativeCommandScript | Should -BeTrue
+    }
+
+    It 'NativeCommandScript invokes the official `dotnet complete` API' {
+        $text = [string]$script:dotnet.NativeCommandOutputs['dotnet']
+        $text | Should -Match 'Register-ArgumentCompleter\b[\s\S]*-CommandName\s+dotnet'
+        $text | Should -Match 'dotnet\s+complete\b'
+    }
+
+    It 'declares an expanded ExpectedCompletions subset for tab-completion validation' {
+        $expected = @($script:dotnet.ExpectedCompletions.dotnet)
+        foreach ($cmd in 'add','build','clean','pack','publish','restore','run','test') {
+            $expected | Should -Contain $cmd
+        }
+    }
+}


### PR DESCRIPTION
## Summary
Convert the `dotnet` package entry in `bucket/DeveloperBasePackages.ps1` from `Completion='pscompletions'` to `Completion='auto'` with a hand-curated `NativeCommandScript` that delegates to the official `dotnet complete` CLI API.

This is Phase 2 of the native-completion migration, following PRs #221/#224/#225/#227. With this change, no entry in DeveloperBasePackages depends on the third-party PSCompletions catalog for `dotnet`.

## Changes

- `bucket/DeveloperBasePackages.ps1` (dotnet entry)
  - `Completion = 'auto'`
  - New `NativeCommandScript` that registers a native ArgumentCompleter forwarding `$wordToComplete` + `$commandAst` + `$cursorPosition` to `dotnet complete --position` and wrapping each suggestion in a `CompletionResult`. This is the canonical PowerShell snippet documented at https://learn.microsoft.com/en-us/dotnet/core/tools/enable-tab-autocomplete.
  - `ExpectedCompletions.dotnet` expanded from `build,run,test` to the canonical verb subset `add,build,clean,pack,publish,restore,run,test` so the completion-test harness covers more verbs.
  - `Notes` field added explaining the migration rationale.
- `bucket/DotnetNativeCompletion.Tests.ps1` (new) -- focused regression guard:
  - Asserts `Completion='auto'`, non-null `NativeCommandScript`, output references `dotnet complete`, and the expanded `ExpectedCompletions` subset.
  - Fails when the entry is reverted to `pscompletions`.

## Why native?

- Sourcing completions from the SDK itself (`dotnet complete`) means tab completion tracks whatever subcommands the installed dotnet ships, including future verbs.
- Removes the PSCompletions module dependency for `dotnet`, mirroring the `Node.js` (AIAgents) and `devenv` (DeveloperBasePackages) reference patterns.

## Tests

- `Invoke-Pester bucket\DotnetNativeCompletion.Tests.ps1` -- 5/5 pass (was 4/5 fail before the impl change; RED -> GREEN confirmed).
- `Invoke-Pester bucket\Bundles.Tests.ps1, bucket\DotnetNativeCompletion.Tests.ps1, bucket\PackageNameCompletion.Tests.ps1, bucket\CliCompletionOutput.Tests.ps1` -- 812 passed, 1 skipped, 0 failed.
- The data-driven cases in `Bundles.Tests.ps1` already enforce that any `Completion='auto'` package has a `NativeCommandScript` whose output emits `Register-ArgumentCompleter` for every declared CLI; the new entry passes that contract automatically.

Closes #228
