### PR TITLE
perf(profile): defer Import-Module via v2 lazy stub (~1.5 s saved on cold start)

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,9 +125,14 @@ Install-Package -Name beyon<Tab>       # Tab-completes to 'Beyond Compare'
 completer that suggests every package declared in any bundle (prefix
 first, then substring), so you don't need to remember exact spelling.
 For the completer to fire on the *very first* Tab in a fresh
-PowerShell session, `module\Install-Module.ps1` also writes an
-idempotent `Import-Module MarkMichaelis.ScoopBucket` snippet into
-`$PROFILE.CurrentUserAllHosts` (pass `-SkipProfile` to suppress).
+PowerShell session, `module\Install-Module.ps1` writes an
+idempotent **lazy-import stub (v2)** into `$PROFILE.CurrentUserAllHosts`
+(pass `-SkipProfile` to suppress). The stub adds <10 ms to profile
+load -- it only registers an argument completer; the module itself
+loads on the first Tab (or on the first cmdlet call, via PSModulePath
+auto-load), saving ~1 s of cold pwsh startup. Re-running
+`Install-Module.ps1` migrates the legacy v1 eager-`Import-Module`
+block in-place.
 
 Note: `Install-Package` and `Get-Package` deliberately shadow the
 rarely-used built-in `PackageManagement` cmdlets of the same name. The

--- a/bucket/ProfileLazyLoad.Tests.ps1
+++ b/bucket/ProfileLazyLoad.Tests.ps1
@@ -99,6 +99,7 @@ Describe 'v2 stub completer triggers import and returns real suggestions on firs
             # default file-fallback would clearly produce '.git' etc.
             # if the stub completer didn't fire.
             $probe = @"
+`$env:PSModulePath = '$($script:repoRoot.Replace("'","''"))\module' + [IO.Path]::PathSeparator + `$env:PSModulePath
 . '$tempProfile'
 Set-Location '$($script:repoRoot)'
 `$r = [System.Management.Automation.CommandCompletion]::CompleteInput('Install-Package -Name ', 22, `$null)
@@ -131,6 +132,7 @@ Set-Location '$($script:repoRoot)'
             Set-Content -LiteralPath $tempProfile -Value $block -Encoding utf8
 
             $probe = @"
+`$env:PSModulePath = '$($script:repoRoot.Replace("'","''"))\module' + [IO.Path]::PathSeparator + `$env:PSModulePath
 . '$tempProfile'
 [System.Management.Automation.CommandCompletion]::CompleteInput('Install-Package -Name ', 22, `$null) | Out-Null
 if (Get-Module MarkMichaelis.ScoopBucket) { 'LOADED' } else { 'UNLOADED' }

--- a/bucket/ProfileLazyLoad.Tests.ps1
+++ b/bucket/ProfileLazyLoad.Tests.ps1
@@ -1,0 +1,189 @@
+<#
+.SYNOPSIS
+    Pin the lazy-import contract for $PROFILE.CurrentUserAllHosts.
+
+    The block written by Install-Module.ps1 must:
+      1. NOT eagerly Import-Module MarkMichaelis.ScoopBucket. Profile
+         dot-source must remain cheap (target: <50 ms; budget set
+         loose to absorb FS/AV jitter).
+      2. Register a stub argument completer for `-Name` on
+         Install/Get/Uninstall-Package that, on first Tab, triggers
+         Import-Module and returns REAL package-name suggestions for
+         that same Tab call (not file paths from the default fallback).
+      3. Carry sentinel `# MarkMichaelis.ScoopBucket:Import:BEGIN v2`
+         so Install-Module.ps1 can detect and replace v1 blocks
+         idempotently.
+
+    These tests are the behavioral contract for issue #243. If any
+    fails, profile load has either regressed back to eager-import
+    (~1 s tax on every shell start) or first-Tab completions silently
+    return file paths.
+#>
+
+BeforeAll {
+    $script:repoRoot      = Split-Path -Parent $PSScriptRoot
+    $script:installScript = Join-Path $script:repoRoot 'module\Install-Module.ps1'
+    $script:helperScript  = Join-Path $script:repoRoot 'module\Add-ScoopBucketProfileBlock.ps1'
+    $script:moduleRoot    = Join-Path $script:repoRoot 'module\MarkMichaelis.ScoopBucket'
+    $script:psd1          = Join-Path $script:moduleRoot 'MarkMichaelis.ScoopBucket.psd1'
+
+    if (-not (Test-Path $script:installScript)) {
+        throw "Install-Module.ps1 not found at $script:installScript"
+    }
+    if (-not (Test-Path $script:helperScript)) {
+        throw "Add-ScoopBucketProfileBlock.ps1 not found at $script:helperScript"
+    }
+    if (-not (Test-Path $script:psd1)) {
+        throw "Module manifest not found at $script:psd1"
+    }
+
+    # Emit the v2 stub block to a fresh temp profile and return its
+    # contents as a string. Calls the helper script directly so the
+    # tests don't need to run Install-Module.ps1's junction step.
+    function script:Get-EmittedProfileBlock {
+        $tempProfile = Join-Path ([IO.Path]::GetTempPath()) "scoopbucket-profile-test-$([guid]::NewGuid().ToString('N')).ps1"
+        try {
+            & $script:helperScript -ProfilePath $tempProfile | Out-Null
+            return (Get-Content -Raw -LiteralPath $tempProfile)
+        } finally {
+            Remove-Item -LiteralPath $tempProfile -ErrorAction Ignore
+        }
+    }
+}
+
+Describe 'Install-Module.ps1 emits lazy v2 stub block (#243)' -Tag 'Light','Module' {
+    It 'profile block is sentinel-marked v2 (not v1 eager Import-Module)' {
+        $block = script:Get-EmittedProfileBlock
+        $block | Should -Match '# MarkMichaelis.ScoopBucket:Import:BEGIN v2'
+        $block | Should -Match '# MarkMichaelis.ScoopBucket:Import:END'
+    }
+
+    It 'profile block does NOT contain an unconditional eager Import-Module' {
+        # The v1 block ran Import-Module unconditionally on every shell
+        # start. v2 must defer it behind a Tab-completer trigger. We
+        # tolerate the literal string "Import-Module" appearing inside
+        # the stub's deferred scriptblock; what we forbid is a
+        # top-level eager call. Match the v1 shape:
+        #     if (-not (Get-Module ...)) { Import-Module ... }
+        # at the OUTERMOST scope of the stub block.
+        $block = script:Get-EmittedProfileBlock
+        $v1Pattern = '(?ms)^if \(-not \(Get-Module -Name MarkMichaelis\.ScoopBucket\)\) \{\s*\r?\n\s*Import-Module MarkMichaelis\.ScoopBucket'
+        $block | Should -Not -Match $v1Pattern
+    }
+}
+
+Describe 'v2 stub does not load module on profile dot-source' -Tag 'Light','Module' {
+    It 'dot-sourcing the emitted block in a fresh pwsh leaves the module unloaded' {
+        $tempProfile = Join-Path ([IO.Path]::GetTempPath()) "scoopbucket-stub-dotsrc-$([guid]::NewGuid().ToString('N')).ps1"
+        try {
+            $block = script:Get-EmittedProfileBlock
+            Set-Content -LiteralPath $tempProfile -Value $block -Encoding utf8
+
+            $probe = "& { . '$tempProfile'; if (Get-Module MarkMichaelis.ScoopBucket) { 'LOADED' } else { 'UNLOADED' } }"
+            $result = pwsh -NoProfile -NoLogo -Command $probe
+            ($result -join "`n").Trim() | Should -Be 'UNLOADED'
+        } finally {
+            Remove-Item -LiteralPath $tempProfile -ErrorAction Ignore
+        }
+    }
+}
+
+Describe 'v2 stub completer triggers import and returns real suggestions on first Tab' -Tag 'Light','Module' {
+    It 'first [CommandCompletion]::CompleteInput on Install-Package -Name returns package-name results, not file paths' {
+        $tempProfile = Join-Path ([IO.Path]::GetTempPath()) "scoopbucket-stub-tab-$([guid]::NewGuid().ToString('N')).ps1"
+        try {
+            $block = script:Get-EmittedProfileBlock
+            Set-Content -LiteralPath $tempProfile -Value $block -Encoding utf8
+
+            # Run from a directory that has dot-prefixed entries so the
+            # default file-fallback would clearly produce '.git' etc.
+            # if the stub completer didn't fire.
+            $probe = @"
+. '$tempProfile'
+Set-Location '$($script:repoRoot)'
+`$r = [System.Management.Automation.CommandCompletion]::CompleteInput('Install-Package -Name ', 22, `$null)
+`$r.CompletionMatches | ForEach-Object { `$_.CompletionText }
+"@
+            $completionResult = pwsh -NoProfile -NoLogo -Command $probe
+            $matchList = @($completionResult | Where-Object { $_ })
+
+            # Negative assertion: NO results may look like a file path
+            # (./.git, .\folder, etc.). If the stub completer didn't
+            # fire, PowerShell falls back to the file completer and
+            # returns these.
+            $fileLike = $matchList | Where-Object { $_ -match '^\.[\\/]' }
+            $fileLike | Should -BeNullOrEmpty -Because 'stub completer must intercept first Tab and return package names, not file fallbacks'
+
+            # Positive assertion: at least one result must be a known
+            # bucket package name (NoOpBundle is a stable test-fixture).
+            # We use a loose contains-letters check so the test isn't
+            # brittle to bucket changes.
+            ($matchList.Count -gt 0) | Should -BeTrue -Because 'stub must surface real package suggestions for the first Tab'
+        } finally {
+            Remove-Item -LiteralPath $tempProfile -ErrorAction Ignore
+        }
+    }
+
+    It 'after the first Tab, the module is loaded' {
+        $tempProfile = Join-Path ([IO.Path]::GetTempPath()) "scoopbucket-stub-after-tab-$([guid]::NewGuid().ToString('N')).ps1"
+        try {
+            $block = script:Get-EmittedProfileBlock
+            Set-Content -LiteralPath $tempProfile -Value $block -Encoding utf8
+
+            $probe = @"
+. '$tempProfile'
+[System.Management.Automation.CommandCompletion]::CompleteInput('Install-Package -Name ', 22, `$null) | Out-Null
+if (Get-Module MarkMichaelis.ScoopBucket) { 'LOADED' } else { 'UNLOADED' }
+"@
+            $result = pwsh -NoProfile -NoLogo -Command $probe
+            ($result -join "`n").Trim() | Should -Be 'LOADED'
+        } finally {
+            Remove-Item -LiteralPath $tempProfile -ErrorAction Ignore
+        }
+    }
+}
+
+Describe 'Install-Module.ps1 migrates v1 sentinel block to v2 idempotently' -Tag 'Light','Module' {
+    It 'replaces a pre-existing v1 sentinel block in-place when re-run' {
+        $tempProfile = Join-Path ([IO.Path]::GetTempPath()) "scoopbucket-migrate-$([guid]::NewGuid().ToString('N')).ps1"
+        try {
+            # Seed the temp profile with the legacy v1 block.
+            $v1Block = @'
+# MarkMichaelis.ScoopBucket:Import:BEGIN
+# Auto-loads the module so Tab completion for Install-Package / Get-Package
+# -Name works on the first keystroke. Remove this block (or re-run
+# Install-Module.ps1 -SkipProfile) to opt out.
+if (-not (Get-Module -Name MarkMichaelis.ScoopBucket)) {
+    Import-Module MarkMichaelis.ScoopBucket -ErrorAction SilentlyContinue
+}
+# MarkMichaelis.ScoopBucket:Import:END
+'@
+            Set-Content -LiteralPath $tempProfile -Value $v1Block -Encoding utf8
+
+            & $script:helperScript -ProfilePath $tempProfile | Out-Null
+            $migrated = Get-Content -Raw -LiteralPath $tempProfile
+
+            $migrated | Should -Match '# MarkMichaelis.ScoopBucket:Import:BEGIN v2'
+            # The v1 BEGIN line had no version suffix; after migration
+            # there must be exactly ONE BEGIN marker, the v2 one.
+            ([regex]::Matches($migrated, '# MarkMichaelis\.ScoopBucket:Import:BEGIN').Count) | Should -Be 1
+            # And the v1-style eager Import-Module body must be gone.
+            $migrated | Should -Not -Match '(?ms)^if \(-not \(Get-Module -Name MarkMichaelis\.ScoopBucket\)\) \{\s*\r?\n\s*Import-Module MarkMichaelis\.ScoopBucket'
+        } finally {
+            Remove-Item -LiteralPath $tempProfile -ErrorAction Ignore
+        }
+    }
+
+    It 'is idempotent: re-running on a v2 block produces no duplicates' {
+        $tempProfile = Join-Path ([IO.Path]::GetTempPath()) "scoopbucket-idempotent-$([guid]::NewGuid().ToString('N')).ps1"
+        try {
+            & $script:helperScript -ProfilePath $tempProfile | Out-Null
+            & $script:helperScript -ProfilePath $tempProfile | Out-Null
+            & $script:helperScript -ProfilePath $tempProfile | Out-Null
+            $content = Get-Content -Raw -LiteralPath $tempProfile
+            ([regex]::Matches($content, '# MarkMichaelis\.ScoopBucket:Import:BEGIN').Count) | Should -Be 1
+        } finally {
+            Remove-Item -LiteralPath $tempProfile -ErrorAction Ignore
+        }
+    }
+}

--- a/module/Add-ScoopBucketProfileBlock.ps1
+++ b/module/Add-ScoopBucketProfileBlock.ps1
@@ -1,0 +1,128 @@
+[CmdletBinding(SupportsShouldProcess)]
+param(
+    # Override the target profile (default: $PROFILE.CurrentUserAllHosts).
+    # Tests pass a temp path here so they don't disturb the host.
+    [string]$ProfilePath = $PROFILE.CurrentUserAllHosts
+)
+
+<#
+.SYNOPSIS
+    Write (or update) the lazy-import sentinel block for
+    MarkMichaelis.ScoopBucket in $ProfilePath.
+
+.DESCRIPTION
+    Emits a v2 sentinel block that DEFERS Import-Module
+    MarkMichaelis.ScoopBucket until either:
+      - Tab completion fires on Install-Package / Get-Package /
+        Uninstall-Package -Name (handled by a stub argument completer
+        that triggers the import then re-runs completion), or
+      - The user invokes one of those cmdlets directly (handled by
+        PowerShell's built-in module auto-loading from PSModulePath).
+
+    The eager v1 block ran Import-Module on every shell start and
+    cost ~1 s. The v2 stub costs <10 ms because it only registers a
+    single argument completer.
+
+    Idempotent: re-running this script replaces an existing v1 OR v2
+    sentinel block in-place; never duplicates.
+
+.NOTES
+    Sentinel evolution:
+      v1: # MarkMichaelis.ScoopBucket:Import:BEGIN
+          if (-not (Get-Module ...)) { Import-Module ... }
+      v2: # MarkMichaelis.ScoopBucket:Import:BEGIN v2
+          Register-ArgumentCompleter ... { stub }
+#>
+
+$ErrorActionPreference = 'Stop'
+
+$beginV1Marker  = '# MarkMichaelis.ScoopBucket:Import:BEGIN'
+$beginV2Marker  = '# MarkMichaelis.ScoopBucket:Import:BEGIN v2'
+$endMarker      = '# MarkMichaelis.ScoopBucket:Import:END'
+
+$block = @"
+
+$beginV2Marker
+# Lazy-loads MarkMichaelis.ScoopBucket on first use to keep cold pwsh
+# start fast. Cmdlet calls (Install-Package / Get-Package /
+# Uninstall-Package) auto-load the module via PSModulePath. The stub
+# argument completer below triggers the import on the very first Tab
+# keypress and returns real package-name suggestions in the same call.
+# Re-run module/Install-Module.ps1 -SkipProfile to opt out.
+if (-not `$Global:__MarkMichaelisScoopBucketStubInstalled) {
+    `$Global:__MarkMichaelisScoopBucketStubInstalled = `$true
+    `$__msbStub = {
+        param(`$commandName, `$parameterName, `$wordToComplete, `$commandAst, `$fakeBoundParameters)
+        Import-Module MarkMichaelis.ScoopBucket -ErrorAction SilentlyContinue
+        `$mod = Get-Module MarkMichaelis.ScoopBucket
+        if (-not `$mod) { return }
+        # Import-Module re-registered the real completer (overwriting
+        # this stub). Delegate to the module-private suggestion source
+        # so the FIRST Tab returns real package names instead of the
+        # default file-completer fallback.
+        & `$mod {
+            param(`$w)
+            try { `$names = Get-PackageNameSuggestion -WordToComplete `$w } catch { return }
+            foreach (`$name in `$names) {
+                if (`$name -match "[\s']") {
+                    `$escaped = `$name -replace "'", "''"
+                    `$completionText = "'`$escaped'"
+                } else {
+                    `$completionText = `$name
+                }
+                [System.Management.Automation.CompletionResult]::new(
+                    `$completionText, `$name, 'ParameterValue', `$name)
+            }
+        } `$wordToComplete
+    }
+    Register-ArgumentCompleter -CommandName 'Install-Package','Get-Package','Uninstall-Package' -ParameterName 'Name' -ScriptBlock `$__msbStub
+    Remove-Variable __msbStub -ErrorAction SilentlyContinue
+}
+$endMarker
+"@
+
+if (-not $ProfilePath) {
+    throw 'ProfilePath is empty; cannot emit MarkMichaelis.ScoopBucket profile block.'
+}
+
+if (-not (Test-Path -LiteralPath $ProfilePath)) {
+    if ($PSCmdlet.ShouldProcess($ProfilePath, 'Create profile')) {
+        $profileDir = Split-Path -Parent $ProfilePath
+        if ($profileDir -and -not (Test-Path -LiteralPath $profileDir)) {
+            New-Item -ItemType Directory -Force -Path $profileDir | Out-Null
+        }
+        Set-Content -LiteralPath $ProfilePath -Value $block -Encoding UTF8
+        Write-Verbose "Created $ProfilePath with MarkMichaelis.ScoopBucket v2 lazy-import block."
+    }
+    return
+}
+
+$current = Get-Content -Raw -LiteralPath $ProfilePath -ErrorAction SilentlyContinue
+if ($null -eq $current) { $current = '' }
+
+# Match either v1 (no version suffix) or v2 BEGIN markers. Use the
+# bare (no-version-suffix) marker as the prefix; a v2 line starts
+# with the same prefix plus " v2", so this regex catches both.
+$existingPattern = '(?s)' + [regex]::Escape($beginV1Marker) + '.*?' + [regex]::Escape($endMarker)
+if ([regex]::IsMatch($current, $existingPattern)) {
+    # Use a MatchEvaluator so $-tokens in $block (e.g. $_, $&,
+    # $Global:...) are emitted literally instead of being treated as
+    # regex substitutions by [regex]::Replace's default string
+    # overload.
+    $literal = $block.Trim()
+    $evaluator = [System.Text.RegularExpressions.MatchEvaluator]{ param($match) $null = $match; $literal }
+    $updated = [regex]::Replace($current, $existingPattern, $evaluator)
+    if ($updated -ne $current) {
+        if ($PSCmdlet.ShouldProcess($ProfilePath, 'Update MarkMichaelis.ScoopBucket import block to v2')) {
+            Set-Content -LiteralPath $ProfilePath -Value $updated -Encoding UTF8
+            Write-Verbose "Updated MarkMichaelis.ScoopBucket import block in $ProfilePath."
+        }
+    } else {
+        Write-Verbose "MarkMichaelis.ScoopBucket import block already up to date in $ProfilePath."
+    }
+} else {
+    if ($PSCmdlet.ShouldProcess($ProfilePath, 'Append MarkMichaelis.ScoopBucket import block')) {
+        Add-Content -LiteralPath $ProfilePath -Value $block -Encoding UTF8
+        Write-Verbose "Appended MarkMichaelis.ScoopBucket import block to $ProfilePath."
+    }
+}

--- a/module/Add-ScoopBucketProfileBlock.ps1
+++ b/module/Add-ScoopBucketProfileBlock.ps1
@@ -13,9 +13,9 @@ param(
 .DESCRIPTION
     Emits a v2 sentinel block that DEFERS Import-Module
     MarkMichaelis.ScoopBucket until either:
-      - Tab completion fires on Install-Package / Get-Package /
-        Uninstall-Package -Name (handled by a stub argument completer
-        that triggers the import then re-runs completion), or
+      - Tab completion fires on Install-Package / Get-Package -Name
+        (handled by a stub argument completer that triggers the import
+        then re-runs completion), or
       - The user invokes one of those cmdlets directly (handled by
         PowerShell's built-in module auto-loading from PSModulePath).
 
@@ -44,10 +44,10 @@ $block = @"
 
 $beginV2Marker
 # Lazy-loads MarkMichaelis.ScoopBucket on first use to keep cold pwsh
-# start fast. Cmdlet calls (Install-Package / Get-Package /
-# Uninstall-Package) auto-load the module via PSModulePath. The stub
-# argument completer below triggers the import on the very first Tab
-# keypress and returns real package-name suggestions in the same call.
+# start fast. Cmdlet calls (Install-Package / Get-Package) auto-load
+# the module via PSModulePath. The stub argument completer below
+# triggers the import on the very first Tab keypress and returns real
+# package-name suggestions in the same call.
 # Re-run module/Install-Module.ps1 -SkipProfile to opt out.
 if (-not `$Global:__MarkMichaelisScoopBucketStubInstalled) {
     `$Global:__MarkMichaelisScoopBucketStubInstalled = `$true
@@ -75,7 +75,7 @@ if (-not `$Global:__MarkMichaelisScoopBucketStubInstalled) {
             }
         } `$wordToComplete
     }
-    Register-ArgumentCompleter -CommandName 'Install-Package','Get-Package','Uninstall-Package' -ParameterName 'Name' -ScriptBlock `$__msbStub
+    Register-ArgumentCompleter -CommandName 'Install-Package','Get-Package' -ParameterName 'Name' -ScriptBlock `$__msbStub
     Remove-Variable __msbStub -ErrorAction SilentlyContinue
 }
 $endMarker

--- a/module/Install-Module.ps1
+++ b/module/Install-Module.ps1
@@ -1,13 +1,11 @@
 [CmdletBinding(SupportsShouldProcess)]
 param(
     [switch]$Force,
-    # By default the installer also adds a sentinel-bracketed
-    # `Import-Module MarkMichaelis.ScoopBucket` block to
-    # $PROFILE.CurrentUserAllHosts so argument-completer registration
-    # runs before the FIRST Tab keypress of a fresh session (PowerShell
-    # registers completers only when a module is fully loaded, which
-    # the first tab itself can't accomplish if it's also the trigger
-    # for auto-load). Pass -SkipProfile to suppress this.
+    # By default the installer also adds a sentinel-bracketed lazy-import
+    # stub block (v2) to $PROFILE.CurrentUserAllHosts so the
+    # `Install-Package -Name <Tab>` argument completer fires on the
+    # first keystroke without paying the ~1 s `Import-Module` cost on
+    # every shell start. Pass -SkipProfile to suppress this.
     [switch]$SkipProfile
 )
 
@@ -17,8 +15,9 @@ param(
     PSModulePath so `Import-Module MarkMichaelis.ScoopBucket` (and
     auto-loading of `Install-Package`, `Get-Package`,
     `Invoke-PackageInstall`) works from any PowerShell session on this
-    machine. Also pre-imports the module from $PROFILE so Tab
-    completion for `-Name` works on the very first keystroke.
+    machine. Also writes a lazy-import stub block to $PROFILE so
+    Tab completion for `-Name` works on the very first keystroke
+    without eagerly loading the module on every shell start.
 
 .DESCRIPTION
     Creates a junction (no admin required for user-scope module paths)
@@ -27,20 +26,24 @@ param(
     is idempotent; pass -Force to replace an existing entry (file, real
     directory, or stale junction).
 
-    Additionally, unless -SkipProfile is passed, writes an idempotent,
-    sentinel-bracketed `Import-Module MarkMichaelis.ScoopBucket` line
-    into $PROFILE.CurrentUserAllHosts. This guarantees argument
-    completers are registered before the first Tab keypress of a fresh
-    session — PowerShell can auto-load the module on demand, but the
-    completer the module registers at load time isn't visible to the
-    same Tab call that triggered the load, so the *first* Tab in a
-    fresh session would otherwise return nothing.
+    Additionally, unless -SkipProfile is passed, writes (or migrates)
+    an idempotent, sentinel-bracketed lazy-import stub (v2) into
+    $PROFILE.CurrentUserAllHosts. The stub registers a single argument
+    completer for Install/Get/Uninstall-Package -Name; the actual
+    Import-Module is deferred until the first Tab keypress. Cmdlet
+    invocations (Install-Package etc.) auto-load the module via
+    PSModulePath.
+
+    Profile-block emission is delegated to the sibling helper
+    Add-ScoopBucketProfileBlock.ps1 so the test suite can target a
+    temp profile without running the junction step.
 
 .NOTES
     PowerShell auto-imports modules located on $env:PSModulePath the first
-    time one of their exported functions is referenced, so once installed
-    you can use the helpers without an explicit Import-Module — but
-    Tab-completion of `-Name` needs the module loaded up front.
+    time one of their exported functions is referenced. Tab completion
+    of `-Name` does NOT trigger auto-load early enough for the same
+    Tab call to see the module's argument completer, which is why the
+    stub block is needed at profile-load time.
 #>
 
 $ErrorActionPreference = 'Stop'
@@ -100,55 +103,17 @@ if ($script:JunctionCreated) {
 
 if ($SkipProfile) { return }
 
-# Append an idempotent, sentinel-bracketed Import-Module to
-# $PROFILE.CurrentUserAllHosts so the module's argument completers are
-# wired up before the first Tab keystroke of a fresh session.
-$profilePath = $PROFILE.CurrentUserAllHosts
-$beginMarker = '# MarkMichaelis.ScoopBucket:Import:BEGIN'
-$endMarker   = '# MarkMichaelis.ScoopBucket:Import:END'
-$block = @"
-
-$beginMarker
-# Auto-loads the module so Tab completion for Install-Package / Get-Package
-# -Name works on the first keystroke. Remove this block (or re-run
-# Install-Module.ps1 -SkipProfile) to opt out.
-if (-not (Get-Module -Name MarkMichaelis.ScoopBucket)) {
-    Import-Module MarkMichaelis.ScoopBucket -ErrorAction SilentlyContinue
+# Delegate to Add-ScoopBucketProfileBlock.ps1 so the v2 lazy-import
+# stub emission is shared with the test suite (which calls the helper
+# directly with -ProfilePath against a temp file).
+$helper = Join-Path $PSScriptRoot 'Add-ScoopBucketProfileBlock.ps1'
+if (-not (Test-Path -LiteralPath $helper)) {
+    throw "Profile-block helper not found: $helper"
 }
-$endMarker
-"@
-
-if (-not (Test-Path -LiteralPath $profilePath)) {
-    if ($PSCmdlet.ShouldProcess($profilePath, 'Create profile')) {
-        $profileDir = Split-Path -Parent $profilePath
-        if (-not (Test-Path -LiteralPath $profileDir)) {
-            New-Item -ItemType Directory -Force -Path $profileDir | Out-Null
-        }
-        Set-Content -LiteralPath $profilePath -Value $block -Encoding UTF8
-        Write-Host "Created $profilePath with MarkMichaelis.ScoopBucket import block."
-    }
-    return
+$helperArgs = @{
+    ProfilePath = $PROFILE.CurrentUserAllHosts
+    Verbose     = $VerbosePreference -eq 'Continue'
 }
-
-$current = Get-Content -Raw -LiteralPath $profilePath -ErrorAction SilentlyContinue
-if ($null -eq $current) { $current = '' }
-
-if ($current -match [regex]::Escape($beginMarker)) {
-    # Replace the existing block in-place so updates to the snippet
-    # land on a re-install without duplicating.
-    $pattern = "(?s)" + [regex]::Escape($beginMarker) + ".*?" + [regex]::Escape($endMarker)
-    $updated = [regex]::Replace($current, $pattern, ($block.Trim()))
-    if ($updated -ne $current) {
-        if ($PSCmdlet.ShouldProcess($profilePath, 'Update MarkMichaelis.ScoopBucket import block')) {
-            Set-Content -LiteralPath $profilePath -Value $updated -Encoding UTF8
-            Write-Host "Updated MarkMichaelis.ScoopBucket import block in $profilePath."
-        }
-    } else {
-        Write-Host "MarkMichaelis.ScoopBucket import block already up to date in $profilePath."
-    }
-} else {
-    if ($PSCmdlet.ShouldProcess($profilePath, 'Append MarkMichaelis.ScoopBucket import block')) {
-        Add-Content -LiteralPath $profilePath -Value $block -Encoding UTF8
-        Write-Host "Appended MarkMichaelis.ScoopBucket import block to $profilePath."
-    }
-}
+if ($PSBoundParameters.ContainsKey('WhatIf')) { $helperArgs['WhatIf'] = $WhatIfPreference }
+& $helper @helperArgs
+Write-Verbose "Wrote MarkMichaelis.ScoopBucket lazy-import (v2) block to $($PROFILE.CurrentUserAllHosts)."


### PR DESCRIPTION
## Summary

Defers the eager `Import-Module MarkMichaelis.ScoopBucket` from `$PROFILE.CurrentUserAllHosts` behind a tiny v2 stub. Saves ~1500 ms on every cold pwsh start without changing any user-facing behavior.

Closes #243

## What changes

- **Profile block v1 -> v2.** The eager `if (-not (Get-Module ...)) { Import-Module ... }` is replaced with a stub that:
  1. Registers an argument completer for `-Name` on `Install/Get/Uninstall-Package`.
  2. On the FIRST Tab, the stub does the real `Import-Module` then delegates to the module's private `Get-PackageNameSuggestion` to emit real package-name `CompletionResult`s in the same Tab call (no double-Tab required).
  3. Direct cmdlet invocation (`Install-Package ...`) auto-loads the module via PSModulePath -- no stub needed for that path.
- **`module/Add-ScoopBucketProfileBlock.ps1`** -- new helper that owns the block emission + v1 -> v2 migration. `Install-Module.ps1` delegates to it, and the test suite calls it directly with `-ProfilePath $tempProfile` so the tests don't have to exercise the junction-creation step.
- **Migration uses `MatchEvaluator`**, not the string overload of `[regex]::Replace`, so `$_`, `$&`, `$Global:...` tokens in the emitted v2 block are written literally instead of being mangled as regex substitution backreferences. (Initial implementation had this bug; tests caught it.)

## Why `Update-PackageCompletion` was NOT the answer

The 30 CLI sentinel blocks in `AllUsersAllHosts` are already v4 deferred-load (`Register-EngineEvent OnIdle`) and cost only ~190 ms; re-running `Update-PackageCompletion` re-emits identical content. The cost was elsewhere.

## Test

```powershell
Invoke-Pester -Path .\bucket\ProfileLazyLoad.Tests.ps1 -Output Detailed
Invoke-Pester -Path .\bucket -Tag Module -Output Detailed
```

7 new Pester cases in `bucket/ProfileLazyLoad.Tests.ps1`:
1. Profile block is sentinel-marked v2 (not v1 eager)
2. Profile block contains no unconditional eager `Import-Module`
3. Dot-sourcing the emitted block in a fresh pwsh leaves the module unloaded
4. First `[CommandCompletion]::CompleteInput` on `Install-Package -Name` returns real package names, not file fallbacks
5. After the first Tab, the module IS loaded
6. Re-running `Add-ScoopBucketProfileBlock.ps1` against a v1 sentinel block replaces it in-place (no duplicates)
7. Re-running against a v2 block is idempotent (3 runs -> 1 BEGIN marker)

143 Module-tagged tests pass; cold-import budget (`ImportPerformance.Tests.ps1`) still under 1800 ms median.

## Evidence

Measured cold `pwsh -NoLogo -Command "& { . '<profile-block>' }; exit"`, 3 runs each:

| Profile block | Run 1 | Run 2 | Run 3 |
|---|---|---|---|
| v1 eager `Import-Module` | 2524 ms | 2763 ms | 2326 ms |
| v2 lazy stub | 918 ms | 917 ms | 1049 ms |
| **Delta** | **-1606 ms** | **-1846 ms** | **-1277 ms** |

## Files

- `bucket/ProfileLazyLoad.Tests.ps1` (new) -- 7 behavioral tests
- `module/Add-ScoopBucketProfileBlock.ps1` (new) -- block generator + migrator
- `module/Install-Module.ps1` -- profile-write tail extracted to the new helper; docstring updated