### PR TITLE
feat(aiagents): skip github MCP for Copilot CLI; remove PAT from configs (#242)

### DIFF
--- a/bucket/AIAgents.Mcp.Tests.ps1
+++ b/bucket/AIAgents.Mcp.Tests.ps1
@@ -1,0 +1,336 @@
+#requires -Version 7.0
+#requires -Modules @{ ModuleName = 'Pester'; ModuleVersion = '5.0.0' }
+
+<#
+.SYNOPSIS
+    Behavior-first tests for AIAgents.Mcp.ps1 helpers (issue #242).
+
+.DESCRIPTION
+    Each test asserts observable behavior (file contents, return
+    values, env-scope writes) using a temp-directory fixture so the
+    real user environment is never touched. Calls into
+    [Environment]::SetEnvironmentVariable are routed through the
+    Set-PersistedGitHubToken / Clear-PersistedGitHubToken helpers,
+    which Pester mocks intercept.
+#>
+
+BeforeAll {
+    . (Join-Path $PSScriptRoot 'AIAgents.Mcp.ps1')
+
+    function New-TempDir {
+        $p = Join-Path ([System.IO.Path]::GetTempPath()) "scoopbucket-mcp-tests-$([Guid]::NewGuid().ToString('N'))"
+        New-Item -ItemType Directory -Path $p -Force | Out-Null
+        return $p
+    }
+
+    $script:TempRoots = New-Object System.Collections.Generic.List[string]
+}
+
+AfterAll {
+    foreach ($p in $script:TempRoots) {
+        if ($p -and (Test-Path $p)) { Remove-Item -Path $p -Recurse -Force -ErrorAction SilentlyContinue }
+    }
+}
+
+Describe 'AIAgents.Mcp helpers' -Tag 'Light','Bundle' {
+
+    Context 'Get-McpProfileSentinelBlock' {
+        It 'emits the canonical start and end markers' {
+            $block = Get-McpProfileSentinelBlock
+            $block | Should -Match '# >>> ScoopBucket: GitHub PAT for MCP servers >>>'
+            $block | Should -Match '# <<< ScoopBucket: GitHub PAT for MCP servers <<<'
+        }
+
+        It 'guards the gh call with `-not $env:GITHUB_PERSONAL_ACCESS_TOKEN`' {
+            $block = Get-McpProfileSentinelBlock
+            $block | Should -Match 'if \(-not \$env:GITHUB_PERSONAL_ACCESS_TOKEN'
+        }
+
+        It 'defines the Update-GitHubTokenFromGh helper' {
+            $block = Get-McpProfileSentinelBlock
+            $block | Should -Match 'function Update-GitHubTokenFromGh'
+        }
+    }
+
+    Context 'Get-McpProfileTargets' {
+        It 'returns AllUsersAllHosts only when -IsElevated' {
+            $targets = @(Get-McpProfileTargets -IsElevated)
+            @($targets).Count | Should -Be 1
+            $targets[0] | Should -Be $PROFILE.AllUsersAllHosts
+        }
+
+        It 'returns CurrentUserAllHosts plus a WindowsPowerShell\profile.ps1 path when not elevated' {
+            $targets = @(Get-McpProfileTargets)
+            @($targets).Count | Should -Be 2
+            $targets[0] | Should -Be $PROFILE.CurrentUserAllHosts
+            $targets[1] | Should -Match 'Documents\\WindowsPowerShell\\profile\.ps1$'
+        }
+    }
+
+    Context 'Add-McpProfileSentinel / Remove-McpProfileSentinel' {
+        BeforeEach {
+            $script:TmpDir = New-TempDir
+            $script:TempRoots.Add($script:TmpDir)
+            $script:ProfilePath = Join-Path $script:TmpDir 'profile.ps1'
+        }
+
+        It 'creates the profile file with the sentinel block when it does not exist' {
+            $written = Add-McpProfileSentinel -Path $script:ProfilePath
+            $written | Should -BeTrue
+            (Test-Path $script:ProfilePath) | Should -BeTrue
+            $content = Get-Content -Path $script:ProfilePath -Raw
+            $content | Should -Match '# >>> ScoopBucket: GitHub PAT for MCP servers >>>'
+            $content | Should -Match '# <<< ScoopBucket: GitHub PAT for MCP servers <<<'
+        }
+
+        It 'is idempotent: a second call does not duplicate the block' {
+            Add-McpProfileSentinel -Path $script:ProfilePath | Out-Null
+            $second = Add-McpProfileSentinel -Path $script:ProfilePath
+            $second | Should -BeFalse
+            $content = Get-Content -Path $script:ProfilePath -Raw
+            ([regex]::Matches($content, [regex]::Escape('# >>> ScoopBucket: GitHub PAT for MCP servers >>>'))).Count | Should -Be 1
+        }
+
+        It 'preserves any pre-existing profile content' {
+            Set-Content -Path $script:ProfilePath -Value "Set-Alias ll Get-ChildItem`r`n" -Encoding UTF8 -NoNewline
+            Add-McpProfileSentinel -Path $script:ProfilePath | Out-Null
+            $content = Get-Content -Path $script:ProfilePath -Raw
+            $content | Should -Match 'Set-Alias ll Get-ChildItem'
+            $content | Should -Match '# >>> ScoopBucket: GitHub PAT for MCP servers >>>'
+        }
+
+        It 'Remove strips the sentinel block while preserving surrounding content' {
+            Set-Content -Path $script:ProfilePath -Value "Set-Alias ll Get-ChildItem`r`n" -Encoding UTF8 -NoNewline
+            Add-McpProfileSentinel -Path $script:ProfilePath | Out-Null
+            $removed = Remove-McpProfileSentinel -Path $script:ProfilePath
+            $removed | Should -BeTrue
+            (Test-Path $script:ProfilePath) | Should -BeTrue
+            $content = Get-Content -Path $script:ProfilePath -Raw
+            $content | Should -Match 'Set-Alias ll Get-ChildItem'
+            $content | Should -Not -Match '# >>> ScoopBucket'
+        }
+
+        It 'Remove on a file with only the sentinel deletes the file' {
+            Add-McpProfileSentinel -Path $script:ProfilePath | Out-Null
+            Remove-McpProfileSentinel -Path $script:ProfilePath | Out-Null
+            (Test-Path $script:ProfilePath) | Should -BeFalse
+        }
+
+        It 'Remove is a no-op when the file does not exist' {
+            $missing = Join-Path $script:TmpDir 'absent.ps1'
+            $result = Remove-McpProfileSentinel -Path $missing
+            $result | Should -BeFalse
+        }
+
+        It 'Remove is a no-op when the sentinel marker is absent' {
+            Set-Content -Path $script:ProfilePath -Value "Set-Alias ll Get-ChildItem`r`n" -Encoding UTF8 -NoNewline
+            $result = Remove-McpProfileSentinel -Path $script:ProfilePath
+            $result | Should -BeFalse
+            $content = Get-Content -Path $script:ProfilePath -Raw
+            $content | Should -Match 'Set-Alias ll Get-ChildItem'
+        }
+    }
+
+    Context 'Set/Clear-PersistedGitHubToken (mocked SetEnvironmentVariable)' {
+        BeforeEach {
+            $script:CapturedSet = New-Object System.Collections.Generic.List[hashtable]
+            Mock -CommandName 'Set-PersistedGitHubToken' -MockWith {
+                param($Token, $IsElevated)
+                $scope = if ($IsElevated) { 'Machine' } else { 'User' }
+                $script:CapturedSet.Add(@{ Token = $Token; Scope = $scope; Cleared = $false })
+            }
+            Mock -CommandName 'Clear-PersistedGitHubToken' -MockWith {
+                param($IsElevated)
+                $scope = if ($IsElevated) { 'Machine' } else { 'User' }
+                $script:CapturedSet.Add(@{ Token = $null; Scope = $scope; Cleared = $true })
+            }
+        }
+
+        It 'Set writes at User scope by default' {
+            Set-PersistedGitHubToken -Token 'gho_abc'
+            $script:CapturedSet[0].Scope | Should -Be 'User'
+            $script:CapturedSet[0].Token | Should -Be 'gho_abc'
+        }
+
+        It 'Set writes at Machine scope when -IsElevated' {
+            Set-PersistedGitHubToken -Token 'gho_xyz' -IsElevated
+            $script:CapturedSet[0].Scope | Should -Be 'Machine'
+        }
+
+        It 'Clear targets User scope by default' {
+            Clear-PersistedGitHubToken
+            $script:CapturedSet[0].Cleared | Should -BeTrue
+            $script:CapturedSet[0].Scope   | Should -Be 'User'
+        }
+
+        It 'Clear targets Machine scope when -IsElevated' {
+            Clear-PersistedGitHubToken -IsElevated
+            $script:CapturedSet[0].Scope | Should -Be 'Machine'
+        }
+    }
+
+    Context 'Resolve-NpmBin' {
+        BeforeEach {
+            $script:TmpRoot = New-TempDir
+            $script:TempRoots.Add($script:TmpRoot)
+            $script:NodeModules = Join-Path $script:TmpRoot 'node_modules'
+            New-Item -ItemType Directory -Path $script:NodeModules -Force | Out-Null
+        }
+
+        It 'resolves a string-form bin to a .cmd shim under the global root' {
+            $pkgDir = Join-Path $script:NodeModules '@upstash\context7-mcp'
+            New-Item -ItemType Directory -Path $pkgDir -Force | Out-Null
+            Set-Content -Path (Join-Path $pkgDir 'package.json') -Value '{"name":"@upstash/context7-mcp","bin":"./dist/index.js"}' -Encoding UTF8
+            Set-Content -Path (Join-Path $script:TmpRoot 'context7-mcp.cmd') -Value '@echo off' -Encoding UTF8
+
+            $bin = Resolve-NpmBin -PackageName '@upstash/context7-mcp' -NpmGlobalRoot $script:TmpRoot
+            $bin | Should -Not -BeNullOrEmpty
+            $bin | Should -Match 'context7-mcp\.cmd$'
+        }
+
+        It 'resolves an object-form bin to the first key.cmd' {
+            $pkgDir = Join-Path $script:NodeModules '@modelcontextprotocol\server-github'
+            New-Item -ItemType Directory -Path $pkgDir -Force | Out-Null
+            $manifest = '{"name":"@modelcontextprotocol/server-github","bin":{"mcp-server-github":"./dist/index.js"}}'
+            Set-Content -Path (Join-Path $pkgDir 'package.json') -Value $manifest -Encoding UTF8
+            Set-Content -Path (Join-Path $script:TmpRoot 'mcp-server-github.cmd') -Value '@echo off' -Encoding UTF8
+
+            $bin = Resolve-NpmBin -PackageName '@modelcontextprotocol/server-github' -NpmGlobalRoot $script:TmpRoot
+            $bin | Should -Match 'mcp-server-github\.cmd$'
+        }
+
+        It 'returns $null when the package is not installed' {
+            Resolve-NpmBin -PackageName 'no-such-pkg' -NpmGlobalRoot $script:TmpRoot | Should -Be $null
+        }
+
+        It 'returns $null when the bin shim file is missing' {
+            $pkgDir = Join-Path $script:NodeModules 'some-pkg'
+            New-Item -ItemType Directory -Path $pkgDir -Force | Out-Null
+            Set-Content -Path (Join-Path $pkgDir 'package.json') -Value '{"name":"some-pkg","bin":"./x.js"}' -Encoding UTF8
+            # NOTE: no some-pkg.cmd shim created.
+            Resolve-NpmBin -PackageName 'some-pkg' -NpmGlobalRoot $script:TmpRoot | Should -Be $null
+        }
+    }
+
+    Context 'Resolve-McpServerCommand' {
+        BeforeEach {
+            $script:TmpRoot = New-TempDir
+            $script:TempRoots.Add($script:TmpRoot)
+            $script:NodeModules = Join-Path $script:TmpRoot 'node_modules'
+            New-Item -ItemType Directory -Path $script:NodeModules -Force | Out-Null
+        }
+
+        It 'returns the resolved bin command with empty args when globally installed' {
+            $pkgDir = Join-Path $script:NodeModules '@upstash\context7-mcp'
+            New-Item -ItemType Directory -Path $pkgDir -Force | Out-Null
+            Set-Content -Path (Join-Path $pkgDir 'package.json') -Value '{"bin":"./i.js"}' -Encoding UTF8
+            Set-Content -Path (Join-Path $script:TmpRoot 'context7-mcp.cmd') -Value '@echo off' -Encoding UTF8
+
+            $r = Resolve-McpServerCommand -PackageName '@upstash/context7-mcp' -NpmGlobalRoot $script:TmpRoot
+            $r.Command   | Should -Match 'context7-mcp\.cmd$'
+            $r.Arguments | Should -Be @()
+        }
+
+        It 'falls back to npx -y <pkg> when bin resolution fails' {
+            $r = Resolve-McpServerCommand -PackageName '@nope/missing' -NpmGlobalRoot $script:TmpRoot
+            $r.Command   | Should -Be 'npx'
+            $r.Arguments | Should -Be @('-y', '@nope/missing')
+        }
+
+        It 'appends ExtraArguments to the npx fallback args' {
+            $r = Resolve-McpServerCommand -PackageName '@x/y' -NpmGlobalRoot $script:TmpRoot -ExtraArguments @('--root', 'C:\foo')
+            $r.Command   | Should -Be 'npx'
+            $r.Arguments | Should -Be @('-y', '@x/y', '--root', 'C:\foo')
+        }
+
+        It 'preserves ExtraArguments on the resolved-bin path' {
+            $pkgDir = Join-Path $script:NodeModules '@modelcontextprotocol\server-filesystem'
+            New-Item -ItemType Directory -Path $pkgDir -Force | Out-Null
+            Set-Content -Path (Join-Path $pkgDir 'package.json') -Value '{"bin":{"mcp-server-filesystem":"./i.js"}}' -Encoding UTF8
+            Set-Content -Path (Join-Path $script:TmpRoot 'mcp-server-filesystem.cmd') -Value '@echo off' -Encoding UTF8
+
+            $r = Resolve-McpServerCommand -PackageName '@modelcontextprotocol/server-filesystem' -NpmGlobalRoot $script:TmpRoot -ExtraArguments @('C:\Users\me')
+            $r.Command   | Should -Match 'mcp-server-filesystem\.cmd$'
+            $r.Arguments | Should -Be @('C:\Users\me')
+        }
+    }
+
+    Context 'Add-McpServerToJsonConfig: env emission' {
+        BeforeEach {
+            $script:TmpDir = New-TempDir
+            $script:TempRoots.Add($script:TmpDir)
+            $script:JsonPath = Join-Path $script:TmpDir 'config.json'
+        }
+
+        It 'omits the env block when Server has no Env key' {
+            $server = @{ Name = 'github'; Command = 'npx'; Arguments = @('-y','@modelcontextprotocol/server-github') }
+            Add-McpServerToJsonConfig -Path $script:JsonPath -AgentLabel 'Test' -Server $server
+            $cfg = Get-Content -Path $script:JsonPath -Raw | ConvertFrom-Json
+            $cfg.mcpServers.github.command | Should -Be 'npx'
+            $cfg.mcpServers.github.PSObject.Properties['env'] | Should -Be $null
+        }
+
+        It 'overwrites a pre-existing env block when re-run without Env (migration)' {
+            $initial = @{
+                mcpServers = @{
+                    github = @{
+                        command = 'npx'
+                        args    = @('-y', '@modelcontextprotocol/server-github')
+                        env     = @{ GITHUB_PERSONAL_ACCESS_TOKEN = 'leaked' }
+                    }
+                }
+            }
+            $initial | ConvertTo-Json -Depth 10 | Set-Content -Path $script:JsonPath -Encoding UTF8
+
+            $server = @{ Name = 'github'; Command = 'npx'; Arguments = @('-y','@modelcontextprotocol/server-github') }
+            Add-McpServerToJsonConfig -Path $script:JsonPath -AgentLabel 'Test' -Server $server
+
+            $cfg = Get-Content -Path $script:JsonPath -Raw | ConvertFrom-Json
+            $cfg.mcpServers.github.PSObject.Properties['env'] | Should -Be $null
+            (Get-Content -Path $script:JsonPath -Raw) | Should -Not -Match 'leaked'
+        }
+
+        It 'still emits env when Server has a populated Env hashtable (other servers, sanity check)' {
+            $server = @{
+                Name = 'with-env'; Command = 'foo'; Arguments = @()
+                Env  = @{ TOKEN = 'abc' }
+            }
+            Add-McpServerToJsonConfig -Path $script:JsonPath -AgentLabel 'Test' -Server $server
+            $cfg = Get-Content -Path $script:JsonPath -Raw | ConvertFrom-Json
+            $cfg.mcpServers.'with-env'.env.TOKEN | Should -Be 'abc'
+        }
+    }
+
+    Context 'Add-McpServerToCodex: env emission' {
+        BeforeEach {
+            $script:TmpDir = New-TempDir
+            $script:TempRoots.Add($script:TmpDir)
+            $script:CodexPath = Join-Path $script:TmpDir 'config.toml'
+        }
+
+        It 'omits [mcp_servers.<name>.env] when Server has no Env key' {
+            $server = @{ Name = 'github'; Command = 'npx'; Arguments = @('-y','@modelcontextprotocol/server-github') }
+            Add-McpServerToCodex -Server $server -Path $script:CodexPath
+            $content = Get-Content -Path $script:CodexPath -Raw
+            $content | Should -Match '\[mcp_servers\.github\]'
+            $content | Should -Not -Match '\[mcp_servers\.github\.env\]'
+        }
+
+        It 'strips an existing [mcp_servers.github.env] block on rewrite' {
+            Set-Content -Path $script:CodexPath -Value @"
+[mcp_servers.github]
+command = "npx"
+args = ["-y", "@modelcontextprotocol/server-github"]
+
+[mcp_servers.github.env]
+GITHUB_PERSONAL_ACCESS_TOKEN = "leaked"
+"@ -Encoding UTF8
+
+            $server = @{ Name = 'github'; Command = 'npx'; Arguments = @('-y','@modelcontextprotocol/server-github') }
+            Add-McpServerToCodex -Server $server -Path $script:CodexPath
+            $content = Get-Content -Path $script:CodexPath -Raw
+            $content | Should -Not -Match 'leaked'
+            $content | Should -Not -Match '\[mcp_servers\.github\.env\]'
+        }
+    }
+}

--- a/bucket/AIAgents.Mcp.ps1
+++ b/bucket/AIAgents.Mcp.ps1
@@ -1,0 +1,440 @@
+#requires -Version 7.0
+
+<#
+.SYNOPSIS
+    Helper functions for AIAgents.ps1 MCP-server wiring.
+
+.DESCRIPTION
+    AIAgents.ps1 dot-sources this file. Tests dot-source it directly
+    so they can exercise individual helpers without running the
+    bundle's imperative install side effects.
+
+    Functions ONLY. No top-level work. Dot-sourcing must have zero
+    observable side effects.
+
+    See bucket/AIAgents.Mcp.Tests.ps1 for behavior-first coverage.
+#>
+
+# ---------------------------------------------------------------------------
+# Profile self-heal sentinel: idempotent block appended to PowerShell
+# profile(s) so any new shell whose env var is missing back-fills from
+# `gh auth token`. Steady-state cost is microseconds: HKCU/Machine User
+# env scope auto-populates the variable in nearly every spawn, so the
+# `-not $env:GITHUB_PERSONAL_ACCESS_TOKEN` guard short-circuits before
+# any process spawn.
+# ---------------------------------------------------------------------------
+
+$script:McpProfileSentinelStart = '# >>> ScoopBucket: GitHub PAT for MCP servers >>>'
+$script:McpProfileSentinelEnd   = '# <<< ScoopBucket: GitHub PAT for MCP servers <<<'
+
+function Get-McpProfileSentinelBlock {
+    @"
+$script:McpProfileSentinelStart
+# Self-heal: HKCU User env var (set by AIAgents.ps1) is normally already
+# inherited at process startup. Only fetch from gh as a fallback.
+if (-not `$env:GITHUB_PERSONAL_ACCESS_TOKEN -and (Get-Command gh -ErrorAction SilentlyContinue)) {
+    try { `$env:GITHUB_PERSONAL_ACCESS_TOKEN = (gh auth token 2>`$null).Trim() } catch { }
+}
+function Update-GitHubTokenFromGh {
+    if (-not (Get-Command gh -ErrorAction SilentlyContinue)) { Write-Warning 'gh CLI not found.'; return }
+    `$token = (gh auth token 2>`$null).Trim()
+    if (-not `$token) { Write-Warning 'gh auth token returned empty.'; return }
+    `$env:GITHUB_PERSONAL_ACCESS_TOKEN = `$token
+    [Environment]::SetEnvironmentVariable('GITHUB_PERSONAL_ACCESS_TOKEN', `$token, 'User')
+    Write-Host 'Refreshed GITHUB_PERSONAL_ACCESS_TOKEN in current shell + HKCU User env.'
+}
+$script:McpProfileSentinelEnd
+"@
+}
+
+# ---------------------------------------------------------------------------
+# Elevation detection. Wrapped as a function so tests can Mock it.
+# ---------------------------------------------------------------------------
+
+function Test-IsElevated {
+    [CmdletBinding()]
+    [OutputType([bool])]
+    param()
+
+    try {
+        $identity = [System.Security.Principal.WindowsIdentity]::GetCurrent()
+        $principal = New-Object System.Security.Principal.WindowsPrincipal($identity)
+        return $principal.IsInRole([System.Security.Principal.WindowsBuiltInRole]::Administrator)
+    } catch {
+        return $false
+    }
+}
+
+function Get-McpProfileTargets {
+    <#
+    .SYNOPSIS
+        Returns the list of PowerShell profile paths the sentinel block
+        should be installed into. Elevation-aware:
+          elevated     -> AllUsersAllHosts (machine-wide pwsh 7)
+          non-elevated -> CurrentUserAllHosts (pwsh 7) +
+                          ~\Documents\WindowsPowerShell\profile.ps1 (5.1)
+    #>
+    [CmdletBinding()]
+    [OutputType([string[]])]
+    param(
+        [switch]$IsElevated
+    )
+
+    if ($IsElevated) {
+        return [string[]]@($PROFILE.AllUsersAllHosts)
+    }
+
+    $pwsh7 = $PROFILE.CurrentUserAllHosts
+    $ps51  = Join-Path $env:USERPROFILE 'Documents\WindowsPowerShell\profile.ps1'
+    return [string[]]@($pwsh7, $ps51)
+}
+
+# ---------------------------------------------------------------------------
+# Profile sentinel I/O.
+# ---------------------------------------------------------------------------
+
+function Add-McpProfileSentinel {
+    <#
+    .SYNOPSIS
+        Idempotently append the sentinel-bracketed block to a single
+        profile file. Re-runs are no-ops when the start marker is
+        already present.
+    #>
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)][string]$Path
+    )
+
+    $dir = Split-Path -Parent $Path
+    if ($dir -and -not (Test-Path $dir)) {
+        New-Item -ItemType Directory -Path $dir -Force | Out-Null
+    }
+
+    if (Test-Path $Path) {
+        $existing = Get-Content -Path $Path -Raw -ErrorAction SilentlyContinue
+        if ($existing -and $existing -match [regex]::Escape($script:McpProfileSentinelStart)) {
+            return $false  # already present
+        }
+        $separator = if ($existing -and -not $existing.EndsWith("`n")) { "`r`n" } else { '' }
+        $block = $separator + (Get-McpProfileSentinelBlock) + "`r`n"
+        Add-Content -Path $Path -Value $block -Encoding UTF8 -NoNewline
+    } else {
+        Set-Content -Path $Path -Value ((Get-McpProfileSentinelBlock) + "`r`n") -Encoding UTF8 -NoNewline
+    }
+    return $true
+}
+
+function Remove-McpProfileSentinel {
+    <#
+    .SYNOPSIS
+        Idempotently strip the sentinel-bracketed block from a profile
+        file. No-op if the marker is absent or the file does not exist.
+    #>
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)][string]$Path
+    )
+
+    if (-not (Test-Path $Path)) { return $false }
+
+    $content = Get-Content -Path $Path -Raw -ErrorAction SilentlyContinue
+    if ([string]::IsNullOrEmpty($content)) { return $false }
+
+    $startEsc = [regex]::Escape($script:McpProfileSentinelStart)
+    $endEsc   = [regex]::Escape($script:McpProfileSentinelEnd)
+    $pattern  = "(?ms)\r?\n?$startEsc.*?$endEsc\r?\n?"
+
+    $newContent = [regex]::Replace($content, $pattern, '')
+    if ($newContent -eq $content) { return $false }
+
+    if ([string]::IsNullOrWhiteSpace($newContent)) {
+        Remove-Item -Path $Path -Force -ErrorAction SilentlyContinue
+    } else {
+        Set-Content -Path $Path -Value $newContent.TrimEnd() -Encoding UTF8
+    }
+    return $true
+}
+
+# ---------------------------------------------------------------------------
+# Persisted env var (HKCU User scope, or HKLM Machine scope when elevated).
+# Wrapped so tests can Mock these without touching the real registry.
+# ---------------------------------------------------------------------------
+
+function Set-PersistedGitHubToken {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)][AllowEmptyString()][string]$Token,
+        [switch]$IsElevated
+    )
+
+    $scope = if ($IsElevated) { 'Machine' } else { 'User' }
+    [Environment]::SetEnvironmentVariable('GITHUB_PERSONAL_ACCESS_TOKEN', $Token, $scope)
+}
+
+function Clear-PersistedGitHubToken {
+    [CmdletBinding()]
+    param(
+        [switch]$IsElevated
+    )
+
+    $scope = if ($IsElevated) { 'Machine' } else { 'User' }
+    [Environment]::SetEnvironmentVariable('GITHUB_PERSONAL_ACCESS_TOKEN', $null, $scope)
+}
+
+# ---------------------------------------------------------------------------
+# npm bin resolution. Locates the .cmd shim for a globally-installed
+# package without hard-coding bin names that can change upstream.
+# ---------------------------------------------------------------------------
+
+function Get-NpmGlobalRoot {
+    [CmdletBinding()]
+    [OutputType([string])]
+    param()
+
+    if (-not (Get-Command npm -ErrorAction SilentlyContinue)) { return $null }
+    try {
+        $prefix = (& npm prefix -g 2>$null)
+        if ($LASTEXITCODE -ne 0 -or -not $prefix) { return $null }
+        return ($prefix | Out-String).Trim()
+    } catch {
+        return $null
+    }
+}
+
+function Resolve-NpmBin {
+    <#
+    .SYNOPSIS
+        Resolve a globally-installed npm package's .cmd shim path by
+        reading its package.json#bin map under the global node_modules
+        root. Returns $null if the package or shim is missing.
+    .PARAMETER NpmGlobalRoot
+        Optional override (used by tests to point at a temp directory).
+    #>
+    [CmdletBinding()]
+    [OutputType([string])]
+    param(
+        [Parameter(Mandatory)][string]$PackageName,
+        [string]$NpmGlobalRoot
+    )
+
+    if (-not $NpmGlobalRoot) { $NpmGlobalRoot = Get-NpmGlobalRoot }
+    if (-not $NpmGlobalRoot) { return $null }
+
+    $pkgJson = Join-Path $NpmGlobalRoot "node_modules\$PackageName\package.json"
+    if (-not (Test-Path $pkgJson)) { return $null }
+
+    try {
+        $manifest = Get-Content -Path $pkgJson -Raw | ConvertFrom-Json
+    } catch {
+        return $null
+    }
+    if (-not $manifest -or -not $manifest.bin) { return $null }
+
+    $binName = $null
+    if ($manifest.bin -is [string]) {
+        # Single-bin form: bin name is the package's last path segment.
+        $binName = ($PackageName -split '/')[-1]
+    } elseif ($manifest.bin -is [pscustomobject]) {
+        $binName = ($manifest.bin.PSObject.Properties | Select-Object -First 1).Name
+    } elseif ($manifest.bin -is [hashtable]) {
+        $binName = @($manifest.bin.Keys)[0]
+    }
+    if (-not $binName) { return $null }
+
+    $cmd = Join-Path $NpmGlobalRoot "$binName.cmd"
+    if (-not (Test-Path $cmd)) { return $null }
+    return $cmd
+}
+
+# ---------------------------------------------------------------------------
+# MCP-config writers/removers. Logic preserved from AIAgents.ps1 with
+# one behavioral change: the JSON writer no longer emits an `env` block
+# when the server entry's Env hashtable is missing or empty (so an old
+# token-bearing entry is silently overwritten with a token-less one
+# on the next run).
+# ---------------------------------------------------------------------------
+
+function Add-McpServerToJsonConfig {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)][string]$Path,
+        [Parameter(Mandatory)][string]$AgentLabel,
+        [Parameter(Mandatory)][hashtable]$Server
+    )
+
+    $dir = Split-Path -Parent $Path
+    if ($dir -and -not (Test-Path $dir)) {
+        New-Item -ItemType Directory -Path $dir -Force | Out-Null
+    }
+
+    if (Test-Path $Path) {
+        try {
+            $config = Get-Content -Path $Path -Raw | ConvertFrom-Json
+        }
+        catch {
+            Write-Warning "$AgentLabel`: existing config at $Path is not valid JSON; skipping $($Server.Name)."
+            return
+        }
+    }
+    else {
+        $config = [pscustomobject]@{}
+    }
+
+    if (-not $config.PSObject.Properties['mcpServers']) {
+        $config | Add-Member -NotePropertyName mcpServers -NotePropertyValue ([pscustomobject]@{})
+    }
+
+    $entry = [pscustomobject]@{
+        command = $Server.Command
+        args    = $Server.Arguments
+    }
+    if ($Server.ContainsKey('Env') -and $Server.Env -and $Server.Env.Count -gt 0) {
+        $envObj = [pscustomobject]@{}
+        foreach ($k in $Server.Env.Keys) {
+            $val = $Server.Env[$k]
+            if ($null -eq $val) { $val = '' }
+            $envObj | Add-Member -NotePropertyName $k -NotePropertyValue $val
+        }
+        $entry | Add-Member -NotePropertyName env -NotePropertyValue $envObj
+    }
+
+    if ($config.mcpServers.PSObject.Properties[$Server.Name]) {
+        $config.mcpServers.($Server.Name) = $entry
+    }
+    else {
+        $config.mcpServers | Add-Member -NotePropertyName $Server.Name -NotePropertyValue $entry
+    }
+
+    $config | ConvertTo-Json -Depth 20 | Set-Content -Path $Path -Encoding UTF8
+    Write-Host "$AgentLabel`: configured $($Server.Name) MCP in $Path"
+}
+
+function Add-McpServerToCodex {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)][hashtable]$Server,
+        [string]$Path
+    )
+
+    if (-not $Path) { $Path = Join-Path $env:USERPROFILE '.codex\config.toml' }
+    $dir  = Split-Path -Parent $Path
+    if ($dir -and -not (Test-Path $dir)) {
+        New-Item -ItemType Directory -Path $dir -Force | Out-Null
+    }
+
+    # TOML basic strings interpret backslash as an escape character. Any
+    # raw Windows path like 'C:\Users\Mark' contains '\U' which the TOML
+    # parser tries to consume as a \UXXXXXXXX Unicode escape and fails
+    # with "too few unicode value digits". Escape backslashes (\ -> \\)
+    # and double-quotes (" -> \") in every interpolated value.
+    $argsToml = ($Server.Arguments | ForEach-Object {
+        $esc = $_ -replace '\\','\\' -replace '"','\"'
+        '"' + $esc + '"'
+    }) -join ', '
+    $cmdEsc = $Server.Command -replace '\\','\\' -replace '"','\"'
+    $section = @"
+[mcp_servers.$($Server.Name)]
+command = "$cmdEsc"
+args = [$argsToml]
+"@
+    if ($Server.ContainsKey('Env') -and $Server.Env -and $Server.Env.Count -gt 0) {
+        $envLines = foreach ($k in $Server.Env.Keys) {
+            $v = $Server.Env[$k]
+            if ($null -eq $v) { $v = '' }
+            $vEsc = $v -replace '\\','\\' -replace '"','\"'
+            "$k = `"$vEsc`""
+        }
+        $section += "`r`n[mcp_servers.$($Server.Name).env]`r`n" + ($envLines -join "`r`n")
+    }
+
+    $sectionPattern    = "(?ms)^\[mcp_servers\.$([regex]::Escape($Server.Name))\].*?(?=^\[|\z)"
+    $envSectionPattern = "(?ms)^\[mcp_servers\.$([regex]::Escape($Server.Name))\.env\].*?(?=^\[|\z)"
+
+    if (Test-Path $Path) {
+        $content = Get-Content -Path $Path -Raw
+        $content = [regex]::Replace($content, $envSectionPattern, '')
+        $content = [regex]::Replace($content, $sectionPattern, '')
+        $content = $content.TrimEnd() + "`r`n`r`n" + $section + "`r`n"
+        Set-Content -Path $Path -Value $content -Encoding UTF8
+    }
+    else {
+        Set-Content -Path $Path -Value ($section + "`r`n") -Encoding UTF8
+    }
+    Write-Host "Codex CLI: configured $($Server.Name) MCP in $Path"
+}
+
+function Remove-McpServerFromJsonConfig {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)][string]$Path,
+        [Parameter(Mandatory)][string]$AgentLabel,
+        [Parameter(Mandatory)][string]$ServerName
+    )
+
+    if (-not (Test-Path $Path)) { return }
+    try {
+        $config = Get-Content -Path $Path -Raw | ConvertFrom-Json
+    }
+    catch {
+        Write-Warning "$AgentLabel`: existing config at $Path is not valid JSON; skipping prune of $ServerName."
+        return
+    }
+    if (-not $config.PSObject.Properties['mcpServers']) { return }
+    if (-not $config.mcpServers.PSObject.Properties[$ServerName]) { return }
+
+    $config.mcpServers.PSObject.Properties.Remove($ServerName)
+    $config | ConvertTo-Json -Depth 20 | Set-Content -Path $Path -Encoding UTF8
+    Write-Host "$AgentLabel`: pruned $ServerName MCP from $Path"
+}
+
+function Remove-McpServerFromCodex {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)][string]$ServerName,
+        [string]$Path
+    )
+
+    if (-not $Path) { $Path = Join-Path $env:USERPROFILE '.codex\config.toml' }
+    if (-not (Test-Path $Path)) { return }
+
+    $sectionPattern    = "(?ms)^\[mcp_servers\.$([regex]::Escape($ServerName))\].*?(?=^\[|\z)"
+    $envSectionPattern = "(?ms)^\[mcp_servers\.$([regex]::Escape($ServerName))\.env\].*?(?=^\[|\z)"
+
+    $content    = Get-Content -Path $Path -Raw
+    $newContent = [regex]::Replace($content, $envSectionPattern, '')
+    $newContent = [regex]::Replace($newContent, $sectionPattern, '')
+    if ($newContent -ne $content) {
+        Set-Content -Path $Path -Value $newContent.TrimEnd() -Encoding UTF8
+        Write-Host "Codex CLI: pruned $ServerName MCP from $Path"
+    }
+}
+
+# ---------------------------------------------------------------------------
+# Resolve $McpServers entries. For each npm-backed server, prefer the
+# globally-installed bin shim (fast, no npx round-trip); fall back to
+# `npx -y <pkg>` when bin resolution fails (graceful degradation).
+# ---------------------------------------------------------------------------
+
+function Resolve-McpServerCommand {
+    <#
+    .SYNOPSIS
+        Given an npm package name, return a hashtable with `Command`
+        and `Arguments` keys: the resolved bin path with empty args
+        when the package is globally installed, otherwise an
+        `npx -y <pkg>` fallback.
+    #>
+    [CmdletBinding()]
+    [OutputType([hashtable])]
+    param(
+        [Parameter(Mandatory)][string]$PackageName,
+        [string]$NpmGlobalRoot,
+        [string[]]$ExtraArguments = @()
+    )
+
+    $bin = Resolve-NpmBin -PackageName $PackageName -NpmGlobalRoot $NpmGlobalRoot
+    if ($bin) {
+        return @{ Command = $bin; Arguments = @($ExtraArguments) }
+    }
+    $args = @('-y', $PackageName) + $ExtraArguments
+    return @{ Command = 'npx'; Arguments = $args }
+}

--- a/bucket/AIAgents.json
+++ b/bucket/AIAgents.json
@@ -1,6 +1,6 @@
 {
     "$schema": "https://raw.githubusercontent.com/lukesampson/scoop/master/schema.json",
-    "version": "1.21.000",
+    "version": "1.22.000",
     "url": [
         "https://raw.githubusercontent.com/MarkMichaelis/ScoopBucket/master/bucket/AIAgents.ps1"
     ],

--- a/bucket/AIAgents.ps1
+++ b/bucket/AIAgents.ps1
@@ -334,6 +334,18 @@ Register-ArgumentCompleter -Native -CommandName copilot -ScriptBlock {
 
 Invoke-PackageInstall -Packages $Packages -Bundle 'AIAgents'
 
+# Probe-mode short-circuit: when Get-BundlePackages enumerates the bundle
+# in a child runspace it shims Invoke-PackageInstall and sets this flag,
+# signaling that the trailing imperative work below (npm/dotnet installs,
+# config file writes, HKCU env-var writes, profile-block injection) must
+# be skipped. Production runs leave the flag unset so the work proceeds.
+if ($global:__SBPKG_IS_PROBE) { return }
+
+# Dot-source MCP-wiring helpers. AIAgents.Mcp.ps1 contains function
+# definitions only -- no top-level work -- so the file is safe to source
+# from this bundle as well as from bucket/AIAgents.Mcp.Tests.ps1.
+. (Join-Path $PSScriptRoot 'AIAgents.Mcp.ps1')
+
 # ---------------------------------------------------------------------------
 # MCP server prerequisites that are NOT npm-based.
 # ---------------------------------------------------------------------------
@@ -411,27 +423,68 @@ if ([string]::IsNullOrWhiteSpace($GithubToken)) {
 
 $DeprecatedMcpServers = @('shell')
 
+# ---------------------------------------------------------------------------
+# Pre-install MCP server npm packages globally so each agent spawn invokes
+# the resolved .cmd shim directly instead of paying a fresh npx tarball-
+# fetch round-trip on first use. We deliberately keep `npm install -g
+# <pkg>@latest` (no version pin) so a routine bucket reinstall pulls fixes;
+# `Resolve-McpServerCommand` falls back to `npx -y <pkg>` per-entry when
+# global install or bin resolution fails (graceful degradation).
+# ---------------------------------------------------------------------------
+
+$McpNpmPackages = @(
+    '@upstash/context7-mcp',
+    '@playwright/mcp',
+    '@modelcontextprotocol/server-github',
+    '@modelcontextprotocol/server-filesystem'
+)
+
+if (Get-Command npm -ErrorAction SilentlyContinue) {
+    foreach ($pkg in $McpNpmPackages) {
+        Write-Host "Installing $pkg globally (latest)..."
+        & npm.cmd install --global "$pkg@latest" 2>&1 | Out-Host
+        if ($LASTEXITCODE -ne 0) {
+            Write-Warning "npm install -g $pkg failed; that MCP entry will fall back to 'npx -y'."
+        }
+    }
+}
+else {
+    Write-Warning 'npm not found; all MCP npm entries will fall back to npx (slow first-spawn).'
+}
+
+$NpmGlobalRoot = Get-NpmGlobalRoot
+
+$context7Cmd   = Resolve-McpServerCommand -PackageName '@upstash/context7-mcp'                  -NpmGlobalRoot $NpmGlobalRoot
+$playwrightCmd = Resolve-McpServerCommand -PackageName '@playwright/mcp'                        -NpmGlobalRoot $NpmGlobalRoot
+$filesystemCmd = Resolve-McpServerCommand -PackageName '@modelcontextprotocol/server-filesystem' -NpmGlobalRoot $NpmGlobalRoot -ExtraArguments @($env:USERPROFILE)
+$githubCmd     = Resolve-McpServerCommand -PackageName '@modelcontextprotocol/server-github'    -NpmGlobalRoot $NpmGlobalRoot
+
 $McpServers = @(
     @{
         Name      = 'context7'
-        Command   = 'npx'
-        Arguments = @('-y', '@upstash/context7-mcp')
+        Command   = $context7Cmd.Command
+        Arguments = $context7Cmd.Arguments
     }
     @{
         Name      = 'playwright'
-        Command   = 'npx'
-        Arguments = @('-y', '@playwright/mcp@latest')
+        Command   = $playwrightCmd.Command
+        Arguments = $playwrightCmd.Arguments
     }
     @{
         Name      = 'filesystem'
-        Command   = 'npx'
-        Arguments = @('-y', '@modelcontextprotocol/server-filesystem', $env:USERPROFILE)
+        Command   = $filesystemCmd.Command
+        Arguments = $filesystemCmd.Arguments
     }
     @{
-        Name      = 'github'
-        Command   = 'npx'
-        Arguments = @('-y', '@modelcontextprotocol/server-github')
-        Env       = @{ GITHUB_PERSONAL_ACCESS_TOKEN = $GithubToken }
+        Name       = 'github'
+        Command    = $githubCmd.Command
+        Arguments  = $githubCmd.Arguments
+        # No `Env` block: the token is provisioned out-of-band via HKCU
+        # (Set-PersistedGitHubToken below) and the profile self-heal
+        # sentinel, so it is no longer scattered across config files.
+        # GitHub Copilot CLI ships its own remote `github-mcp-server`
+        # built in; skip writing this entry there to avoid duplication.
+        SkipAgents = @('GitHub Copilot CLI')
     }
 )
 
@@ -443,117 +496,6 @@ if ($PoshMcpAvailable) {
     }
 }
 
-Function Add-McpServerToJsonConfig {
-    [CmdletBinding()]
-    param(
-        [Parameter(Mandatory)][string]$Path,
-        [Parameter(Mandatory)][string]$AgentLabel,
-        [Parameter(Mandatory)][hashtable]$Server
-    )
-
-    $dir = Split-Path -Parent $Path
-    if (-not (Test-Path $dir)) {
-        New-Item -ItemType Directory -Path $dir -Force | Out-Null
-    }
-
-    if (Test-Path $Path) {
-        try {
-            $config = Get-Content -Path $Path -Raw | ConvertFrom-Json
-        }
-        catch {
-            Write-Warning "$AgentLabel`: existing config at $Path is not valid JSON; skipping $($Server.Name)."
-            return
-        }
-    }
-    else {
-        $config = [pscustomobject]@{}
-    }
-
-    if (-not $config.PSObject.Properties['mcpServers']) {
-        $config | Add-Member -NotePropertyName mcpServers -NotePropertyValue ([pscustomobject]@{})
-    }
-
-    $entry = [pscustomobject]@{
-        command = $Server.Command
-        args    = $Server.Arguments
-    }
-    if ($Server.ContainsKey('Env') -and $Server.Env -and $Server.Env.Count -gt 0) {
-        $envObj = [pscustomobject]@{}
-        foreach ($k in $Server.Env.Keys) {
-            $val = $Server.Env[$k]
-            if ($null -eq $val) { $val = '' }
-            $envObj | Add-Member -NotePropertyName $k -NotePropertyValue $val
-        }
-        $entry | Add-Member -NotePropertyName env -NotePropertyValue $envObj
-    }
-
-    if ($config.mcpServers.PSObject.Properties[$Server.Name]) {
-        $config.mcpServers.($Server.Name) = $entry
-    }
-    else {
-        $config.mcpServers | Add-Member -NotePropertyName $Server.Name -NotePropertyValue $entry
-    }
-
-    $config | ConvertTo-Json -Depth 20 | Set-Content -Path $Path -Encoding UTF8
-    Write-Host "$AgentLabel`: configured $($Server.Name) MCP in $Path"
-}
-
-Function Add-McpServerToCodex {
-    param(
-        [Parameter(Mandatory)][hashtable]$Server
-    )
-
-    $path = Join-Path $env:USERPROFILE '.codex\config.toml'
-    $dir  = Split-Path -Parent $path
-    if (-not (Test-Path $dir)) {
-        New-Item -ItemType Directory -Path $dir -Force | Out-Null
-    }
-
-    # TOML basic strings interpret backslash as an escape character. Any
-    # raw Windows path like 'C:\Users\Mark' contains '\U' which the TOML
-    # parser tries to consume as a \UXXXXXXXX Unicode escape and fails
-    # with "too few unicode value digits". Escape backslashes (\ -> \\)
-    # and double-quotes (" -> \") in every interpolated value.
-    #
-    # Note on PowerShell -replace replacement strings: in .NET regex
-    # replacement, '$' is special but '\' is literal. So replacement
-    # '\\' (2 chars) emits 2 chars '\\', and replacement '\"' emits '\"'.
-    $argsToml = ($Server.Arguments | ForEach-Object {
-        $esc = $_ -replace '\\','\\' -replace '"','\"'
-        '"' + $esc + '"'
-    }) -join ', '
-    $cmdEsc = $Server.Command -replace '\\','\\' -replace '"','\"'
-    $section = @"
-[mcp_servers.$($Server.Name)]
-command = "$cmdEsc"
-args = [$argsToml]
-"@
-    if ($Server.ContainsKey('Env') -and $Server.Env -and $Server.Env.Count -gt 0) {
-        $envLines = foreach ($k in $Server.Env.Keys) {
-            $v = $Server.Env[$k]
-            if ($null -eq $v) { $v = '' }
-            $vEsc = $v -replace '\\','\\' -replace '"','\"'
-            "$k = `"$vEsc`""
-        }
-        $section += "`r`n[mcp_servers.$($Server.Name).env]`r`n" + ($envLines -join "`r`n")
-    }
-
-    $sectionPattern    = "(?ms)^\[mcp_servers\.$([regex]::Escape($Server.Name))\].*?(?=^\[|\z)"
-    $envSectionPattern = "(?ms)^\[mcp_servers\.$([regex]::Escape($Server.Name))\.env\].*?(?=^\[|\z)"
-
-    if (Test-Path $path) {
-        $content = Get-Content -Path $path -Raw
-        $content = [regex]::Replace($content, $envSectionPattern, '')
-        $content = [regex]::Replace($content, $sectionPattern, '')
-        $content = $content.TrimEnd() + "`r`n`r`n" + $section + "`r`n"
-        Set-Content -Path $path -Value $content -Encoding UTF8
-    }
-    else {
-        Set-Content -Path $path -Value ($section + "`r`n") -Encoding UTF8
-    }
-    Write-Host "Codex CLI: configured $($Server.Name) MCP in $path"
-}
-
 $JsonAgents = @(
     @{ Label = 'Claude Desktop';      Path = (Join-Path $env:APPDATA      'Claude\claude_desktop_config.json') }
     @{ Label = 'Claude Code CLI';     Path = (Join-Path $env:USERPROFILE  '.claude.json') }
@@ -561,55 +503,42 @@ $JsonAgents = @(
     @{ Label = 'GitHub Copilot CLI';  Path = (Join-Path $env:USERPROFILE  '.copilot\mcp-config.json') }
 )
 
-Function Remove-McpServerFromJsonConfig {
-    [CmdletBinding()]
-    param(
-        [Parameter(Mandatory)][string]$Path,
-        [Parameter(Mandatory)][string]$AgentLabel,
-        [Parameter(Mandatory)][string]$ServerName
-    )
-
-    if (-not (Test-Path $Path)) { return }
-    try {
-        $config = Get-Content -Path $Path -Raw | ConvertFrom-Json
-    }
-    catch {
-        Write-Warning "$AgentLabel`: existing config at $Path is not valid JSON; skipping prune of $ServerName."
-        return
-    }
-    if (-not $config.PSObject.Properties['mcpServers']) { return }
-    if (-not $config.mcpServers.PSObject.Properties[$ServerName]) { return }
-
-    $config.mcpServers.PSObject.Properties.Remove($ServerName)
-    $config | ConvertTo-Json -Depth 20 | Set-Content -Path $Path -Encoding UTF8
-    Write-Host "$AgentLabel`: pruned deprecated $ServerName MCP from $Path"
-}
-
-Function Remove-McpServerFromCodex {
-    param(
-        [Parameter(Mandatory)][string]$ServerName
-    )
-
-    $path = Join-Path $env:USERPROFILE '.codex\config.toml'
-    if (-not (Test-Path $path)) { return }
-
-    $sectionPattern    = "(?ms)^\[mcp_servers\.$([regex]::Escape($ServerName))\].*?(?=^\[|\z)"
-    $envSectionPattern = "(?ms)^\[mcp_servers\.$([regex]::Escape($ServerName))\.env\].*?(?=^\[|\z)"
-
-    $content    = Get-Content -Path $path -Raw
-    $newContent = [regex]::Replace($content, $envSectionPattern, '')
-    $newContent = [regex]::Replace($newContent, $sectionPattern, '')
-    if ($newContent -ne $content) {
-        Set-Content -Path $path -Value $newContent.TrimEnd() -Encoding UTF8
-        Write-Host "Codex CLI: pruned deprecated $ServerName MCP from $path"
-    }
-}
-
 foreach ($server in $McpServers) {
+    $skip = @()
+    if ($server.ContainsKey('SkipAgents') -and $server.SkipAgents) { $skip = @($server.SkipAgents) }
+
     foreach ($agent in $JsonAgents) {
+        if ($skip -contains $agent.Label) {
+            Write-Host "$($agent.Label): skipping $($server.Name) MCP (built-in equivalent)."
+            continue
+        }
         Add-McpServerToJsonConfig -Path $agent.Path -AgentLabel $agent.Label -Server $server
     }
-    Add-McpServerToCodex -Server $server
+    if ($skip -notcontains 'Codex CLI') {
+        Add-McpServerToCodex -Server $server
+    }
+}
+
+# ---------------------------------------------------------------------------
+# Provision the GitHub PAT out-of-band so it does NOT live in any agent
+# config file. Claude Desktop launches from the Start menu and will not
+# inherit shell env, so we additionally persist the value at HKCU User
+# (or HKLM Machine when elevated) scope. Profile sentinel acts as a
+# self-heal fallback if HKCU is ever cleared.
+# ---------------------------------------------------------------------------
+
+$IsElevated = Test-IsElevated
+
+if (-not [string]::IsNullOrWhiteSpace($GithubToken)) {
+    Set-PersistedGitHubToken -Token $GithubToken -IsElevated:$IsElevated
+    $scopeLabel = if ($IsElevated) { 'HKLM Machine' } else { 'HKCU User' }
+    Write-Host "GitHub MCP: persisted GITHUB_PERSONAL_ACCESS_TOKEN at $scopeLabel scope."
+}
+
+foreach ($profilePath in (Get-McpProfileTargets -IsElevated:$IsElevated)) {
+    if (Add-McpProfileSentinel -Path $profilePath) {
+        Write-Host "GitHub MCP: installed self-heal block in $profilePath"
+    }
 }
 
 if ($Reset) {
@@ -619,6 +548,36 @@ if ($Reset) {
             Remove-McpServerFromJsonConfig -Path $agent.Path -AgentLabel $agent.Label -ServerName $name
         }
         Remove-McpServerFromCodex -ServerName $name
+    }
+
+    # Prune entries this run intentionally skipped (e.g., GitHub Copilot
+    # CLI) so users upgrading from a pre-skip version get their stale
+    # `github` entry cleaned out of `~\.copilot\mcp-config.json`.
+    foreach ($server in $McpServers) {
+        if (-not $server.ContainsKey('SkipAgents')) { continue }
+        foreach ($skipLabel in @($server.SkipAgents)) {
+            $agent = $JsonAgents | Where-Object { $_.Label -eq $skipLabel } | Select-Object -First 1
+            if ($agent) {
+                Remove-McpServerFromJsonConfig -Path $agent.Path -AgentLabel $agent.Label -ServerName $server.Name
+            }
+        }
+    }
+
+    Write-Host "-Reset: removing GitHub PAT self-heal block from PowerShell profile(s)..."
+    foreach ($profilePath in (Get-McpProfileTargets -IsElevated:$IsElevated)) {
+        if (Remove-McpProfileSentinel -Path $profilePath) {
+            Write-Host "  pruned $profilePath"
+        }
+    }
+
+    Write-Host "-Reset: clearing persisted GITHUB_PERSONAL_ACCESS_TOKEN env var..."
+    Clear-PersistedGitHubToken -IsElevated:$IsElevated
+
+    if (Get-Command npm -ErrorAction SilentlyContinue) {
+        Write-Host "-Reset: uninstalling MCP npm packages globally..."
+        foreach ($pkg in $McpNpmPackages) {
+            & npm.cmd uninstall --global $pkg 2>&1 | Out-Host
+        }
     }
 }
 

--- a/module/MarkMichaelis.ScoopBucket/Private/Get-BundlePackages.ps1
+++ b/module/MarkMichaelis.ScoopBucket/Private/Get-BundlePackages.ps1
@@ -79,6 +79,10 @@ function Get-ScoopBucketModulePath { return '$packageClass' }
 
 function global:Invoke-PackageInstall {
     param([Parameter(Mandatory)][object[]]`$Packages, [Parameter(Mandatory)][string]`$Bundle, [Parameter(ValueFromRemainingArguments)]`$Remaining)
+    # Mark the runspace as a probe so bundle scripts that continue past
+    # this shimmed call (e.g. AIAgents.ps1's MCP wiring) can short-circuit
+    # before performing real side effects.
+    `$global:__SBPKG_IS_PROBE = `$true
     `$exported = foreach (`$p in `$Packages) {
         # Pre-invoke the NativeCommandScript per declared CLI inside this
         # child runspace so the parent process can assert on what the


### PR DESCRIPTION
## Summary

Three intertwined improvements to `bucket/AIAgents.ps1` MCP wiring:

1. **Skip `github` MCP for GitHub Copilot CLI.** Copilot CLI ships a built-in
   remote `github-mcp-server`, so our injected entry is redundant. New
   `SkipAgents` field on each `McpServers` entry; the registration loop
   honors it, and `-Reset` prunes any stale entry from
   `~\.copilot\mcp-config.json`.

2. **Stop persisting the GitHub PAT in any agent config file.** The token
   used to be written verbatim into the `env` block of all 5 agent
   configs (`%APPDATA%\Claude\claude_desktop_config.json`, `~\.claude.json`,
   `~\.gemini\settings.json`, `~\.copilot\mcp-config.json`,
   `~\.codex\config.toml`). It now lives:
   - At `HKCU` User scope (`HKLM` Machine when elevated) so GUI-launched
     agents (Claude Desktop) inherit it without paying any shell cost.
   - Behind a sentinel-bracketed self-heal block in elevation-appropriate
     PowerShell profile(s) -- `AllUsersAllHosts` when elevated, otherwise
     both `CurrentUserAllHosts` and the WindowsPowerShell 5.1 profile.
   - Steady-state cost is microseconds: the profile guard short-circuits
     when `env:GITHUB_PERSONAL_ACCESS_TOKEN` is already set (the common
     case once HKCU is populated). Defines an `Update-GitHubTokenFromGh`
     helper for on-demand refresh after `gh auth refresh`.
   - Old token-bearing config entries are silently overwritten on the next
     run because the JSON/TOML writers no longer emit `env` for the
     `github` entry.

3. **Pre-install MCP server npm packages globally and dispatch via the
   resolved `.cmd` shim.** `Resolve-NpmBin` reads `package.json#bin`
   under `npm prefix -g` to locate the shim without hard-coding bin
   names. Eliminates 200-800 ms of `npx` overhead per agent spawn (and
   the multi-second registry round-trip caused by `@latest`-tagged cold
   spawns). `Resolve-McpServerCommand` falls back to `npx -y` per
   entry when the global install or bin resolution fails.

## Implementation

- New `bucket/AIAgents.Mcp.ps1` -- helpers only, zero side effects on
  dot-source. Exports: `Get-McpProfileSentinelBlock`, `Test-IsElevated`,
  `Get-McpProfileTargets`, `Add/Remove-McpProfileSentinel`,
  `Set/Clear-PersistedGitHubToken`, `Get-NpmGlobalRoot`,
  `Resolve-NpmBin`, `Resolve-McpServerCommand`, plus the four
  config writers/removers extracted from `AIAgents.ps1`.
- `AIAgents.ps1` dot-sources the helpers, drops the inline function
  bodies, and wires the new behaviors. `-Reset` extended to remove
  the sentinel block, clear HKCU/Machine env, prune skipped-agent
  entries, and `npm uninstall -g` each MCP package.
- `Get-BundlePackages.ps1` sets `global:__SBPKG_IS_PROBE = true` in
  its `Invoke-PackageInstall` shim; `AIAgents.ps1` short-circuits on
  that flag so bundle enumeration never triggers the imperative
  npm/HKCU/profile work.

## Tests

- New `bucket/AIAgents.Mcp.Tests.ps1` -- 29 behavior-first Pester tests
  across 7 contexts covering profile injection (both elevation paths),
  sentinel removal, persisted-token mocks, `Resolve-NpmBin` happy +
  fallback paths, `Resolve-McpServerCommand` bin-vs-npx selection,
  and the JSON/TOML writers (with + without env).
- `AIAgents.Tests.ps1` and `Bundles.Tests.ps1` still green.
- Local verification: 827/828 passed, 1 pre-existing skip.

## Test command

```powershell
Invoke-Pester -Path .\bucket\AIAgents.Tests.ps1, .\bucket\AIAgents.Mcp.Tests.ps1, .\bucket\Bundles.Tests.ps1
```

Closes #242