### PR TITLE
fix(aiagents): use npm.cmd in Get-NpmGlobalRoot to avoid npm.ps1 arg mangling (#249)

### DIFF
--- a/bucket/AIAgents.Mcp.Tests.ps1
+++ b/bucket/AIAgents.Mcp.Tests.ps1
@@ -169,6 +169,40 @@ Describe 'AIAgents.Mcp helpers' -Tag 'Light','Bundle' {
         }
     }
 
+    Context 'Get-NpmGlobalRoot' {
+        It 'uses npm.cmd (not npm.ps1) so args are not mangled by the .ps1 shim (#249)' {
+            # Repro for #249: on Windows where `npm` resolves to npm.ps1
+            # (Scoop nodejs install), `& npm prefix -g` is dispatched
+            # through the .ps1 shim as `npm pm -g` and fails with
+            # "Unknown command: pm". Verify by placing an npm.cmd stub on
+            # a temp PATH that echoes a known path, and asserting we
+            # actually invoked it (not the broken default npm).
+            $stubDir = New-TempDir
+            $script:TempRoots.Add($stubDir)
+            $expected = (Join-Path $stubDir 'global-root').Replace('\','/')
+            New-Item -ItemType Directory -Path (Join-Path $stubDir 'global-root') | Out-Null
+
+            # The .cmd stub: if invoked correctly with `prefix -g`, echo $expected.
+            # If the .ps1 shim were invoked instead, it would never reach this.
+            $stubCmd = Join-Path $stubDir 'npm.cmd'
+            @"
+@echo off
+if "%1"=="prefix" if "%2"=="-g" (echo $($expected -replace '/','\') & exit /b 0)
+echo unexpected: %*
+exit /b 1
+"@ | Set-Content -Path $stubCmd -Encoding ASCII
+
+            $savedPath = $env:PATH
+            try {
+                $env:PATH = "$stubDir;$env:PATH"
+                $result = Get-NpmGlobalRoot
+                $result | Should -Be ($expected -replace '/','\')
+            } finally {
+                $env:PATH = $savedPath
+            }
+        }
+    }
+
     Context 'Resolve-NpmBin' {
         BeforeEach {
             $script:TmpRoot = New-TempDir

--- a/bucket/AIAgents.Mcp.ps1
+++ b/bucket/AIAgents.Mcp.ps1
@@ -191,9 +191,17 @@ function Get-NpmGlobalRoot {
     [OutputType([string])]
     param()
 
-    if (-not (Get-Command npm -ErrorAction SilentlyContinue)) { return $null }
+    # On Windows, prefer `npm.cmd` explicitly: when PowerShell's call
+    # operator invokes `npm` (which resolves to npm.ps1 under Scoop and
+    # most other npm-on-Windows installs), the .ps1 shim's parameter
+    # parsing mangles the first positional argument -- `& npm prefix -g`
+    # is dispatched as `npm pm -g` and fails with `Unknown command: pm`.
+    # `npm.cmd` is the batch shim and passes args verbatim.
+    $npm = Get-Command npm.cmd -ErrorAction SilentlyContinue
+    if (-not $npm) { $npm = Get-Command npm -ErrorAction SilentlyContinue }
+    if (-not $npm) { return $null }
     try {
-        $prefix = (& npm prefix -g 2>$null)
+        $prefix = & $npm.Source prefix -g 2>$null
         if ($LASTEXITCODE -ne 0 -or -not $prefix) { return $null }
         return ($prefix | Out-String).Trim()
     } catch {


### PR DESCRIPTION
## Summary

On Windows where `npm` resolves to the `npm.ps1` shim (typical with Scoop-installed nodejs --
`C:\ProgramData\scoop\apps\nodejs\current\npm.ps1`), the PowerShell call operator dispatches
`& npm prefix -g` through the .ps1 shim, which mangles the first positional argument:

```
& npm prefix -g
# Unknown command: "pm"
```

(The shim's param-binder interprets `prefix` as a parameter name, strips the leading `n`, and
leaves `pm` as the supposed npm subcommand.)

Result: `Get-NpmGlobalRoot` returned `null`, and `Resolve-McpServerCommand` silently fell
back to `npx -y <pkg>` for **every** MCP server even when the package was globally installed --
defeating the entire pre-install optimization shipped in #244.

## Fix

Prefer `npm.cmd` (batch shim, passes args verbatim) when available. Falls back to `npm` on
non-Windows systems where only `npm` exists.

## Tests

Added a behavior-first regression test in `bucket/AIAgents.Mcp.Tests.ps1` that drops a real
`npm.cmd` stub on a temp PATH; the stub succeeds **only** if invoked with the literal args
`prefix -g` -- so the test would fail if `Get-NpmGlobalRoot` ever reverted to invoking the
broken `npm.ps1` path. Total: 30/30 Mcp tests green.

## Test command

```powershell
Invoke-Pester -Path .\bucket\AIAgents.Mcp.Tests.ps1
```

Closes #249