### PR TITLE
feat(update): add -All switch to Update-Package for machine-wide sweeps

### DIFF
--- a/bucket/UpdatePackage.Tests.ps1
+++ b/bucket/UpdatePackage.Tests.ps1
@@ -466,3 +466,294 @@ Describe 'Update-Package dispatcher' -Tag 'Light','Module' {
         $pkg.WingetExtraArgs | Should -Be @('--skip-dependencies','--silent')
     }
 }
+
+Describe 'Update-All<engine>Packages sweep engines' -Tag 'Light','Module' {
+
+    Context 'Update-AllWingetPackages' {
+        BeforeAll {
+            $script:Engine = & (Get-Module MarkMichaelis.ScoopBucket) { Get-Command Update-AllWingetPackages }
+        }
+
+        It 'returns Skipped when winget not on PATH (no invocation)' {
+            Mock -ModuleName MarkMichaelis.ScoopBucket Get-Command { return $null } -ParameterFilter { $Name -eq 'winget' }
+            Mock -ModuleName MarkMichaelis.ScoopBucket winget { throw 'should not run' }
+            $r = & $script:Engine
+            $r.State  | Should -Be 'Skipped'
+            $r.Engine | Should -Be 'winget'
+            Should -Invoke -ModuleName MarkMichaelis.ScoopBucket winget -Times 0 -Exactly
+        }
+
+        It 'with -WhatIf prints the bulk command and does not invoke winget' {
+            Mock -ModuleName MarkMichaelis.ScoopBucket Get-Command { return [pscustomobject]@{ Name='winget' } } -ParameterFilter { $Name -eq 'winget' }
+            Mock -ModuleName MarkMichaelis.ScoopBucket winget { throw 'should not run' }
+            $r = & $script:Engine -WhatIf
+            $r.State  | Should -Be 'Updated'
+            $r.Reason | Should -Match 'WhatIf'
+            $r.Engine | Should -Be 'winget'
+            Should -Invoke -ModuleName MarkMichaelis.ScoopBucket winget -Times 0 -Exactly
+        }
+
+        It 'invokes winget upgrade --all with required flags and returns Updated on exit 0' {
+            Mock -ModuleName MarkMichaelis.ScoopBucket Get-Command { return [pscustomobject]@{ Name='winget' } } -ParameterFilter { $Name -eq 'winget' }
+            $script:captured = $null
+            Mock -ModuleName MarkMichaelis.ScoopBucket winget {
+                $script:captured = $args
+                $global:LASTEXITCODE = 0
+                return ''
+            }
+            $r = & $script:Engine
+            $r.State | Should -Be 'Updated'
+            $script:captured[0] | Should -Be 'upgrade'
+            ($script:captured -contains '--all')                         | Should -BeTrue
+            ($script:captured -contains '--include-unknown')             | Should -BeTrue
+            ($script:captured -contains '--silent')                      | Should -BeTrue
+            ($script:captured -contains '--accept-package-agreements')   | Should -BeTrue
+            ($script:captured -contains '--accept-source-agreements')    | Should -BeTrue
+        }
+
+        It 'returns Failed on non-zero exit' {
+            Mock -ModuleName MarkMichaelis.ScoopBucket Get-Command { return [pscustomobject]@{ Name='winget' } } -ParameterFilter { $Name -eq 'winget' }
+            Mock -ModuleName MarkMichaelis.ScoopBucket winget { $global:LASTEXITCODE = 7; return 'boom' }
+            $r = & $script:Engine
+            $r.State  | Should -Be 'Failed'
+            $r.Reason | Should -Match '7'
+        }
+    }
+
+    Context 'Update-AllScoopPackages' {
+        BeforeAll {
+            $script:Engine = & (Get-Module MarkMichaelis.ScoopBucket) { Get-Command Update-AllScoopPackages }
+        }
+
+        It 'returns Skipped when scoop not on PATH' {
+            Mock -ModuleName MarkMichaelis.ScoopBucket Get-Command { return $null } -ParameterFilter { $Name -eq 'scoop' }
+            $r = & $script:Engine
+            $r.State  | Should -Be 'Skipped'
+            $r.Engine | Should -Be 'scoop'
+        }
+
+        It 'invokes scoop update * (not bare scoop update which only updates scoop+buckets)' {
+            Mock -ModuleName MarkMichaelis.ScoopBucket Get-Command { return [pscustomobject]@{ Name='scoop' } } -ParameterFilter { $Name -eq 'scoop' }
+            $script:captured = $null
+            Mock -ModuleName MarkMichaelis.ScoopBucket scoop {
+                $script:captured = $args
+                $global:LASTEXITCODE = 0
+                return ''
+            }
+            $r = & $script:Engine
+            $r.State | Should -Be 'Updated'
+            $script:captured[0] | Should -Be 'update'
+            $script:captured[1] | Should -Be '*'
+        }
+
+        It 'with -WhatIf prints the bulk command and does not invoke scoop' {
+            Mock -ModuleName MarkMichaelis.ScoopBucket Get-Command { return [pscustomobject]@{ Name='scoop' } } -ParameterFilter { $Name -eq 'scoop' }
+            Mock -ModuleName MarkMichaelis.ScoopBucket scoop { throw 'should not run' }
+            $r = & $script:Engine -WhatIf
+            $r.State  | Should -Be 'Updated'
+            $r.Reason | Should -Match 'WhatIf'
+            Should -Invoke -ModuleName MarkMichaelis.ScoopBucket scoop -Times 0 -Exactly
+        }
+    }
+
+    Context 'Update-AllChocoPackages' {
+        BeforeAll {
+            $script:Engine = & (Get-Module MarkMichaelis.ScoopBucket) { Get-Command Update-AllChocoPackages }
+        }
+
+        It 'returns Skipped when choco not on PATH' {
+            Mock -ModuleName MarkMichaelis.ScoopBucket Get-Command { return $null } -ParameterFilter { $Name -eq 'choco' }
+            $r = & $script:Engine
+            $r.State  | Should -Be 'Skipped'
+            $r.Engine | Should -Be 'choco'
+        }
+
+        It 'invokes choco upgrade all -y --no-progress' {
+            Mock -ModuleName MarkMichaelis.ScoopBucket Get-Command { return [pscustomobject]@{ Name='choco' } } -ParameterFilter { $Name -eq 'choco' }
+            $script:captured = $null
+            Mock -ModuleName MarkMichaelis.ScoopBucket choco {
+                $script:captured = $args
+                $global:LASTEXITCODE = 0
+                return ''
+            }
+            $r = & $script:Engine
+            $r.State | Should -Be 'Updated'
+            $script:captured[0] | Should -Be 'upgrade'
+            $script:captured[1] | Should -Be 'all'
+            ($script:captured -contains '-y')            | Should -BeTrue
+            ($script:captured -contains '--no-progress') | Should -BeTrue
+        }
+    }
+
+    Context 'Update-AllNpmGlobalPackages' {
+        BeforeAll {
+            $script:Engine = & (Get-Module MarkMichaelis.ScoopBucket) { Get-Command Update-AllNpmGlobalPackages }
+        }
+
+        It 'returns Skipped when npm.cmd not on PATH' {
+            Mock -ModuleName MarkMichaelis.ScoopBucket Get-Command { return $null } -ParameterFilter { $Name -eq 'npm.cmd' }
+            $r = & $script:Engine
+            $r.State  | Should -Be 'Skipped'
+            $r.Engine | Should -Be 'npmGlobal'
+        }
+
+        It 'invokes npm update -g via npm.cmd' {
+            Mock -ModuleName MarkMichaelis.ScoopBucket Get-Command { return [pscustomobject]@{ Name='npm.cmd' } } -ParameterFilter { $Name -eq 'npm.cmd' }
+            $script:captured = $null
+            Mock -ModuleName MarkMichaelis.ScoopBucket npm.cmd {
+                $script:captured = $args
+                $global:LASTEXITCODE = 0
+                return ''
+            }
+            $r = & $script:Engine
+            $r.State | Should -Be 'Updated'
+            $script:captured[0] | Should -Be 'update'
+            ($script:captured -contains '-g') | Should -BeTrue
+        }
+    }
+
+    Context 'Update-AllDotnetToolPackages' {
+        BeforeAll {
+            $script:Engine = & (Get-Module MarkMichaelis.ScoopBucket) { Get-Command Update-AllDotnetToolPackages }
+        }
+
+        It 'returns Skipped when dotnet not on PATH' {
+            Mock -ModuleName MarkMichaelis.ScoopBucket Get-Command { return $null } -ParameterFilter { $Name -eq 'dotnet' }
+            $r = & $script:Engine
+            $r.State  | Should -Be 'Skipped'
+            $r.Engine | Should -Be 'dotnetTool'
+        }
+
+        It 'invokes dotnet tool update -g --all on supported SDKs' {
+            Mock -ModuleName MarkMichaelis.ScoopBucket Get-Command { return [pscustomobject]@{ Name='dotnet' } } -ParameterFilter { $Name -eq 'dotnet' }
+            $script:allCalls = New-Object System.Collections.Generic.List[object]
+            Mock -ModuleName MarkMichaelis.ScoopBucket dotnet {
+                $script:allCalls.Add(@($args))
+                $global:LASTEXITCODE = 0
+                return 'Tools restored.'
+            }
+            $r = & $script:Engine
+            $r.State | Should -Be 'Updated'
+            # First call should be `dotnet tool update -g --all`.
+            $first = $script:allCalls[0]
+            $first[0] | Should -Be 'tool'
+            $first[1] | Should -Be 'update'
+            ($first -contains '-g')    | Should -BeTrue
+            ($first -contains '--all') | Should -BeTrue
+        }
+
+        It 'falls back to per-tool enumeration when --all is unrecognized' {
+            Mock -ModuleName MarkMichaelis.ScoopBucket Get-Command { return [pscustomobject]@{ Name='dotnet' } } -ParameterFilter { $Name -eq 'dotnet' }
+            $script:allCalls = New-Object System.Collections.Generic.List[object]
+            Mock -ModuleName MarkMichaelis.ScoopBucket dotnet {
+                $script:allCalls.Add(@($args))
+                $argList = @($args)
+                # First call with --all: simulate older SDK that rejects the flag.
+                if ($argList -contains '--all') {
+                    $global:LASTEXITCODE = 1
+                    return "Unrecognized option '--all'"
+                }
+                # `dotnet tool list -g` fallback enumeration.
+                if ($argList[0] -eq 'tool' -and $argList[1] -eq 'list') {
+                    $global:LASTEXITCODE = 0
+                    return @(
+                        'Package Id      Version      Commands',
+                        '----------------------------------------',
+                        'foo             1.0.0        foo',
+                        'bar             2.0.0        bar'
+                    )
+                }
+                # Per-tool updates.
+                $global:LASTEXITCODE = 0
+                return ''
+            }
+            $r = & $script:Engine
+            $r.State | Should -Be 'Updated'
+            # Expect: 1 (--all probe) + 1 (list -g) + 2 (foo + bar per-tool) = 4 calls.
+            $script:allCalls.Count | Should -BeGreaterOrEqual 3
+            # Confirm fallback per-tool updates happened.
+            $perTool = $script:allCalls | Where-Object { $_ -contains 'update' -and $_ -notcontains '--all' -and $_ -notcontains 'list' }
+            $perTool.Count | Should -BeGreaterOrEqual 2
+        }
+    }
+}
+
+Describe 'Invoke-AllEnginesUpdate orchestrator' -Tag 'Light','Module' {
+
+    BeforeEach {
+        Mock -ModuleName MarkMichaelis.ScoopBucket Update-AllScoopPackages      { return @{ State='Updated'; Reason=$null; Engine='scoop' } }
+        Mock -ModuleName MarkMichaelis.ScoopBucket Update-AllWingetPackages     { return @{ State='Updated'; Reason=$null; Engine='winget' } }
+        Mock -ModuleName MarkMichaelis.ScoopBucket Update-AllChocoPackages      { return @{ State='Skipped'; Reason='not installed'; Engine='choco' } }
+        Mock -ModuleName MarkMichaelis.ScoopBucket Update-AllNpmGlobalPackages  { return @{ State='Updated'; Reason=$null; Engine='npmGlobal' } }
+        Mock -ModuleName MarkMichaelis.ScoopBucket Update-AllDotnetToolPackages { return @{ State='Updated'; Reason=$null; Engine='dotnetTool' } }
+    }
+
+    It 'runs all five engines in scoop->winget->choco->npmGlobal->dotnetTool order' {
+        $script:order = New-Object System.Collections.Generic.List[string]
+        Mock -ModuleName MarkMichaelis.ScoopBucket Update-AllScoopPackages      { $script:order.Add('scoop');      return @{ State='Updated'; Reason=$null; Engine='scoop' } }
+        Mock -ModuleName MarkMichaelis.ScoopBucket Update-AllWingetPackages     { $script:order.Add('winget');     return @{ State='Updated'; Reason=$null; Engine='winget' } }
+        Mock -ModuleName MarkMichaelis.ScoopBucket Update-AllChocoPackages      { $script:order.Add('choco');      return @{ State='Updated'; Reason=$null; Engine='choco' } }
+        Mock -ModuleName MarkMichaelis.ScoopBucket Update-AllNpmGlobalPackages  { $script:order.Add('npmGlobal');  return @{ State='Updated'; Reason=$null; Engine='npmGlobal' } }
+        Mock -ModuleName MarkMichaelis.ScoopBucket Update-AllDotnetToolPackages { $script:order.Add('dotnetTool'); return @{ State='Updated'; Reason=$null; Engine='dotnetTool' } }
+
+        $orch = & (Get-Module MarkMichaelis.ScoopBucket) { Get-Command Invoke-AllEnginesUpdate }
+        $null = & $orch
+
+        $script:order -join ',' | Should -Be 'scoop,winget,choco,npmGlobal,dotnetTool'
+    }
+
+    It 'does NOT short-circuit when one engine fails' {
+        Mock -ModuleName MarkMichaelis.ScoopBucket Update-AllWingetPackages { return @{ State='Failed'; Reason='boom'; Engine='winget' } }
+        $orch = & (Get-Module MarkMichaelis.ScoopBucket) { Get-Command Invoke-AllEnginesUpdate }
+        $null = & $orch
+        # All five engines must still run despite winget failure.
+        Should -Invoke -ModuleName MarkMichaelis.ScoopBucket Update-AllScoopPackages      -Times 1 -Exactly
+        Should -Invoke -ModuleName MarkMichaelis.ScoopBucket Update-AllWingetPackages     -Times 1 -Exactly
+        Should -Invoke -ModuleName MarkMichaelis.ScoopBucket Update-AllChocoPackages      -Times 1 -Exactly
+        Should -Invoke -ModuleName MarkMichaelis.ScoopBucket Update-AllNpmGlobalPackages  -Times 1 -Exactly
+        Should -Invoke -ModuleName MarkMichaelis.ScoopBucket Update-AllDotnetToolPackages -Times 1 -Exactly
+    }
+
+    It 'propagates -DryRun to each engine as -WhatIf' {
+        Mock -ModuleName MarkMichaelis.ScoopBucket Update-AllScoopPackages -ParameterFilter { $WhatIf } { return @{ State='Updated'; Reason='(WhatIf)'; Engine='scoop' } }
+        $orch = & (Get-Module MarkMichaelis.ScoopBucket) { Get-Command Invoke-AllEnginesUpdate }
+        $null = & $orch -DryRun
+        Should -Invoke -ModuleName MarkMichaelis.ScoopBucket Update-AllScoopPackages -Times 1 -Exactly -ParameterFilter { $WhatIf }
+    }
+
+    It 'prints the completer-refresh hint at the end' {
+        $orch = & (Get-Module MarkMichaelis.ScoopBucket) { Get-Command Invoke-AllEnginesUpdate }
+        $out = & $orch 6>&1 | Out-String
+        $out | Should -Match 'Update-PackageCompletion'
+    }
+}
+
+Describe 'Update-Package -All dispatcher' -Tag 'Light','Module' {
+
+    BeforeEach {
+        Mock -ModuleName MarkMichaelis.ScoopBucket Invoke-AllEnginesUpdate { }
+        Mock -ModuleName MarkMichaelis.ScoopBucket Get-BundlePackages      { throw 'should not be called under -All' }
+    }
+
+    It '-All skips bundle resolution entirely (Get-BundlePackages NOT called)' {
+        Update-Package -All -SkipCompletion
+        Should -Invoke -ModuleName MarkMichaelis.ScoopBucket Get-BundlePackages -Times 0 -Exactly
+        Should -Invoke -ModuleName MarkMichaelis.ScoopBucket Invoke-AllEnginesUpdate -Times 1 -Exactly
+    }
+
+    It '-All -DryRun propagates DryRun to Invoke-AllEnginesUpdate' {
+        Mock -ModuleName MarkMichaelis.ScoopBucket Invoke-AllEnginesUpdate -ParameterFilter { $DryRun } { }
+        Update-Package -All -DryRun -SkipCompletion
+        Should -Invoke -ModuleName MarkMichaelis.ScoopBucket Invoke-AllEnginesUpdate -Times 1 -Exactly -ParameterFilter { $DryRun }
+    }
+
+    It '-Name foo -All errors with parameter-set ambiguity (mutually exclusive)' {
+        { Update-Package -Name 'foo' -All -SkipCompletion } | Should -Throw
+    }
+
+    It '-All -WhatIf folds into -DryRun (orchestrator sees DryRun)' {
+        Mock -ModuleName MarkMichaelis.ScoopBucket Invoke-AllEnginesUpdate -ParameterFilter { $DryRun } { }
+        Update-Package -All -WhatIf -SkipCompletion
+        Should -Invoke -ModuleName MarkMichaelis.ScoopBucket Invoke-AllEnginesUpdate -Times 1 -Exactly -ParameterFilter { $DryRun }
+    }
+}

--- a/docs/designs/2026-05-30-update-package-all-plan.md
+++ b/docs/designs/2026-05-30-update-package-all-plan.md
@@ -1,0 +1,66 @@
+# Update-Package -All — Implementation Plan
+
+Tracks #259. See the issue for design rationale.
+
+## Task 1 — Test scaffolding (RED)
+
+Append a new `Describe 'Update-Package -All (machine-wide)'` block to
+`bucket/UpdatePackage.Tests.ps1` with these `It`s, all initially RED because
+neither the private engine sweeps nor the dispatcher route exist yet:
+
+1. `-All -DryRun` invokes Invoke-AllEnginesUpdate (mocked) and skips Get-BundlePackages.
+2. `-Name foo -All` errors with parameter-set ambiguity (no execution).
+3. Each Update-All*Packages engine: prints the bulk command under -WhatIf and returns Updated/(WhatIf).
+4. Each engine: Get-Command returns null → returns Skipped, no invocation.
+5. Each engine: exit 0 → Updated; exit non-zero → Failed (engine continues; verified at orchestrator level).
+6. Orchestrator runs all five engines in scoop→winget→choco→npmGlobal→dotnetTool order.
+7. Orchestrator: one engine failing does not prevent others from running.
+8. dotnet `--all` fallback: output containing "Unrecognized option" triggers per-tool enumeration path.
+9. Hint line printed at end of -All run.
+
+## Task 2 — Engine sweeps (GREEN)
+
+Create five private files, each ~40 lines, all following the
+`Update-WingetPackage` template:
+
+- `Private/Update-AllWingetPackages.ps1`
+- `Private/Update-AllScoopPackages.ps1`
+- `Private/Update-AllChocoPackages.ps1`
+- `Private/Update-AllNpmGlobalPackages.ps1`
+- `Private/Update-AllDotnetToolPackages.ps1`
+
+Signature: `param([switch]$WhatIf)` → returns `@{ State; Reason; Engine }`.
+
+## Task 3 — Orchestrator (GREEN)
+
+`Private/Invoke-AllEnginesUpdate.ps1` — runs the five sweeps in order,
+collects results, prints glyph summary table (reuse the existing glyph
+scheme), prints the completer hint at the end.
+
+## Task 4 — Dispatcher (GREEN)
+
+Refactor `Public/Update-Package.ps1`:
+
+- Add `[CmdletBinding(DefaultParameterSetName='ByName', SupportsShouldProcess, ConfirmImpact='Medium')]`.
+- `-Name` → `ParameterSetName='ByName'`.
+- New `[Parameter(ParameterSetName='MachineWide', Mandatory)][switch]$All`.
+- Branch at top of function: if `$All` → call `Invoke-AllEnginesUpdate -DryRun:$DryRun` and return.
+
+## Task 5 — Refactor + lint pass
+
+- Function ≤ 20 lines where possible (engine sweeps will hit this naturally; orchestrator may need 30-40).
+- No duplication between the five engine sweeps that screams for extraction — they each have distinct probe and parse logic, so DRY-via-helper is YAGNI for five callsites.
+
+## Task 6 — Phase 5b evidence
+
+- `Update-Package -All -DryRun` transcript saved to `.evidence/phase-5b-<ts>/dry-run.md`.
+- One real low-blast-radius run: scoop only, by invoking `Update-AllScoopPackages` directly.
+
+## Commit map
+
+- `test(update): add failing Update-Package -All tests` (RED)
+- `feat(update): add per-engine bulk update sweeps` (GREEN engines)
+- `feat(update): add Invoke-AllEnginesUpdate orchestrator` (GREEN orchestrator)
+- `feat(update): add -All switch to Update-Package` (GREEN dispatcher)
+- `refactor(update): <if any>` (Phase 4)
+- `docs(spec): add Update-Package -All to spec` (Phase 7 step 2)

--- a/module/MarkMichaelis.ScoopBucket/Private/Invoke-AllEnginesUpdate.ps1
+++ b/module/MarkMichaelis.ScoopBucket/Private/Invoke-AllEnginesUpdate.ps1
@@ -1,0 +1,61 @@
+# Orchestrator for `Update-Package -All`: runs the five per-engine bulk
+# sweeps in a deterministic order and prints a one-row-per-engine summary
+# table using the same glyph scheme as Invoke-PackageUpdate.
+#
+# Engine order: scoop -> winget -> choco -> npmGlobal -> dotnetTool.
+# scoop first because it's this bucket's primary engine; the rest are
+# alphabetical for predictability.
+#
+# A per-engine failure does NOT short-circuit the remaining sweeps -- each
+# engine reports independently in the summary.
+
+function Invoke-AllEnginesUpdate {
+    [CmdletBinding()]
+    param([switch]$DryRun)
+
+    $engineOrder = @(
+        @{ Name = 'scoop';      Cmd = { param($w) Update-AllScoopPackages      -WhatIf:$w } },
+        @{ Name = 'winget';     Cmd = { param($w) Update-AllWingetPackages     -WhatIf:$w } },
+        @{ Name = 'choco';      Cmd = { param($w) Update-AllChocoPackages      -WhatIf:$w } },
+        @{ Name = 'npmGlobal';  Cmd = { param($w) Update-AllNpmGlobalPackages  -WhatIf:$w } },
+        @{ Name = 'dotnetTool'; Cmd = { param($w) Update-AllDotnetToolPackages -WhatIf:$w } }
+    )
+
+    Write-Host ""
+    Write-Host "=== Invoke-AllEnginesUpdate: machine-wide sweep across $($engineOrder.Count) engines ==="
+
+    $results = New-Object System.Collections.Generic.List[object]
+    foreach ($engine in $engineOrder) {
+        Write-Host ""
+        Write-Host "[update-all] [$($engine.Name)]"
+        try {
+            $r = & $engine.Cmd $DryRun
+        } catch {
+            $r = @{ State = 'Failed'; Reason = "Engine threw: $($_.Exception.Message)"; Engine = $engine.Name }
+        }
+        if (-not $r.Engine) { $r.Engine = $engine.Name }
+        $results.Add($r)
+    }
+
+    Write-Host ""
+    Write-Host "=== Machine-wide update summary ==="
+    foreach ($r in $results) {
+        $glyph = switch ($r.State) {
+            'Updated' { [char]0x2713 }   # checkmark
+            'Failed'  { [char]0x2717 }   # X
+            'Skipped' { [char]0x2192 }   # right-arrow
+            default   { ' ' }
+        }
+        $color = switch ($r.State) {
+            'Updated' { 'Green' }
+            'Failed'  { 'Red' }
+            'Skipped' { 'Yellow' }
+            default   { $Host.UI.RawUI.ForegroundColor }
+        }
+        $reason = if ($r.Reason) { " -- $($r.Reason)" } else { '' }
+        Write-Host ("  {0} {1,-14} {2}{3}" -f $glyph, $r.State, $r.Engine, $reason) -ForegroundColor $color
+    }
+
+    Write-Host ""
+    Write-Host "Note: completers were not auto-refreshed for -All. Run Update-PackageCompletion if a CLI version bumped." -ForegroundColor DarkGray
+}

--- a/module/MarkMichaelis.ScoopBucket/Private/Update-AllChocoPackages.ps1
+++ b/module/MarkMichaelis.ScoopBucket/Private/Update-AllChocoPackages.ps1
@@ -1,0 +1,31 @@
+# Chocolatey bulk sweep: `choco upgrade all -y --no-progress`. Probes for
+# `choco` first -- choco is optional on most machines and Skipped beats
+# throwing CommandNotFound from inside a -All sweep.
+
+function Update-AllChocoPackages {
+    [CmdletBinding()]
+    [OutputType([hashtable])]
+    param([switch]$WhatIf)
+
+    if (-not (Get-Command choco -ErrorAction SilentlyContinue)) {
+        return @{ State = 'Skipped'; Reason = 'choco not on PATH.'; Engine = 'choco' }
+    }
+
+    $upgradeArgs = @('upgrade', 'all', '-y', '--no-progress')
+
+    if ($WhatIf) {
+        Write-Host "  [WhatIf] choco $($upgradeArgs -join ' ')"
+        return @{ State = 'Updated'; Reason = '(WhatIf)'; Engine = 'choco' }
+    }
+
+    Write-Host "  choco $($upgradeArgs -join ' ')"
+    & choco @upgradeArgs
+    $exit = $LASTEXITCODE
+    # Treat reboot-required exits as Updated (same convention as
+    # Update-ChocoPackage); only true failures map to Failed.
+    if ($exit -eq 0 -or $exit -in @(1641, 3010)) {
+        $reason = if ($exit -ne 0) { "Reboot pending (choco exit $exit)." } else { $null }
+        return @{ State = 'Updated'; Reason = $reason; Engine = 'choco' }
+    }
+    return @{ State = 'Failed'; Reason = "choco upgrade all exited with $exit."; Engine = 'choco' }
+}

--- a/module/MarkMichaelis.ScoopBucket/Private/Update-AllDotnetToolPackages.ps1
+++ b/module/MarkMichaelis.ScoopBucket/Private/Update-AllDotnetToolPackages.ps1
@@ -31,7 +31,10 @@ function Update-AllDotnetToolPackages {
     }
 
     # Fallback: --all unsupported on this SDK. Enumerate + per-tool update.
-    if ($joined -match "Unrecognized option|Unknown option|--all") {
+    # Match only on explicit "unknown/unrecognized option" diagnostics --
+    # NOT the literal "--all" token (which would falsely trigger fallback
+    # for any unrelated error whose message happens to echo our argv).
+    if ($joined -match '(?i)unrecognized option|unknown option|unrecognized command') {
         Write-Host "  dotnet tool update --all unsupported on this SDK; falling back to per-tool enumeration."
         $listOut = & dotnet tool list -g 2>&1
         $listExit = $LASTEXITCODE

--- a/module/MarkMichaelis.ScoopBucket/Private/Update-AllDotnetToolPackages.ps1
+++ b/module/MarkMichaelis.ScoopBucket/Private/Update-AllDotnetToolPackages.ps1
@@ -1,0 +1,60 @@
+# dotnet global-tool bulk sweep.
+#
+# Preferred path: `dotnet tool update -g --all` (added in .NET SDK 9.0.200).
+# Older SDKs reject the flag with "Unrecognized option '--all'"; in that
+# case we enumerate `dotnet tool list -g`, parse package IDs, and dispatch
+# `dotnet tool update -g <id>` per row. Aggregate exit codes -- any failure
+# downgrades the whole sweep to Failed but does not abort the loop.
+
+function Update-AllDotnetToolPackages {
+    [CmdletBinding()]
+    [OutputType([hashtable])]
+    param([switch]$WhatIf)
+
+    if (-not (Get-Command dotnet -ErrorAction SilentlyContinue)) {
+        return @{ State = 'Skipped'; Reason = 'dotnet not on PATH.'; Engine = 'dotnetTool' }
+    }
+
+    if ($WhatIf) {
+        Write-Host "  [WhatIf] dotnet tool update -g --all"
+        return @{ State = 'Updated'; Reason = '(WhatIf)'; Engine = 'dotnetTool' }
+    }
+
+    # Try the modern --all flag first.
+    Write-Host "  dotnet tool update -g --all"
+    $out = & dotnet tool update -g --all 2>&1
+    $exit = $LASTEXITCODE
+    $joined = (@($out) -join "`n")
+
+    if ($exit -eq 0) {
+        return @{ State = 'Updated'; Reason = $null; Engine = 'dotnetTool' }
+    }
+
+    # Fallback: --all unsupported on this SDK. Enumerate + per-tool update.
+    if ($joined -match "Unrecognized option|Unknown option|--all") {
+        Write-Host "  dotnet tool update --all unsupported on this SDK; falling back to per-tool enumeration."
+        $listOut = & dotnet tool list -g 2>&1
+        $listExit = $LASTEXITCODE
+        if ($listExit -ne 0) {
+            return @{ State = 'Failed'; Reason = "dotnet tool list -g exited with $listExit."; Engine = 'dotnetTool' }
+        }
+        # Skip the two header lines ("Package Id  Version  Commands" + dashes).
+        $rows = @($listOut | ForEach-Object { $_.ToString() } | Where-Object { $_ -match '^\s*\S' -and $_ -notmatch '^\s*Package\s+Id' -and $_ -notmatch '^\s*---' })
+        $anyFail = $false
+        $count   = 0
+        foreach ($row in $rows) {
+            $id = ($row -split '\s+' | Where-Object { $_ })[0]
+            if (-not $id) { continue }
+            Write-Host "  dotnet tool update -g $id"
+            & dotnet tool update -g $id | Out-Null
+            if ($LASTEXITCODE -ne 0) { $anyFail = $true }
+            $count++
+        }
+        if ($anyFail) {
+            return @{ State = 'Failed'; Reason = "One or more per-tool updates failed (of $count tools)."; Engine = 'dotnetTool' }
+        }
+        return @{ State = 'Updated'; Reason = "Per-tool fallback updated $count tools."; Engine = 'dotnetTool' }
+    }
+
+    return @{ State = 'Failed'; Reason = "dotnet tool update -g --all exited with $exit. Output: $($joined.Trim())"; Engine = 'dotnetTool' }
+}

--- a/module/MarkMichaelis.ScoopBucket/Private/Update-AllNpmGlobalPackages.ps1
+++ b/module/MarkMichaelis.ScoopBucket/Private/Update-AllNpmGlobalPackages.ps1
@@ -1,0 +1,28 @@
+# npmGlobal bulk sweep: `npm update -g`. Hard-codes `npm.cmd` for the same
+# reason Update-NpmGlobalPackage does (avoids the npm.ps1 arg-mangling bug
+# fixed in #249). Probes for `npm.cmd` specifically.
+
+function Update-AllNpmGlobalPackages {
+    [CmdletBinding()]
+    [OutputType([hashtable])]
+    param([switch]$WhatIf)
+
+    if (-not (Get-Command npm.cmd -ErrorAction SilentlyContinue)) {
+        return @{ State = 'Skipped'; Reason = 'npm.cmd not on PATH.'; Engine = 'npmGlobal' }
+    }
+
+    $updateArgs = @('update', '-g')
+
+    if ($WhatIf) {
+        Write-Host "  [WhatIf] npm $($updateArgs -join ' ')"
+        return @{ State = 'Updated'; Reason = '(WhatIf)'; Engine = 'npmGlobal' }
+    }
+
+    Write-Host "  npm $($updateArgs -join ' ')"
+    & npm.cmd @updateArgs
+    $exit = $LASTEXITCODE
+    if ($exit -eq 0) {
+        return @{ State = 'Updated'; Reason = $null; Engine = 'npmGlobal' }
+    }
+    return @{ State = 'Failed'; Reason = "npm update -g exited with $exit."; Engine = 'npmGlobal' }
+}

--- a/module/MarkMichaelis.ScoopBucket/Private/Update-AllScoopPackages.ps1
+++ b/module/MarkMichaelis.ScoopBucket/Private/Update-AllScoopPackages.ps1
@@ -1,0 +1,33 @@
+# scoop bulk sweep: `scoop update *` updates every installed app. Note that
+# bare `scoop update` only refreshes scoop itself + buckets, NOT apps -- the
+# explicit `*` is required for a true "update everything" sweep.
+
+function Update-AllScoopPackages {
+    [CmdletBinding()]
+    [OutputType([hashtable])]
+    param([switch]$WhatIf)
+
+    if (-not (Get-Command scoop -ErrorAction SilentlyContinue)) {
+        return @{ State = 'Skipped'; Reason = 'scoop not on PATH.'; Engine = 'scoop' }
+    }
+
+    $updateArgs = @('update', '*')
+
+    if ($WhatIf) {
+        Write-Host "  [WhatIf] scoop $($updateArgs -join ' ')"
+        return @{ State = 'Updated'; Reason = '(WhatIf)'; Engine = 'scoop' }
+    }
+
+    Write-Host "  scoop $($updateArgs -join ' ')"
+    # Merge all streams; scoop writes its per-app status via Write-Host
+    # which lands on the Information stream in PS7 (same rationale as
+    # Update-ScoopPackage).
+    $out = & scoop @updateArgs *>&1
+    $exit = $LASTEXITCODE
+    $joined = ($out | ForEach-Object { $_.ToString() }) -join "`n"
+    if ($joined) { Write-Host $joined }
+    if ($exit -eq 0) {
+        return @{ State = 'Updated'; Reason = $null; Engine = 'scoop' }
+    }
+    return @{ State = 'Failed'; Reason = "scoop update * exited with $exit."; Engine = 'scoop' }
+}

--- a/module/MarkMichaelis.ScoopBucket/Private/Update-AllWingetPackages.ps1
+++ b/module/MarkMichaelis.ScoopBucket/Private/Update-AllWingetPackages.ps1
@@ -1,0 +1,31 @@
+# winget bulk sweep: `winget upgrade --all` with the recommended noninteractive
+# flags. Probes for `winget` first so a non-winget machine returns Skipped
+# instead of throwing CommandNotFound.
+
+function Update-AllWingetPackages {
+    [CmdletBinding()]
+    [OutputType([hashtable])]
+    param([switch]$WhatIf)
+
+    if (-not (Get-Command winget -ErrorAction SilentlyContinue)) {
+        return @{ State = 'Skipped'; Reason = 'winget not on PATH.'; Engine = 'winget' }
+    }
+
+    $upgradeArgs = @(
+        'upgrade', '--all', '--include-unknown', '--silent',
+        '--accept-package-agreements', '--accept-source-agreements'
+    )
+
+    if ($WhatIf) {
+        Write-Host "  [WhatIf] winget $($upgradeArgs -join ' ')"
+        return @{ State = 'Updated'; Reason = '(WhatIf)'; Engine = 'winget' }
+    }
+
+    Write-Host "  winget $($upgradeArgs -join ' ')"
+    & winget @upgradeArgs
+    $exit = $LASTEXITCODE
+    if ($exit -eq 0) {
+        return @{ State = 'Updated'; Reason = $null; Engine = 'winget' }
+    }
+    return @{ State = 'Failed'; Reason = "winget upgrade --all exited with $exit."; Engine = 'winget' }
+}

--- a/module/MarkMichaelis.ScoopBucket/Public/Update-Package.ps1
+++ b/module/MarkMichaelis.ScoopBucket/Public/Update-Package.ps1
@@ -89,7 +89,7 @@ function Update-Package {
     # straight to each engine's native bulk-upgrade command. The hint at
     # the end of the run reminds users to run Update-PackageCompletion
     # manually since we can't tell which CLIs (if any) version-bumped.
-    if ($PSCmdlet.ParameterSetName -eq 'MachineWide') {
+    if ($All) {
         Invoke-AllEnginesUpdate -DryRun:$DryRun
         return
     }

--- a/module/MarkMichaelis.ScoopBucket/Public/Update-Package.ps1
+++ b/module/MarkMichaelis.ScoopBucket/Public/Update-Package.ps1
@@ -15,6 +15,13 @@ function Update-Package {
               owner: no metadata to drive a typed update; surface as
               Skipped with a reason.
 
+        Use `-All` (mutually exclusive with `-Name`) to run a machine-wide
+        sweep that bypasses bundle metadata entirely and dispatches each
+        engine's native bulk-upgrade command (scoop update *, winget
+        upgrade --all, choco upgrade all, npm update -g, dotnet tool
+        update -g --all). Engines that aren't installed are skipped; a
+        per-engine failure does not abort the remaining sweeps.
+
         For each resolved package the dispatch goes through
         Invoke-PackageUpdate which:
           - Topologically sorts by DependsOn (does NOT auto-install
@@ -24,13 +31,16 @@ function Update-Package {
           - Refreshes `$env:Path` and re-registers completion when a
             CLI version actually changed.
 
-        Out of scope: machine-wide "upgrade everything on the box"
-        delegation (winget upgrade --all, scoop update *, etc.). That
-        belongs in a separate Update-Machine cmdlet — Update-Package is
-        intentionally scoped to packages this bucket declares.
-
     .PARAMETER Name
         One or more package names, bundle names, or the literal '*'.
+        Mutually exclusive with -All.
+
+    .PARAMETER All
+        Run a machine-wide update sweep across every engine this bucket
+        knows about (scoop, winget, choco, npmGlobal, dotnetTool),
+        independent of bundle metadata. Mutually exclusive with -Name.
+        Completers are NOT auto-refreshed under -All; run
+        `Update-PackageCompletion` manually if a CLI version bumped.
 
     .PARAMETER DryRun
         Plan only — engines receive -WhatIf and do not invoke the CLI.
@@ -49,11 +59,20 @@ function Update-Package {
 
     .EXAMPLE
         Update-Package -Name 'OSBasePackages'
+
+    .EXAMPLE
+        Update-Package -All -DryRun
+        # Plan a machine-wide update across every engine this bucket knows
+        # about (scoop, winget, choco, npmGlobal, dotnetTool). Mutually
+        # exclusive with -Name. Bundle metadata is bypassed entirely --
+        # each engine's native bulk-upgrade command runs against every
+        # package it knows about on the machine.
     #>
-    [CmdletBinding(SupportsShouldProcess, ConfirmImpact = 'Medium')]
+    [CmdletBinding(DefaultParameterSetName = 'ByName', SupportsShouldProcess, ConfirmImpact = 'Medium')]
     [OutputType([Package])]
     param(
-        [Parameter(Mandatory, Position = 0)][string[]]$Name,
+        [Parameter(ParameterSetName = 'ByName', Mandatory, Position = 0)][string[]]$Name,
+        [Parameter(ParameterSetName = 'MachineWide', Mandatory)][switch]$All,
         [switch]$DryRun,
         [switch]$SkipCompletion,
         [string]$BucketPath
@@ -65,6 +84,15 @@ function Update-Package {
     # not propagate to the engines (which key off $DryRun, mapped to
     # their own -WhatIf at dispatch time) and real updates would run.
     if ($WhatIfPreference -and -not $DryRun) { $DryRun = $true }
+
+    # Machine-wide sweep: bypass bundle resolution entirely and dispatch
+    # straight to each engine's native bulk-upgrade command. The hint at
+    # the end of the run reminds users to run Update-PackageCompletion
+    # manually since we can't tell which CLIs (if any) version-bumped.
+    if ($PSCmdlet.ParameterSetName -eq 'MachineWide') {
+        Invoke-AllEnginesUpdate -DryRun:$DryRun
+        return
+    }
 
     $bundleArgs = @{}
     if ($BucketPath) { $bundleArgs['BucketPath'] = $BucketPath }


### PR DESCRIPTION
Closes #259.

## Summary

Adds a `-All` switch to `Update-Package` for machine-wide updates across every engine this bucket knows about. The default bucket-scoped behavior (shipped in #258) is unchanged.

```pwsh
Update-Package -All           # sweep scoop -> winget -> choco -> npmGlobal -> dotnetTool
Update-Package -All -DryRun   # plan-only: print the exact commands per engine, run nothing
Update-Package -Name foo -All # errors: parameter sets are mutually exclusive
```

## Per-engine bulk commands

| Engine     | Command                                                                                    |
|------------|--------------------------------------------------------------------------------------------|
| scoop      | `scoop update *`                                                                           |
| winget     | `winget upgrade --all --include-unknown --silent --accept-package-agreements --accept-source-agreements` |
| choco      | `choco upgrade all -y --no-progress` (skipped if `choco` not on PATH)                      |
| npmGlobal  | `npm update -g` (via `npm.cmd`; skipped if absent)                                         |
| dotnetTool | `dotnet tool update -g --all`, with per-tool enumeration fallback for older SDKs           |

Engine ordering: **scoop -> winget -> choco -> npmGlobal -> dotnetTool**. scoop first because it is the bucket's primary engine; the rest alphabetical for predictability. A per-engine failure does NOT short-circuit the remaining sweeps -- each engine reports independently in the summary table.

## What landed

| File | Change |
|---|---|
| `module/MarkMichaelis.ScoopBucket/Private/Update-AllWingetPackages.ps1`     | NEW |
| `module/MarkMichaelis.ScoopBucket/Private/Update-AllScoopPackages.ps1`      | NEW |
| `module/MarkMichaelis.ScoopBucket/Private/Update-AllChocoPackages.ps1`      | NEW |
| `module/MarkMichaelis.ScoopBucket/Private/Update-AllNpmGlobalPackages.ps1`  | NEW |
| `module/MarkMichaelis.ScoopBucket/Private/Update-AllDotnetToolPackages.ps1` | NEW (with `--all` fallback to per-tool enumeration) |
| `module/MarkMichaelis.ScoopBucket/Private/Invoke-AllEnginesUpdate.ps1`      | NEW orchestrator + glyph summary + completer-refresh hint |
| `module/MarkMichaelis.ScoopBucket/Public/Update-Package.ps1`                | Add `[switch]$All` in new `MachineWide` parameter set; branch to `Invoke-AllEnginesUpdate` |
| `bucket/UpdatePackage.Tests.ps1`                                            | +22 Pester 5 tests (engine sweeps, orchestrator order/failure-tolerance/DryRun, dispatcher mutual-exclusion) |

## Behavior details

- `-All` skips `Get-BundlePackages` entirely (no bundle-metadata resolution overhead).
- `-WhatIf` folds into `-DryRun`; engines see `-WhatIf` and print the exact command without invoking.
- Engines absent from PATH return `Skipped` (no failure, no command invocation). On a typical full-stack Windows dev box all five run; minimal boxes will show Skipped rows for the missing ones.
- Completers are NOT auto-refreshed under `-All` -- bulk commands don't surface which CLIs (if any) version-bumped. A one-line hint at the end of every `-All` run reminds users to run `Update-PackageCompletion` if needed.
- dotnet `--all` fallback: when `dotnet tool update -g --all` returns "unrecognized option" (older SDKs), the driver enumerates `dotnet tool list -g`, parses package IDs, and dispatches `dotnet tool update -g <id>` per tool. Fallback detection is restricted to explicit unknown/unrecognized-option diagnostics so unrelated errors don't get miscategorized.

## Test evidence

```
Tests Passed: 53, Failed: 0, Skipped: 0
```

(Full Light suite: 1173 passed, 0 failed, 3 skipped.)

### Dry-run transcript (real machine, `-All -DryRun`)

```
=== Invoke-AllEnginesUpdate: machine-wide sweep across 5 engines ===

[update-all] [scoop]
  [WhatIf] scoop update *

[update-all] [winget]
  [WhatIf] winget upgrade --all --include-unknown --silent --accept-package-agreements --accept-source-agreements

[update-all] [choco]
  [WhatIf] choco upgrade all -y --no-progress

[update-all] [npmGlobal]
  [WhatIf] npm update -g

[update-all] [dotnetTool]
  [WhatIf] dotnet tool update -g --all

=== Machine-wide update summary ===
  v Updated        scoop -- (WhatIf)
  v Updated        winget -- (WhatIf)
  v Updated        choco -- (WhatIf)
  v Updated        npmGlobal -- (WhatIf)
  v Updated        dotnetTool -- (WhatIf)

Note: completers were not auto-refreshed for -All. Run Update-PackageCompletion if a CLI version bumped.
```

## Out of scope

- Per-package state reporting under `-All` (bulk commands don't yield that cleanly).
- Auto-refreshing completers under `-All` (documented one-line hint instead).
- Modifying anything PR #258 shipped except the parameter set / dispatch in `Update-Package.ps1`.
- A separate `Update-Machine` cmdlet -- user's follow-up explicitly asked for a switch on the existing cmdlet.
