### PR TITLE
fix(manifests): rewrite hard-coded /master/ raw URLs to /main/ (#247)

### DIFF
--- a/bucket/AIAgents.json
+++ b/bucket/AIAgents.json
@@ -1,8 +1,8 @@
 {
     "$schema": "https://raw.githubusercontent.com/lukesampson/scoop/master/schema.json",
-    "version": "1.22.000",
+    "version": "1.23.000",
     "url": [
-        "https://raw.githubusercontent.com/MarkMichaelis/ScoopBucket/master/bucket/AIAgents.ps1"
+        "https://raw.githubusercontent.com/MarkMichaelis/ScoopBucket/main/bucket/AIAgents.ps1"
     ],
     "installer": {
         "script": "& \"$dir\\AIAgents.ps1\""

--- a/bucket/AddLocalRepoBucket.json
+++ b/bucket/AddLocalRepoBucket.json
@@ -2,9 +2,9 @@
   "$schema": "https://raw.githubusercontent.com/lukesampson/scoop/master/schema.json",
   "homepage": "https://github.com/MarkMichaelis/ScoopBucket",
   "description": "Setups my personal scoop bucket.",
-  "url": "https://raw.githubusercontent.com/MarkMichaelis/ScoopBucket/master/blank",
+  "url": "https://raw.githubusercontent.com/MarkMichaelis/ScoopBucket/main/blank",
   "notes": "Of course, this script is placed in the MarkMichaelis bucket so you it presents a chicken and egg problem.",
-  "version": "1.00.000",
+  "version": "1.01.000",
   "installer": {
     "script": [
       "scoop bucket add LocalRepo https://github.com/MarkMichaelis/ScoopBucket.git"

--- a/bucket/AddMarkMichaelisScoopBucket.json
+++ b/bucket/AddMarkMichaelisScoopBucket.json
@@ -3,7 +3,7 @@
   "homepage": "https://github.com/MarkMichaelis/ScoopBucket",
   "description": "Setups my personal scoop bucket.",
   "notes": "Of course, this script is placed in the MarkMichaelis bucket so you it presents a chicken and egg problem.",
-  "version": "1.00.000",
+  "version": "1.01.000",
   "installer": {
     "script": [
       "scoop bucket add MarkMichaelis https://github.com/MarkMichaelis/ScoopBucket.git"
@@ -12,5 +12,5 @@
   "uninstaller": {
     "script": ["scoop bucket rm MarkMichaelis"]
   },
-  "url": "https://raw.githubusercontent.com/MarkMichaelis/ScoopBucket/master/blank"
+  "url": "https://raw.githubusercontent.com/MarkMichaelis/ScoopBucket/main/blank"
 }

--- a/bucket/Aspire.json
+++ b/bucket/Aspire.json
@@ -1,8 +1,8 @@
 {
     "$schema": "https://raw.githubusercontent.com/lukesampson/scoop/master/schema.json",
-    "version": "1.09.000",
+    "version": "1.10.000",
     "url": [
-        "https://raw.githubusercontent.com/MarkMichaelis/ScoopBucket/master/bucket/Aspire.ps1"
+        "https://raw.githubusercontent.com/MarkMichaelis/ScoopBucket/main/bucket/Aspire.ps1"
     ],
     "installer": {
         "script": "& \"$dir\\Aspire.ps1\""

--- a/bucket/ChatGPT.json
+++ b/bucket/ChatGPT.json
@@ -1,8 +1,8 @@
 {
     "$schema": "https://raw.githubusercontent.com/lukesampson/scoop/master/schema.json",
-    "version": "1.11.000",
+    "version": "1.12.000",
     "url": [
-        "https://raw.githubusercontent.com/MarkMichaelis/ScoopBucket/master/bucket/ChatGPT.ps1"
+        "https://raw.githubusercontent.com/MarkMichaelis/ScoopBucket/main/bucket/ChatGPT.ps1"
     ],
     "installer": {
         "script": "& \"$dir\\ChatGPT.ps1\""

--- a/bucket/Chocolatey.json
+++ b/bucket/Chocolatey.json
@@ -1,8 +1,8 @@
 {
     "$schema": "https://raw.githubusercontent.com/lukesampson/scoop/master/schema.json",
-    "version": "1.09.000",
+    "version": "1.10.000",
     "url": [
-        "https://raw.githubusercontent.com/MarkMichaelis/ScoopBucket/master/bucket/Chocolatey.ps1"
+        "https://raw.githubusercontent.com/MarkMichaelis/ScoopBucket/main/bucket/Chocolatey.ps1"
     ],
     "installer": {
         "script": "& \"$dir\\Chocolatey.ps1\""

--- a/bucket/Claude.json
+++ b/bucket/Claude.json
@@ -1,7 +1,7 @@
 {
     "$schema": "https://raw.githubusercontent.com/lukesampson/scoop/master/schema.json",
-    "version": "1.00.000",
-    "url": ["https://raw.githubusercontent.com/MarkMichaelis/ScoopBucket/master/blank"],
+    "version": "1.01.000",
+    "url": ["https://raw.githubusercontent.com/MarkMichaelis/ScoopBucket/main/blank"],
     "installer": {
         "script": [
             "winget install --id Anthropic.Claude -e --silent --accept-package-agreements --accept-source-agreements"

--- a/bucket/ClaudeCode.json
+++ b/bucket/ClaudeCode.json
@@ -1,7 +1,7 @@
 {
     "$schema": "https://raw.githubusercontent.com/lukesampson/scoop/master/schema.json",
-    "version": "1.00.000",
-    "url": ["https://raw.githubusercontent.com/MarkMichaelis/ScoopBucket/master/blank"],
+    "version": "1.01.000",
+    "url": ["https://raw.githubusercontent.com/MarkMichaelis/ScoopBucket/main/blank"],
     "installer": {
         "script": [
             "winget install --id Anthropic.ClaudeCode -e --silent --accept-package-agreements --accept-source-agreements"

--- a/bucket/ClaudeExcel.json
+++ b/bucket/ClaudeExcel.json
@@ -1,8 +1,8 @@
 {
     "$schema": "https://raw.githubusercontent.com/lukesampson/scoop/master/schema.json",
-    "version": "1.07.000",
+    "version": "1.08.000",
     "url": [
-        "https://raw.githubusercontent.com/MarkMichaelis/ScoopBucket/master/bucket/ClaudeExcel.ps1"
+        "https://raw.githubusercontent.com/MarkMichaelis/ScoopBucket/main/bucket/ClaudeExcel.ps1"
     ],
     "installer": {
         "script": "& \"$dir\\ClaudeExcel.ps1\""

--- a/bucket/ClientBasePackages.json
+++ b/bucket/ClientBasePackages.json
@@ -1,8 +1,8 @@
 {
     "$schema": "https://raw.githubusercontent.com/lukesampson/scoop/master/schema.json",
-    "version": "1.19.000",
+    "version": "1.20.000",
     "url": [
-        "https://raw.githubusercontent.com/MarkMichaelis/ScoopBucket/master/bucket/ClientBasePackages.ps1"
+        "https://raw.githubusercontent.com/MarkMichaelis/ScoopBucket/main/bucket/ClientBasePackages.ps1"
     ],
     "installer": {
         "script": "& \"$dir\\ClientBasePackages.ps1\""

--- a/bucket/Codex.json
+++ b/bucket/Codex.json
@@ -1,7 +1,7 @@
 {
     "$schema": "https://raw.githubusercontent.com/lukesampson/scoop/master/schema.json",
-    "version": "1.00.000",
-    "url": ["https://raw.githubusercontent.com/MarkMichaelis/ScoopBucket/master/blank"],
+    "version": "1.01.000",
+    "url": ["https://raw.githubusercontent.com/MarkMichaelis/ScoopBucket/main/blank"],
     "installer": {
         "script": [
             "winget install --id OpenAI.Codex -e --silent --accept-package-agreements --accept-source-agreements"

--- a/bucket/DeveloperBasePackages.json
+++ b/bucket/DeveloperBasePackages.json
@@ -1,8 +1,8 @@
 {
     "$schema": "https://raw.githubusercontent.com/lukesampson/scoop/master/schema.json",
-    "version": "1.24.000",
+    "version": "1.25.000",
     "url": [
-        "https://raw.githubusercontent.com/MarkMichaelis/ScoopBucket/master/bucket/DeveloperBasePackages.ps1"
+        "https://raw.githubusercontent.com/MarkMichaelis/ScoopBucket/main/bucket/DeveloperBasePackages.ps1"
     ],
     "installer": {
         "script": "& \"$dir\\DeveloperBasePackages.ps1\""

--- a/bucket/EnableHybernate.json
+++ b/bucket/EnableHybernate.json
@@ -1,7 +1,7 @@
-﻿{
+{
     "$schema": "https://raw.githubusercontent.com/lukesampson/scoop/master/schema.json",
-    "version": "1.00.002",
-    "url": ["https://raw.githubusercontent.com/MarkMichaelis/ScoopBucket/master/blank"],
+    "version": "1.01.000",
+    "url": ["https://raw.githubusercontent.com/MarkMichaelis/ScoopBucket/main/blank"],
     "installer": {
         "script": [
             "powercfg /HIBERNATE ON"

--- a/bucket/Gemini.json
+++ b/bucket/Gemini.json
@@ -1,8 +1,8 @@
 {
     "$schema": "https://raw.githubusercontent.com/lukesampson/scoop/master/schema.json",
-    "version": "1.11.000",
+    "version": "1.12.000",
     "url": [
-        "https://raw.githubusercontent.com/MarkMichaelis/ScoopBucket/master/bucket/Gemini.ps1"
+        "https://raw.githubusercontent.com/MarkMichaelis/ScoopBucket/main/bucket/Gemini.ps1"
     ],
     "installer": {
         "script": "& \"$dir\\Gemini.ps1\""

--- a/bucket/GeminiCli.json
+++ b/bucket/GeminiCli.json
@@ -1,7 +1,7 @@
 {
     "$schema": "https://raw.githubusercontent.com/lukesampson/scoop/master/schema.json",
-    "version": "1.00.000",
-    "url": ["https://raw.githubusercontent.com/MarkMichaelis/ScoopBucket/master/blank"],
+    "version": "1.01.000",
+    "url": ["https://raw.githubusercontent.com/MarkMichaelis/ScoopBucket/main/blank"],
     "installer": {
         "script": [
             "choco install -y gemini-cli"

--- a/bucket/GitConfigBeyondCompare.json
+++ b/bucket/GitConfigBeyondCompare.json
@@ -1,8 +1,8 @@
 {
     "$schema": "https://raw.githubusercontent.com/lukesampson/scoop/master/schema.json",
-    "version": "1.12.000",
+    "version": "1.13.000",
     "url": [
-        "https://raw.githubusercontent.com/MarkMichaelis/ScoopBucket/master/bucket/GitConfigBeyondCompare.ps1"
+        "https://raw.githubusercontent.com/MarkMichaelis/ScoopBucket/main/bucket/GitConfigBeyondCompare.ps1"
     ],
     "installer": {
         "script": "& \"$dir\\GitConfigBeyondCompare.ps1\""

--- a/bucket/GitConfigVSCode.json
+++ b/bucket/GitConfigVSCode.json
@@ -1,9 +1,9 @@
 {
     "$schema": "https://raw.githubusercontent.com/lukesampson/scoop/master/schema.json",
-    "version": "1.02.000",
+    "version": "1.03.000",
     "url": [
-        "https://raw.githubusercontent.com/MarkMichaelis/ScoopBucket/master/bucket/GitConfigVSCode.ps1",
-        "https://raw.githubusercontent.com/MarkMichaelis/ScoopBucket/master/bucket/Invoke-GitDiffCode.ps1"
+        "https://raw.githubusercontent.com/MarkMichaelis/ScoopBucket/main/bucket/GitConfigVSCode.ps1",
+        "https://raw.githubusercontent.com/MarkMichaelis/ScoopBucket/main/bucket/Invoke-GitDiffCode.ps1"
     ],
     "installer": {
         "script": "& \"$dir\\GitConfigVSCode.ps1\""

--- a/bucket/GitConfigVisualStudio.json
+++ b/bucket/GitConfigVisualStudio.json
@@ -1,8 +1,8 @@
 {
     "$schema": "https://raw.githubusercontent.com/lukesampson/scoop/master/schema.json",
-    "version": "1.09.000",
+    "version": "1.10.000",
     "url": [
-        "https://raw.githubusercontent.com/MarkMichaelis/ScoopBucket/master/bucket/GitConfigVisualStudio.ps1"
+        "https://raw.githubusercontent.com/MarkMichaelis/ScoopBucket/main/bucket/GitConfigVisualStudio.ps1"
     ],
     "installer": {
         "script": "& \"$dir\\GitConfigVisualStudio.ps1\""

--- a/bucket/GitConfigure.json
+++ b/bucket/GitConfigure.json
@@ -1,12 +1,12 @@
 {
     "$schema": "https://raw.githubusercontent.com/lukesampson/scoop/master/schema.json",
-    "version": "1.22.000",
+    "version": "1.23.000",
     "url": [
-        "https://raw.githubusercontent.com/MarkMichaelis/ScoopBucket/master/bucket/GitConfigBeyondCompare.ps1",
-        "https://raw.githubusercontent.com/MarkMichaelis/ScoopBucket/master/bucket/GitConfigVSCode.ps1",
-        "https://raw.githubusercontent.com/MarkMichaelis/ScoopBucket/master/bucket/Invoke-GitDiffCode.ps1",
-        "https://raw.githubusercontent.com/MarkMichaelis/ScoopBucket/master/bucket/GitConfigVisualStudio.ps1",
-        "https://raw.githubusercontent.com/MarkMichaelis/ScoopBucket/master/bucket/GitConfigure.ps1"
+        "https://raw.githubusercontent.com/MarkMichaelis/ScoopBucket/main/bucket/GitConfigBeyondCompare.ps1",
+        "https://raw.githubusercontent.com/MarkMichaelis/ScoopBucket/main/bucket/GitConfigVSCode.ps1",
+        "https://raw.githubusercontent.com/MarkMichaelis/ScoopBucket/main/bucket/Invoke-GitDiffCode.ps1",
+        "https://raw.githubusercontent.com/MarkMichaelis/ScoopBucket/main/bucket/GitConfigVisualStudio.ps1",
+        "https://raw.githubusercontent.com/MarkMichaelis/ScoopBucket/main/bucket/GitConfigure.ps1"
     ],
     "installer": {
         "script": "& \"$dir\\GitConfigure.ps1\""

--- a/bucket/GitHubCopilotCli.json
+++ b/bucket/GitHubCopilotCli.json
@@ -1,7 +1,7 @@
 {
     "$schema": "https://raw.githubusercontent.com/lukesampson/scoop/master/schema.json",
-    "version": "1.00.000",
-    "url": ["https://raw.githubusercontent.com/MarkMichaelis/ScoopBucket/master/blank"],
+    "version": "1.01.000",
+    "url": ["https://raw.githubusercontent.com/MarkMichaelis/ScoopBucket/main/blank"],
     "installer": {
         "script": [
             "winget install --id GitHub.Copilot -e --silent --accept-package-agreements --accept-source-agreements"

--- a/bucket/LocalManifestInstallJson.Tests.ps1
+++ b/bucket/LocalManifestInstallJson.Tests.ps1
@@ -72,8 +72,8 @@ Describe 'Update-LocalManifestInstallMetadata' -Tag 'Light' {
 
         $urls = (Get-Content (Join-Path $fake.CurrentDir 'manifest.json') -Raw | ConvertFrom-Json).url
         @($urls) | Should -Be @(
-            'https://raw.githubusercontent.com/MarkMichaelis/ScoopBucket/master/bucket/Sample.ps1',
-            'https://raw.githubusercontent.com/MarkMichaelis/ScoopBucket/master/bucket/Utils.ps1'
+            'https://raw.githubusercontent.com/MarkMichaelis/ScoopBucket/main/bucket/Sample.ps1',
+            'https://raw.githubusercontent.com/MarkMichaelis/ScoopBucket/main/bucket/Utils.ps1'
         )
     }
 

--- a/bucket/MarkMichaelisOneDriveConfiguration.json
+++ b/bucket/MarkMichaelisOneDriveConfiguration.json
@@ -1,9 +1,9 @@
 {
     "$schema": "https://raw.githubusercontent.com/lukesampson/scoop/master/schema.json",
-    "version": "1.13.000",
+    "version": "1.14.000",
     "description": "Personal post-install customization bundle (member of the MarkMichaelis* run-last family). Pins OneDrive sync roots under a single parent, applies tenant-redirection policy, and rewrites KFM bindings to follow the canonical Work account. Runs AFTER all install bundles; reshapes state rather than installing software.",
     "url": [
-        "https://raw.githubusercontent.com/MarkMichaelis/ScoopBucket/master/bucket/MarkMichaelisOneDriveConfiguration.ps1"
+        "https://raw.githubusercontent.com/MarkMichaelis/ScoopBucket/main/bucket/MarkMichaelisOneDriveConfiguration.ps1"
     ],
     "installer": {
         "script": "& \"$dir\\MarkMichaelisOneDriveConfiguration.ps1\""

--- a/bucket/McAfeeUninstall.json
+++ b/bucket/McAfeeUninstall.json
@@ -2,7 +2,7 @@
   "$schema": "https://raw.githubusercontent.com/lukesampson/scoop/master/schema.json",
   "version": "1.01.001",
   "url": [
-    "https://raw.githubusercontent.com/MarkMichaelis/ScoopBucket/master/bucket/McAfeeUninstall.ps1",
+    "https://raw.githubusercontent.com/MarkMichaelis/ScoopBucket/main/bucket/McAfeeUninstall.ps1",
     "https://download.mcafee.com/molbin/iss-loc/SupportTools/MCPR/MCPR.exe"
   ],
   "pre_install": "& \"$dir\\McAfeeUninstall.ps1\"",

--- a/bucket/MicrosoftCopilot.json
+++ b/bucket/MicrosoftCopilot.json
@@ -1,7 +1,7 @@
 {
     "$schema": "https://raw.githubusercontent.com/lukesampson/scoop/master/schema.json",
-    "version": "1.00.000",
-    "url": ["https://raw.githubusercontent.com/MarkMichaelis/ScoopBucket/master/blank"],
+    "version": "1.01.000",
+    "url": ["https://raw.githubusercontent.com/MarkMichaelis/ScoopBucket/main/blank"],
     "installer": {
         "script": [
             "Write-Warning 'Microsoft Copilot consumer desktop app is built into Windows 11; no separate install required.'"

--- a/bucket/MicrosoftOffice365.json
+++ b/bucket/MicrosoftOffice365.json
@@ -1,8 +1,8 @@
 {
     "$schema": "https://raw.githubusercontent.com/lukesampson/scoop/master/schema.json",
-    "version": "1.13.000",
+    "version": "1.14.000",
     "url": [
-        "https://raw.githubusercontent.com/MarkMichaelis/ScoopBucket/master/bucket/MicrosoftOffice365.ps1"
+        "https://raw.githubusercontent.com/MarkMichaelis/ScoopBucket/main/bucket/MicrosoftOffice365.ps1"
     ],
     "installer": {
         "script": "& \"$dir\\MicrosoftOffice365.ps1\""

--- a/bucket/OSBasePackages.json
+++ b/bucket/OSBasePackages.json
@@ -1,8 +1,8 @@
 {
     "$schema": "https://raw.githubusercontent.com/lukesampson/scoop/master/schema.json",
-    "version": "1.30.000",
+    "version": "1.31.000",
     "url": [
-        "https://raw.githubusercontent.com/MarkMichaelis/ScoopBucket/master/bucket/OSBasePackages.ps1"
+        "https://raw.githubusercontent.com/MarkMichaelis/ScoopBucket/main/bucket/OSBasePackages.ps1"
     ],
     "installer": {
         "script": "& \"$dir\\OSBasePackages.ps1\""

--- a/bucket/PowerShellCore.json
+++ b/bucket/PowerShellCore.json
@@ -1,8 +1,8 @@
 {
     "$schema": "https://raw.githubusercontent.com/lukesampson/scoop/master/schema.json",
-    "version": "1.11.000",
+    "version": "1.12.000",
     "url": [
-        "https://raw.githubusercontent.com/MarkMichaelis/ScoopBucket/master/bucket/PowerShell.ps1"
+        "https://raw.githubusercontent.com/MarkMichaelis/ScoopBucket/main/bucket/PowerShell.ps1"
     ],
     "installer": {
         "script":  [

--- a/bucket/PowerShellCorePreview.json
+++ b/bucket/PowerShellCorePreview.json
@@ -1,7 +1,7 @@
-﻿{
+{
     "$schema": "https://raw.githubusercontent.com/lukesampson/scoop/master/schema.json",
-    "version": "1.01.000",
-    "url": ["https://raw.githubusercontent.com/MarkMichaelis/ScoopBucket/master/blank"],
+    "version": "1.02.000",
+    "url": ["https://raw.githubusercontent.com/MarkMichaelis/ScoopBucket/main/blank"],
     "installer": {
         "script": [
             "choco install PowerShell-Preview",

--- a/bucket/PowerShellWindows.json
+++ b/bucket/PowerShellWindows.json
@@ -1,8 +1,8 @@
 {
     "$schema": "https://raw.githubusercontent.com/lukesampson/scoop/master/schema.json",
-    "version": "1.14.000",
+    "version": "1.15.000",
     "url": [
-        "https://raw.githubusercontent.com/MarkMichaelis/ScoopBucket/master/bucket/PowerShell.ps1"
+        "https://raw.githubusercontent.com/MarkMichaelis/ScoopBucket/main/bucket/PowerShell.ps1"
     ],
     "installer": {
         "script": [

--- a/bucket/RemapShiftLockToWindowsKey.json
+++ b/bucket/RemapShiftLockToWindowsKey.json
@@ -2,9 +2,9 @@
   "$schema": "https://raw.githubusercontent.com/lukesampson/scoop/master/schema.json",
   "homepage": "https://github.com/MarkMichaelis/ScoopBucket",
   "description": "Remap Shift-Lock key to Windows Key",
-  "url": "https://raw.githubusercontent.com/MarkMichaelis/ScoopBucket/master/blank",
+  "url": "https://raw.githubusercontent.com/MarkMichaelis/ScoopBucket/main/blank",
   "notes": "Of course, this script is placed in the MarkMichaelis bucket so you it presents a chicken and egg problem.",
-  "version": "0.08.001",
+  "version": "0.09.000",
   "installer": {
     "script": [
       "reg add 'HKLM\\SYSTEM\\CurrentControlSet\\Control\\Keyboard Layout' /v 'Scancode Map' /t REG_BINARY /d 0000000000000000020000005BE03A0000000000 /f"

--- a/bucket/SetPowerConfiguration.json
+++ b/bucket/SetPowerConfiguration.json
@@ -1,7 +1,7 @@
-﻿{
+{
     "$schema": "https://raw.githubusercontent.com/lukesampson/scoop/master/schema.json",
-    "version": "1.05.000",
-    "url": "https://raw.githubusercontent.com/MarkMichaelis/ScoopBucket/master/bucket/SetPowerConfiguration.ps1",
+    "version": "1.06.000",
+    "url": "https://raw.githubusercontent.com/MarkMichaelis/ScoopBucket/main/bucket/SetPowerConfiguration.ps1",
     "depends" :[
         "EnableHybernate"
     ],

--- a/bucket/TotalCommander.json
+++ b/bucket/TotalCommander.json
@@ -1,7 +1,7 @@
-﻿{
+{
     "$schema": "https://raw.githubusercontent.com/lukesampson/scoop/master/schema.json",
-    "version": "1.00.000",
-    "url": ["https://raw.githubusercontent.com/MarkMichaelis/ScoopBucket/master/blank"],
+    "version": "1.01.000",
+    "url": ["https://raw.githubusercontent.com/MarkMichaelis/ScoopBucket/main/blank"],
     "installer": {
         "script": [
             "choco install TotalCommander"

--- a/bucket/VisualStudio2026Enterprise.json
+++ b/bucket/VisualStudio2026Enterprise.json
@@ -1,7 +1,7 @@
 {
     "$schema": "https://raw.githubusercontent.com/lukesampson/scoop/master/schema.json",
-    "version": "1.00.001",
-    "url": ["https://raw.githubusercontent.com/MarkMichaelis/ScoopBucket/master/blank"],
+    "version": "1.01.000",
+    "url": ["https://raw.githubusercontent.com/MarkMichaelis/ScoopBucket/main/blank"],
     "installer": {
         "script": [
             "choco install -y VisualStudio2026enterprise --package-parameters \"--includeRecommended --add Microsoft.VisualStudio.Workload.Azure --add Microsoft.VisualStudio.Workload.Data --add Microsoft.VisualStudio.Workload.DataScience --add Microsoft.VisualStudio.Component.CodeClone --add Microsoft.VisualStudio.Workload.ManagedDesktop --add Microsoft.VisualStudio.Workload.NativeCrossPlat --add Microsoft.VisualStudio.Workload.NativeDesktop --add Microsoft.VisualStudio.Workload.NetCrossPlat --add Microsoft.VisualStudio.Workload.NetWeb --add Microsoft.VisualStudio.Workload.Node --add Microsoft.VisualStudio.Workload.Office --add Microsoft.VisualStudio.Workload.Python --add Microsoft.VisualStudio.Workload.VisualStudioExtension --add Microsoft.VisualStudio.Workload.Universal --add Microsoft.VisualStudio.Component.VisualStudioData\"",

--- a/bucket/WSL-Ubuntu-1804.json
+++ b/bucket/WSL-Ubuntu-1804.json
@@ -1,7 +1,7 @@
-﻿{
+{
     "$schema": "https://raw.githubusercontent.com/lukesampson/scoop/master/schema.json",
-    "version": "1.01.000",
-    "url": ["https://raw.githubusercontent.com/MarkMichaelis/ScoopBucket/master/blank"],
+    "version": "1.02.000",
+    "url": ["https://raw.githubusercontent.com/MarkMichaelis/ScoopBucket/main/blank"],
     "installer": {
         "script": [
             "choco install wsl-ubuntu-1804"

--- a/bucket/WSL-Ubuntu-2004.json
+++ b/bucket/WSL-Ubuntu-2004.json
@@ -1,7 +1,7 @@
-﻿{
+{
     "$schema": "https://raw.githubusercontent.com/lukesampson/scoop/master/schema.json",
-    "version": "1.00.000",
-    "url": ["https://raw.githubusercontent.com/MarkMichaelis/ScoopBucket/master/blank"],
+    "version": "1.01.000",
+    "url": ["https://raw.githubusercontent.com/MarkMichaelis/ScoopBucket/main/blank"],
     "installer": {
         "script": [
             "choco install wsl-ubuntu-2004"

--- a/bucket/WindowsPowerShell.json
+++ b/bucket/WindowsPowerShell.json
@@ -1,7 +1,7 @@
-﻿{
+{
     "$schema": "https://raw.githubusercontent.com/lukesampson/scoop/master/schema.json",
     "version": "1.03.000",
-    "url": "https://raw.githubusercontent.com/MarkMichaelis/ScoopBucket/master/bucket/SetPowerConfiguration.ps1",
+    "url": "https://raw.githubusercontent.com/MarkMichaelis/ScoopBucket/main/bucket/SetPowerConfiguration.ps1",
     "depends" :[
         "PowerShellWindows"
     ]

--- a/bucket/dotnet.json
+++ b/bucket/dotnet.json
@@ -1,7 +1,7 @@
-﻿{
+{
     "$schema": "https://raw.githubusercontent.com/lukesampson/scoop/master/schema.json",
-    "version": "1.00.001",
-    "url": ["https://raw.githubusercontent.com/MarkMichaelis/ScoopBucket/master/blank"],
+    "version": "1.01.000",
+    "url": ["https://raw.githubusercontent.com/MarkMichaelis/ScoopBucket/main/blank"],
     "installer": {
         "script": [
             "choco install dotnetcore-sdk -y;choco install dotnetcore-sdk -pre -y"

--- a/module/MarkMichaelis.ScoopBucket/Private/Legacy.ps1
+++ b/module/MarkMichaelis.ScoopBucket/Private/Legacy.ps1
@@ -398,7 +398,7 @@ function Install-LocalManifest {
         $manifest.url = @(
             $manifest.url | ForEach-Object {
                 $rewritten = $_ -replace `
-                    'https://raw\.githubusercontent\.com/MarkMichaelis/ScoopBucket/master/bucket', `
+                    'https://raw\.githubusercontent\.com/MarkMichaelis/ScoopBucket/(master|main)/bucket', `
                     $LocalBucketRoot
                 ([Uri]$rewritten).AbsoluteUri
             }
@@ -546,7 +546,7 @@ function Update-LocalManifestInstallMetadata {
                 $manifestJson = Get-Content -LiteralPath $manifestJsonPath -Raw -ErrorAction Stop |
                     ConvertFrom-Json -ErrorAction Stop
                 if ($manifestJson.url) {
-                    $canonicalPrefix = "https://raw.githubusercontent.com/$BucketName/ScoopBucket/master/bucket"
+                    $canonicalPrefix = "https://raw.githubusercontent.com/$BucketName/ScoopBucket/main/bucket"
                     $manifestJson.url = @(
                         $manifestJson.url | ForEach-Object {
                             # Strip any file:// or local path prefix and rebuild against canonical master URL.


### PR DESCRIPTION
## Summary

GitHub default branch was renamed `master` -> `main` for this repository, so every manifest that
hard-coded `https://raw.githubusercontent.com/MarkMichaelis/ScoopBucket/master/...` returned 404.
Notably `scoop install -g MarkMichaelis/MicrosoftCopilot` failed with:

```
URL https://raw.githubusercontent.com/MarkMichaelis/ScoopBucket/master/blank is not valid
```

## Changes

- **36 manifests** (`bucket/*.json`): `ScoopBucket/master/` -> `ScoopBucket/main/` (script URLs and the `/blank` sentinel).
- **`bucket/LocalManifestInstallJson.Tests.ps1`**: fixture URLs updated to `main`.
- **`module/MarkMichaelis.ScoopBucket/Private/Legacy.ps1`**:
  - `Update-LocalManifestInstallMetadata` rewrite regex now accepts `(master|main)` so any
    already-installed manifests still pointing at `master` continue to work.
  - `Update-LocalManifestInstallJson` writes the canonical URL with `/main/`.

Foreign references (`lukesampson/scoop/master/schema.json`) are untouched -- that's a different repo that did not rename.

## Verification

```powershell
# zero hits after sweep
grep -rn 'MarkMichaelis/ScoopBucket/master/' bucket/
```

## Tests

Local: 856/858 passed, 1 pre-existing skip, 1 fixed by the Legacy.ps1 update. Suites run:
`LocalManifestInstallJson`, `InstallPackageFilter`, `UninstallPackage`, `AIAgents`,
`AIAgents.Mcp`, `Bundles`.

## Test command

```powershell
Invoke-Pester -Path .\bucket\LocalManifestInstallJson.Tests.ps1, .\bucket\Bundles.Tests.ps1
```

Closes #247