### PR TITLE
feat(install): -Uninstall switch + per-directory usage docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,24 @@ auto-load), saving ~1 s of cold pwsh startup. Re-running
 `Install-Module.ps1` migrates the legacy v1 eager-`Import-Module`
 block in-place.
 
+**Per-directory-only usage (no global install):** if you only use this
+bucket from inside the repo and don't want *any* profile / PSModulePath
+footprint, run:
+
+```powershell
+pwsh -File .\module\Install-Module.ps1 -Uninstall
+```
+
+`-Uninstall` strips the sentinel block from `$PROFILE.CurrentUserAllHosts`
+and removes the `MarkMichaelis.ScoopBucket` junction from your user
+module path (only if the junction points back to this repo). Then load
+the module on demand:
+
+```powershell
+cd C:\path\to\scoop
+Import-Module .\module\MarkMichaelis.ScoopBucket
+```
+
 Note: `Install-Package` and `Get-Package` deliberately shadow the
 rarely-used built-in `PackageManagement` cmdlets of the same name. The
 OneGet cmdlets remain reachable as `PackageManagement\Install-Package`

--- a/bucket/ProfileLazyLoad.Tests.ps1
+++ b/bucket/ProfileLazyLoad.Tests.ps1
@@ -189,3 +189,74 @@ if (-not (Get-Module -Name MarkMichaelis.ScoopBucket)) {
         }
     }
 }
+
+Describe 'Add-ScoopBucketProfileBlock.ps1 -Remove strips the sentinel block (#251)' -Tag 'Light','Module' {
+    It 'removes a v2 sentinel block in place, preserving surrounding content' {
+        $tempProfile = Join-Path ([IO.Path]::GetTempPath()) "scoopbucket-remove-v2-$([guid]::NewGuid().ToString('N')).ps1"
+        try {
+            $before = "Write-Host 'before'`n"
+            $after  = "`nWrite-Host 'after'`n"
+            Set-Content -LiteralPath $tempProfile -Value $before -Encoding utf8
+            & $script:helperScript -ProfilePath $tempProfile | Out-Null
+            Add-Content -LiteralPath $tempProfile -Value $after -Encoding utf8
+
+            & $script:helperScript -ProfilePath $tempProfile -Remove | Out-Null
+            $content = Get-Content -Raw -LiteralPath $tempProfile
+
+            $content | Should -Not -Match '# MarkMichaelis\.ScoopBucket:Import:BEGIN'
+            $content | Should -Not -Match '# MarkMichaelis\.ScoopBucket:Import:END'
+            $content | Should -Match "Write-Host 'before'"
+            $content | Should -Match "Write-Host 'after'"
+        } finally {
+            Remove-Item -LiteralPath $tempProfile -ErrorAction Ignore
+        }
+    }
+
+    It 'removes a legacy v1 sentinel block too' {
+        $tempProfile = Join-Path ([IO.Path]::GetTempPath()) "scoopbucket-remove-v1-$([guid]::NewGuid().ToString('N')).ps1"
+        try {
+            $v1Block = @'
+# MarkMichaelis.ScoopBucket:Import:BEGIN
+if (-not (Get-Module -Name MarkMichaelis.ScoopBucket)) {
+    Import-Module MarkMichaelis.ScoopBucket -ErrorAction SilentlyContinue
+}
+# MarkMichaelis.ScoopBucket:Import:END
+'@
+            Set-Content -LiteralPath $tempProfile -Value $v1Block -Encoding utf8
+
+            & $script:helperScript -ProfilePath $tempProfile -Remove | Out-Null
+            $content = Get-Content -Raw -LiteralPath $tempProfile -ErrorAction SilentlyContinue
+            if ($null -eq $content) { $content = '' }
+
+            $content | Should -Not -Match '# MarkMichaelis\.ScoopBucket:Import:BEGIN'
+            $content | Should -Not -Match 'Import-Module MarkMichaelis\.ScoopBucket'
+        } finally {
+            Remove-Item -LiteralPath $tempProfile -ErrorAction Ignore
+        }
+    }
+
+    It 'is a no-op when the profile has no sentinel block' {
+        $tempProfile = Join-Path ([IO.Path]::GetTempPath()) "scoopbucket-remove-noop-$([guid]::NewGuid().ToString('N')).ps1"
+        try {
+            $original = "# unrelated profile content`nWrite-Host 'hi'`n"
+            Set-Content -LiteralPath $tempProfile -Value $original -Encoding utf8
+
+            & $script:helperScript -ProfilePath $tempProfile -Remove | Out-Null
+            $content = Get-Content -Raw -LiteralPath $tempProfile
+
+            $content.TrimEnd() | Should -Be $original.TrimEnd()
+        } finally {
+            Remove-Item -LiteralPath $tempProfile -ErrorAction Ignore
+        }
+    }
+}
+
+Describe 'Install-Module.ps1 -Uninstall surfaces the -Remove path (#251)' -Tag 'Light','Module' {
+    It 'accepts -Uninstall and runs without throwing under -WhatIf' {
+        # We invoke under -WhatIf so the host's real profile / junction
+        # are not modified. The contract here is only: the script
+        # parses the new switch and reaches the uninstall branch
+        # without throwing.
+        { & $script:installScript -Uninstall -WhatIf } | Should -Not -Throw
+    }
+}

--- a/module/Add-ScoopBucketProfileBlock.ps1
+++ b/module/Add-ScoopBucketProfileBlock.ps1
@@ -2,7 +2,12 @@
 param(
     # Override the target profile (default: $PROFILE.CurrentUserAllHosts).
     # Tests pass a temp path here so they don't disturb the host.
-    [string]$ProfilePath = $PROFILE.CurrentUserAllHosts
+    [string]$ProfilePath = $PROFILE.CurrentUserAllHosts,
+
+    # Strip any existing MarkMichaelis.ScoopBucket sentinel block
+    # (v1 or v2) instead of emitting one. Used by
+    # Install-Module.ps1 -Uninstall (#251).
+    [switch]$Remove
 )
 
 <#
@@ -83,6 +88,29 @@ $endMarker
 
 if (-not $ProfilePath) {
     throw 'ProfilePath is empty; cannot emit MarkMichaelis.ScoopBucket profile block.'
+}
+
+if ($Remove) {
+    if (-not (Test-Path -LiteralPath $ProfilePath)) {
+        Write-Verbose "No profile at $ProfilePath; nothing to remove."
+        return
+    }
+    $current = Get-Content -Raw -LiteralPath $ProfilePath -ErrorAction SilentlyContinue
+    if ($null -eq $current -or $current -eq '') {
+        Write-Verbose "Profile $ProfilePath is empty; nothing to remove."
+        return
+    }
+    $removalPattern = '(?s)\r?\n?' + [regex]::Escape($beginV1Marker) + '.*?' + [regex]::Escape($endMarker) + '\r?\n?'
+    if (-not [regex]::IsMatch($current, $removalPattern)) {
+        Write-Verbose "No MarkMichaelis.ScoopBucket sentinel block found in $ProfilePath."
+        return
+    }
+    $updated = [regex]::Replace($current, $removalPattern, "`n")
+    if ($PSCmdlet.ShouldProcess($ProfilePath, 'Remove MarkMichaelis.ScoopBucket import block')) {
+        Set-Content -LiteralPath $ProfilePath -Value $updated -Encoding UTF8
+        Write-Verbose "Removed MarkMichaelis.ScoopBucket import block from $ProfilePath."
+    }
+    return
 }
 
 if (-not (Test-Path -LiteralPath $ProfilePath)) {

--- a/module/Install-Module.ps1
+++ b/module/Install-Module.ps1
@@ -6,7 +6,14 @@ param(
     # `Install-Package -Name <Tab>` argument completer fires on the
     # first keystroke without paying the ~1 s `Import-Module` cost on
     # every shell start. Pass -SkipProfile to suppress this.
-    [switch]$SkipProfile
+    [switch]$SkipProfile,
+
+    # Reverse a previous install: remove the sentinel-bracketed v1/v2
+    # block from $PROFILE.CurrentUserAllHosts AND remove the
+    # PSModulePath junction (only if it points back to this repo).
+    # After -Uninstall, use the module by `cd`-ing here and running
+    # `Import-Module .\module\MarkMichaelis.ScoopBucket`. See #251.
+    [switch]$Uninstall
 )
 
 <#
@@ -65,14 +72,59 @@ if (-not $userModulePath) {
     $userModulePath = Join-Path $HOME 'Documents\PowerShell\Modules'
 }
 
+$target = Join-Path $userModulePath 'MarkMichaelis.ScoopBucket'
+
+if ($Uninstall) {
+    # Strip the v1/v2 sentinel block from the profile (delegated to
+    # the same helper used by the install path).
+    $helper = Join-Path $PSScriptRoot 'Add-ScoopBucketProfileBlock.ps1'
+    if (Test-Path -LiteralPath $helper) {
+        $helperArgs = @{
+            ProfilePath = $PROFILE.CurrentUserAllHosts
+            Remove      = $true
+            Verbose     = $VerbosePreference -eq 'Continue'
+        }
+        if ($PSBoundParameters.ContainsKey('WhatIf')) { $helperArgs['WhatIf'] = $WhatIfPreference }
+        & $helper @helperArgs
+        Write-Host "Removed MarkMichaelis.ScoopBucket lazy-import block from $($PROFILE.CurrentUserAllHosts) (if present)."
+    } else {
+        Write-Warning "Profile-block helper not found at $helper; skipping profile cleanup."
+    }
+
+    # Remove the junction iff it points back to this repo. Leave any
+    # non-junction install (e.g. real directory from a different
+    # workflow) alone unless -Force is passed.
+    if (Test-Path -LiteralPath $target) {
+        $existing = Get-Item -LiteralPath $target -Force
+        $isJunction = ($existing.Attributes -band [System.IO.FileAttributes]::ReparsePoint) -ne 0
+        $pointsHere = $false
+        if ($isJunction -and $existing.Target) {
+            try {
+                $pointsHere = (Resolve-Path -LiteralPath $existing.Target).Path -eq (Resolve-Path -LiteralPath $source).Path
+            } catch { $pointsHere = $false }
+        }
+        if ($pointsHere -or $Force) {
+            if ($PSCmdlet.ShouldProcess($target, 'Remove MarkMichaelis.ScoopBucket junction')) {
+                Remove-Item -LiteralPath $target -Recurse -Force
+                Write-Host "Removed MarkMichaelis.ScoopBucket entry at $target."
+            }
+        } else {
+            Write-Warning "Entry at $target is not a junction to this repo; leaving it in place. Pass -Force to remove anyway."
+        }
+    } else {
+        Write-Verbose "No MarkMichaelis.ScoopBucket entry at $target; nothing to remove."
+    }
+
+    Write-Host "Uninstall complete. To use the module from this repo: cd here and run 'Import-Module .\module\MarkMichaelis.ScoopBucket'."
+    return
+}
+
 if (-not (Test-Path -LiteralPath $userModulePath -PathType Container)) {
     Write-Verbose "Creating module path: $userModulePath"
     if ($PSCmdlet.ShouldProcess($userModulePath, 'New-Item -ItemType Directory')) {
         New-Item -ItemType Directory -Force -Path $userModulePath | Out-Null
     }
 }
-
-$target = Join-Path $userModulePath 'MarkMichaelis.ScoopBucket'
 
 if (Test-Path -LiteralPath $target) {
     $existing = Get-Item -LiteralPath $target -Force


### PR DESCRIPTION
## Summary

Adds `-Uninstall` to `module\Install-Module.ps1` for users who only need MarkMichaelis.ScoopBucket from inside the repo directory and don't want any global profile / PSModulePath footprint.

## What it does

- Strips the v1/v2 sentinel block from `$PROFILE.CurrentUserAllHosts` (delegated to a new `-Remove` switch on `module\Add-ScoopBucketProfileBlock.ps1`).
- Removes the junction at `<UserModules>\MarkMichaelis.ScoopBucket` -- but only if it points back to this repo. Pass `-Force` to remove a non-junction entry.
- README documents the per-directory ritual: `cd <repo>; Import-Module .\module\MarkMichaelis.ScoopBucket`.

## Tests

4 new behavioral Pester cases in `bucket\ProfileLazyLoad.Tests.ps1`:
- removes v2 block in place, preserving surrounding profile content
- removes legacy v1 block too
- no-op when profile has no sentinel block
- `Install-Module.ps1 -Uninstall -WhatIf` reaches the uninstall branch without throwing

All 11 tests in the file pass locally. Module-tagged suite is otherwise green; the only `[-]` is the cold-import perf budget test which fails on `main` too at 1901ms median (1800ms budget) -- environmental, unrelated.

## Verify

```powershell
Invoke-Pester -Path .\bucket\ProfileLazyLoad.Tests.ps1 -Output Detailed
```

Closes #251