### PR TITLE
fix(scoop): remove [InstallArgs] cast to avoid type-identity collision (#255)

### DIFF
--- a/bucket/ScoopWrapperInstallArgsCast.Tests.ps1
+++ b/bucket/ScoopWrapperInstallArgsCast.Tests.ps1
@@ -1,0 +1,57 @@
+<#
+.SYNOPSIS
+    Regression test for issue #255 -- the `scoop` wrapper must not declare
+    `[InstallArgs]` on its locally-scoped $scoopArgs variable.
+
+.DESCRIPTION
+    `InstallArgs` is defined in a dot-sourced Private file rather than via
+    the manifest's ScriptsToProcess. Any second load of the module (or a
+    second runtime copy of the dot-sourced class in the same session)
+    creates a new `[InstallArgs]` type identity. The cast on
+    `Private/Legacy.ps1:207` then fails with the confusing:
+
+        Cannot convert the "InstallArgs" value of type "InstallArgs" to
+        type "InstallArgs".
+
+    `Get-InstallArgs` already returns the correct shape, so the type
+    constraint adds no value and must stay removed.
+
+    This is an AST-level pin -- it fails for a behavioral reason
+    (assertion failure naming the offending line) when the constraint is
+    re-introduced.
+#>
+
+BeforeAll {
+    $script:legacyPath = Resolve-Path (Join-Path (Split-Path -Parent $PSScriptRoot) 'module\MarkMichaelis.ScoopBucket\Private\Legacy.ps1')
+}
+
+Describe 'scoop wrapper -- InstallArgs cast (issue #255)' -Tag 'Light','Module' {
+
+    It 'does not constrain $scoopArgs to [InstallArgs] inside function scoop' {
+        $tokens = $null
+        $errors = $null
+        $ast = [System.Management.Automation.Language.Parser]::ParseFile(
+            $script:legacyPath, [ref]$tokens, [ref]$errors)
+        $errors | Should -BeNullOrEmpty
+
+        $scoopFn = $ast.FindAll({
+            param($n)
+            $n -is [System.Management.Automation.Language.FunctionDefinitionAst] -and
+            $n.Name -eq 'scoop'
+        }, $true) | Select-Object -First 1
+        $scoopFn | Should -Not -BeNullOrEmpty -Because 'function scoop must exist in Legacy.ps1'
+
+        $offending = $scoopFn.FindAll({
+            param($n)
+            $n -is [System.Management.Automation.Language.ConvertExpressionAst] -and
+            $n.Type.TypeName.Name -eq 'InstallArgs'
+        }, $true)
+
+        $offending | Should -BeNullOrEmpty -Because @"
+The [InstallArgs] cast inside `function scoop` triggers a type-identity
+collision after the module is reloaded (issue #255). Get-InstallArgs
+already returns an InstallArgs instance -- leave $scoopArgs untyped, the
+same way the sibling `choco` wrapper does.
+"@
+    }
+}

--- a/module/MarkMichaelis.ScoopBucket/Private/Legacy.ps1
+++ b/module/MarkMichaelis.ScoopBucket/Private/Legacy.ps1
@@ -204,7 +204,13 @@ function Get-InstallArgs {
 }
 
 function scoop {
-    [InstallArgs]$scoopArgs = Get-InstallArgs @args
+    # No [InstallArgs] type constraint here on purpose: the class is
+    # defined in a dot-sourced Private file (not via ScriptsToProcess),
+    # so a second runtime copy of the type in the same session would
+    # trip a "Cannot convert InstallArgs to InstallArgs" type-identity
+    # mismatch. See issue #255. `choco` is intentionally untyped for
+    # the same reason.
+    $scoopArgs = Get-InstallArgs @args
     $localArgs = $scoopArgs.OriginalArgs
     $cmd = $scoopArgs.Action
     $options = $scoopArgs.Options


### PR DESCRIPTION
## Summary

Fixes #255. The `scoop` wrapper failed with:

```
MetadataError: Private\Legacy.ps1:207
Cannot convert the "InstallArgs" value of type "InstallArgs" to type "InstallArgs".
```

## Root cause

`InstallArgs` is defined in a dot-sourced Private file rather than via the manifest's `ScriptsToProcess` (the way `Package` is). Any second runtime copy of the class in the same session creates a new `[InstallArgs]` type identity, so the cast on line 207 ends up resolving to a different type than what `Get-InstallArgs` returns -- even though the names match.

## Change

- Remove the `[InstallArgs]` type constraint on `` in `function scoop`. `Get-InstallArgs` already returns an `InstallArgs` instance, and the sibling `choco` wrapper is already untyped for the same reason.
- Add `bucket/ScoopWrapperInstallArgsCast.Tests.ps1` -- AST-level pin that fails on revert and passes after the fix.

## Verification

```
Invoke-Pester -Path ./bucket/ScoopWrapperInstallArgsCast.Tests.ps1 -Output Detailed
# RED on revert, GREEN on this branch
```

Full Light suite: 1119 passed, 1 pre-existing perf-budget failure (`ImportPerformance.Tests.ps1` cold import median 1967 ms vs 1800 ms budget) confirmed against `main` -- not caused by this change.

Closes #255