### PR TITLE
fix(install): junction-safe -Uninstall (#253)

### DIFF
--- a/bucket/ProfileLazyLoad.Tests.ps1
+++ b/bucket/ProfileLazyLoad.Tests.ps1
@@ -260,3 +260,54 @@ Describe 'Install-Module.ps1 -Uninstall surfaces the -Remove path (#251)' -Tag '
         { & $script:installScript -Uninstall -WhatIf } | Should -Not -Throw
     }
 }
+
+Describe 'Install-Module.ps1 -Uninstall removes a ReadOnly junction (#253)' -Tag 'Light','Module' {
+    # Regression for #253: New-Item -ItemType Junction creates a link
+    # with ReadOnly attribute set on some hosts. The original
+    # implementation used `Remove-Item -Recurse -Force` which follows
+    # the reparse point into the target and fails with Access Denied
+    # if the target tree contains read-only files (or the link itself
+    # is ReadOnly). The fix strips ReadOnly and uses
+    # [System.IO.Directory]::Delete($path, $false) to remove only the
+    # link.
+    It 'removes a junction whose Attributes include ReadOnly' {
+        $sandbox    = Join-Path ([IO.Path]::GetTempPath()) "scoopbucket-junction-$([guid]::NewGuid().ToString('N'))"
+        $sourceDir  = Join-Path $sandbox 'real-source'
+        $linkParent = Join-Path $sandbox 'fake-modules'
+        $linkPath   = Join-Path $linkParent 'MarkMichaelis.ScoopBucket'
+        try {
+            New-Item -ItemType Directory -Path $sourceDir | Out-Null
+            New-Item -ItemType Directory -Path $linkParent | Out-Null
+            # Put a read-only file inside the source so a recursive
+            # delete via the junction would fail with Access Denied.
+            $sentinelFile = Join-Path $sourceDir 'sentinel.txt'
+            Set-Content -LiteralPath $sentinelFile -Value 'do-not-delete' -Encoding utf8
+            (Get-Item -LiteralPath $sentinelFile).IsReadOnly = $true
+
+            $junction = New-Item -ItemType Junction -Path $linkPath -Target $sourceDir
+            # Force ReadOnly on the junction itself to mirror the bug.
+            $junction.Attributes = $junction.Attributes -bor [System.IO.FileAttributes]::ReadOnly
+
+            # Apply the same junction-removal logic as Install-Module.ps1.
+            $existing  = Get-Item -LiteralPath $linkPath -Force
+            $isJunction = ($existing.Attributes -band [System.IO.FileAttributes]::ReparsePoint) -ne 0
+            $isJunction | Should -BeTrue
+
+            if (($existing.Attributes -band [System.IO.FileAttributes]::ReadOnly) -ne 0) {
+                $existing.Attributes = $existing.Attributes -band (-bnot [System.IO.FileAttributes]::ReadOnly)
+            }
+            { [System.IO.Directory]::Delete($linkPath, $false) } | Should -Not -Throw
+
+            Test-Path -LiteralPath $linkPath  | Should -BeFalse
+            # Source dir + read-only file must remain intact (the bug
+            # would have either failed entirely or wiped them).
+            Test-Path -LiteralPath $sourceDir    | Should -BeTrue
+            Test-Path -LiteralPath $sentinelFile | Should -BeTrue
+        } finally {
+            if (Test-Path -LiteralPath $sentinelFile) {
+                (Get-Item -LiteralPath $sentinelFile -ErrorAction Ignore).IsReadOnly = $false
+            }
+            Remove-Item -LiteralPath $sandbox -Recurse -Force -ErrorAction Ignore
+        }
+    }
+}

--- a/module/Install-Module.ps1
+++ b/module/Install-Module.ps1
@@ -105,7 +105,22 @@ if ($Uninstall) {
         }
         if ($pointsHere -or $Force) {
             if ($PSCmdlet.ShouldProcess($target, 'Remove MarkMichaelis.ScoopBucket junction')) {
-                Remove-Item -LiteralPath $target -Recurse -Force
+                if ($isJunction) {
+                    # PowerShell's Remove-Item -Recurse follows the
+                    # reparse point and tries to delete the *target*
+                    # contents (which fails with Access Denied if the
+                    # target is read-only or the junction has the
+                    # ReadOnly attribute set, as New-Item -ItemType
+                    # Junction does on some hosts). Strip ReadOnly
+                    # then use the .NET non-recursive Directory.Delete
+                    # which removes only the link itself.
+                    if (($existing.Attributes -band [System.IO.FileAttributes]::ReadOnly) -ne 0) {
+                        $existing.Attributes = $existing.Attributes -band (-bnot [System.IO.FileAttributes]::ReadOnly)
+                    }
+                    [System.IO.Directory]::Delete($target, $false)
+                } else {
+                    Remove-Item -LiteralPath $target -Recurse -Force
+                }
                 Write-Host "Removed MarkMichaelis.ScoopBucket entry at $target."
             }
         } else {


### PR DESCRIPTION
## Summary

Live repro after merging #252: `pwsh -File .\module\Install-Module.ps1 -Uninstall` removed the profile block but failed to remove the junction with:

```
Cannot remove item C:\Users\...\Documents\PowerShell\Modules\MarkMichaelis.ScoopBucket: Access to the path '...' is denied.
```

`New-Item -ItemType Junction` sets the **ReadOnly** attribute on the link, and `Remove-Item -Recurse -Force` follows the reparse point into the target tree (which is this repo, full of read-only-flagged files), so the recurse step Access-Denies.

## Fix

For junctions: strip ReadOnly, then call `[System.IO.Directory]::Delete($path, $false)` to remove only the link. Non-junction entries (real directories from a different install workflow) still take the original `Remove-Item -Recurse -Force` path.

## Test

New regression case in `bucket\ProfileLazyLoad.Tests.ps1`: creates a Junction with the ReadOnly attribute pointing to a real source dir that contains a ReadOnly file, then runs the new logic and asserts the link is gone while the source tree is intact. All 12 tests in the file pass locally.

```powershell
Invoke-Pester -Path .\bucket\ProfileLazyLoad.Tests.ps1 -Output Detailed
```

Closes #253