### PR TITLE
feat(update): rename -All to -AllInstalled with clearer help (#261)

### DIFF
--- a/bucket/UpdatePackage.Tests.ps1
+++ b/bucket/UpdatePackage.Tests.ps1
@@ -757,3 +757,55 @@ Describe 'Update-Package -All dispatcher' -Tag 'Light','Module' {
         Should -Invoke -ModuleName MarkMichaelis.ScoopBucket Invoke-AllEnginesUpdate -Times 1 -Exactly -ParameterFilter { $DryRun }
     }
 }
+
+Describe 'Update-Package -AllInstalled rename (#261)' -Tag 'Light','Module' {
+
+    BeforeEach {
+        Mock -ModuleName MarkMichaelis.ScoopBucket Invoke-AllEnginesUpdate { }
+        Mock -ModuleName MarkMichaelis.ScoopBucket Get-BundlePackages      { throw 'should not be called under -AllInstalled' }
+    }
+
+    It '-AllInstalled is the primary parameter name and dispatches to Invoke-AllEnginesUpdate' {
+        Update-Package -AllInstalled -SkipCompletion
+        Should -Invoke -ModuleName MarkMichaelis.ScoopBucket Invoke-AllEnginesUpdate -Times 1 -Exactly
+        Should -Invoke -ModuleName MarkMichaelis.ScoopBucket Get-BundlePackages      -Times 0 -Exactly
+    }
+
+    It '-All (back-compat alias) still routes to Invoke-AllEnginesUpdate without a warning' {
+        Update-Package -All -SkipCompletion 3>&1 | Out-Null
+        Should -Invoke -ModuleName MarkMichaelis.ScoopBucket Invoke-AllEnginesUpdate -Times 1 -Exactly
+    }
+
+    It '-Name foo -AllInstalled errors (mutually exclusive parameter sets)' {
+        { Update-Package -Name 'foo' -AllInstalled -SkipCompletion } | Should -Throw
+    }
+
+    It '-AllInstalled -DryRun propagates DryRun to the orchestrator' {
+        Mock -ModuleName MarkMichaelis.ScoopBucket Invoke-AllEnginesUpdate -ParameterFilter { $DryRun } { }
+        Update-Package -AllInstalled -DryRun -SkipCompletion
+        Should -Invoke -ModuleName MarkMichaelis.ScoopBucket Invoke-AllEnginesUpdate -Times 1 -Exactly -ParameterFilter { $DryRun }
+    }
+}
+
+Describe 'Update-Package help documents -AllInstalled explicitly (#261)' -Tag 'Light','Module' {
+
+    BeforeAll {
+        $script:help = Get-Help Update-Package -Full
+    }
+
+    It 'AllInstalled parameter help enumerates all five engines verbatim' {
+        $param = $script:help.parameters.parameter | Where-Object { $_.name -eq 'AllInstalled' }
+        $param | Should -Not -BeNullOrEmpty -Because '-AllInstalled must be the documented parameter name'
+        $text = ($param.description | ForEach-Object { $_.Text }) -join "`n"
+        $text | Should -Match 'winget'
+        $text | Should -Match 'scoop'
+        $text | Should -Match 'choco'      # matches both "choco" and "chocolatey"
+        $text | Should -Match 'npm'
+        $text | Should -Match 'dotnet'
+    }
+
+    It 'DESCRIPTION explicitly warns that machine-wide sweep covers packages NOT installed by this bucket' {
+        $desc = ($script:help.description | ForEach-Object { $_.Text }) -join "`n"
+        $desc | Should -Match 'not installed by this bucket'
+    }
+}

--- a/docs/designs/2026-05-31-rename-allinstalled-plan.md
+++ b/docs/designs/2026-05-31-rename-allinstalled-plan.md
@@ -1,0 +1,35 @@
+# Plan: Rename Update-Package `-All` to `-AllInstalled` (#261)
+
+## Tasks
+
+### T1 — RED: add failing tests for new surface
+File: `bucket/UpdatePackage.Tests.ps1` — append a new `Describe` block:
+- `Update-Package -AllInstalled` invokes `Invoke-AllEnginesUpdate` once.
+- `Update-Package -All` (alias) invokes `Invoke-AllEnginesUpdate` once.
+- `Update-Package -Name foo -AllInstalled` throws (param-set conflict).
+- `Get-Help Update-Package -Parameter AllInstalled` description mentions all five engines verbatim: `winget`, `scoop`, `choco` or `chocolatey`, `npm`, `dotnet`.
+- `Get-Help Update-Package -Full` description contains `not installed by this bucket`.
+
+Watch fail (parameter `-AllInstalled` doesn't exist yet).
+
+### T2 — GREEN: rename parameter + alias + rewrite help
+File: `module/MarkMichaelis.ScoopBucket/Public/Update-Package.ps1`
+- Change `[switch]$All` → `[Alias('All')][switch]$AllInstalled` in MachineWide set.
+- Update the `if ($All)` branch to `if ($AllInstalled)`.
+- Rewrite SYNOPSIS / DESCRIPTION / PARAMETER AllInstalled / PARAMETER Name / EXAMPLEs per design (engines verbatim, "not installed by this bucket" phrase present).
+
+Watch all tests pass — new 5 + existing 22 (via alias) + the other 26.
+
+### T3 — Phase 4 Refactor
+Nothing structural expected; verify functions ≤ 20 lines unchanged.
+
+### T4 — Phase 5 Functional + Phase 5b Evidence
+- Capture `Get-Help Update-Package -Full` showing the new help.
+- Capture `Update-Package -AllInstalled -DryRun` transcript.
+- Capture `Update-Package -All -DryRun` transcript (alias still works).
+
+### T5 — PSScriptAnalyzer + commit + PR
+
+## Commits
+1. `test(update): add failing tests for -AllInstalled rename (#261)`
+2. `feat(update): rename -All to -AllInstalled with explicit-engine help (#261)`

--- a/module/MarkMichaelis.ScoopBucket/Private/Invoke-AllEnginesUpdate.ps1
+++ b/module/MarkMichaelis.ScoopBucket/Private/Invoke-AllEnginesUpdate.ps1
@@ -57,5 +57,5 @@ function Invoke-AllEnginesUpdate {
     }
 
     Write-Host ""
-    Write-Host "Note: completers were not auto-refreshed for -All. Run Update-PackageCompletion if a CLI version bumped." -ForegroundColor DarkGray
+    Write-Host "Note: completers were not auto-refreshed for -AllInstalled. Run Update-PackageCompletion if a CLI version bumped." -ForegroundColor DarkGray
 }

--- a/module/MarkMichaelis.ScoopBucket/Public/Update-Package.ps1
+++ b/module/MarkMichaelis.ScoopBucket/Public/Update-Package.ps1
@@ -1,29 +1,45 @@
 function Update-Package {
     <#
     .SYNOPSIS
-        Companion to Install-Package: update one (or more) named packages
-        from any bundle in this bucket via each package's declared engine.
+        Update packages declared by this bucket (default), or update every
+        installed package on the machine across all supported engines
+        (-AllInstalled).
 
     .DESCRIPTION
-        Mirrors Install-Package's name-resolution model with one extra
-        wildcard shorthand:
-          (*) The literal '*' expands to "every declarative package across
-              every bundle in this bucket" (the bucket-wide update sweep).
-          (a) Package.Name match within a declarative bundle.
-          (b) Bundle-name match — update every package in the bundle.
-          (c) Bare manifest fallback — `<name>.json` with no declarative
-              owner: no metadata to drive a typed update; surface as
-              Skipped with a reason.
+        Two operating modes:
 
-        Use `-All` (mutually exclusive with `-Name`) to run a machine-wide
-        sweep that bypasses bundle metadata entirely and dispatches each
-        engine's native bulk-upgrade command (scoop update *, winget
-        upgrade --all, choco upgrade all, npm update -g, dotnet tool
-        update -g --all). Engines that aren't installed are skipped; a
-        per-engine failure does not abort the remaining sweeps.
+        1) Bucket-scoped (default, -Name). Mirrors Install-Package's
+           name-resolution model with one extra wildcard shorthand:
+             (*) The literal '*' expands to "every declarative package across
+                 every bundle in this bucket" (the bucket-wide update sweep).
+             (a) Package.Name match within a declarative bundle.
+             (b) Bundle-name match — update every package in the bundle.
+             (c) Bare manifest fallback — `<name>.json` with no declarative
+                 owner: no metadata to drive a typed update; surface as
+                 Skipped with a reason.
 
-        For each resolved package the dispatch goes through
-        Invoke-PackageUpdate which:
+           This mode operates ONLY on packages declared in this bucket's
+           bundles. To update every installed package on the machine
+           regardless of source, use -AllInstalled.
+
+        2) Machine-wide (-AllInstalled, mutually exclusive with -Name).
+           Sweeps every package manager this module knows about — winget,
+           scoop, chocolatey, npm (global), and dotnet tools — and runs
+           that engine's bulk-upgrade command. This updates EVERY installed
+           package the engine knows about on the local machine, INCLUDING
+           packages that were NOT installed by this bucket. Bundle metadata
+           is bypassed entirely; DependsOn, PostInstallScript,
+           PostUpdateScript, and CISkip have no effect in this mode.
+           Tab-completers are not refreshed automatically — run
+           Update-PackageCompletion afterwards if you need the latest CLI
+           completers. Engines that aren't installed on the machine are
+           skipped silently with a Skipped row in the summary; a per-engine
+           failure does not abort the remaining sweeps.
+
+           `-All` is preserved as a back-compat alias of `-AllInstalled`.
+
+        For each resolved package in bucket-scoped mode the dispatch goes
+        through Invoke-PackageUpdate which:
           - Topologically sorts by DependsOn (does NOT auto-install
             missing prereqs — warns instead).
           - Runs the per-engine `Update-*Package` (or PostUpdateScript
@@ -33,14 +49,30 @@ function Update-Package {
 
     .PARAMETER Name
         One or more package names, bundle names, or the literal '*'.
-        Mutually exclusive with -All.
+        Operates ONLY on packages declared in this bucket's bundles.
+        Mutually exclusive with -AllInstalled. To update every installed
+        package on the machine regardless of source, use -AllInstalled.
 
-    .PARAMETER All
-        Run a machine-wide update sweep across every engine this bucket
-        knows about (scoop, winget, choco, npmGlobal, dotnetTool),
-        independent of bundle metadata. Mutually exclusive with -Name.
-        Completers are NOT auto-refreshed under -All; run
-        `Update-PackageCompletion` manually if a CLI version bumped.
+    .PARAMETER AllInstalled
+        Run a machine-wide update sweep across every engine this module
+        knows about, independent of bundle metadata. This updates EVERY
+        installed package the engine knows about on the local machine,
+        including packages that were NOT installed by this bucket.
+        Mutually exclusive with -Name. `-All` is accepted as a back-compat
+        alias.
+
+        The five engine commands invoked (in order: scoop, winget, choco,
+        npmGlobal, dotnetTool) are:
+          - winget upgrade --all --include-unknown --silent --accept-package-agreements --accept-source-agreements
+          - scoop update *
+          - choco upgrade all -y --no-progress
+          - npm update -g
+          - dotnet tool update -g --all   (with per-tool fallback on older SDKs)
+
+        An engine that is not installed on the machine is skipped silently
+        with a Skipped row in the summary. Completers are NOT auto-refreshed
+        under -AllInstalled; run `Update-PackageCompletion` manually if a
+        CLI version bumped.
 
     .PARAMETER DryRun
         Plan only — engines receive -WhatIf and do not invoke the CLI.
@@ -61,18 +93,24 @@ function Update-Package {
         Update-Package -Name 'OSBasePackages'
 
     .EXAMPLE
-        Update-Package -All -DryRun
-        # Plan a machine-wide update across every engine this bucket knows
-        # about (scoop, winget, choco, npmGlobal, dotnetTool). Mutually
-        # exclusive with -Name. Bundle metadata is bypassed entirely --
+        Update-Package -AllInstalled -DryRun
+        # Plan a machine-wide update across every engine this module knows
+        # about (winget, scoop, chocolatey, npm global, dotnet tools).
+        # Mutually exclusive with -Name. Bundle metadata is bypassed --
         # each engine's native bulk-upgrade command runs against every
-        # package it knows about on the machine.
+        # package it knows about on the machine, INCLUDING packages NOT
+        # installed by this bucket.
+
+    .EXAMPLE
+        Update-Package -All           # alias for -AllInstalled (back-compat)
     #>
     [CmdletBinding(DefaultParameterSetName = 'ByName', SupportsShouldProcess, ConfirmImpact = 'Medium')]
     [OutputType([Package])]
     param(
         [Parameter(ParameterSetName = 'ByName', Mandatory, Position = 0)][string[]]$Name,
-        [Parameter(ParameterSetName = 'MachineWide', Mandatory)][switch]$All,
+        [Parameter(ParameterSetName = 'MachineWide', Mandatory)]
+        [Alias('All')]
+        [switch]$AllInstalled,
         [switch]$DryRun,
         [switch]$SkipCompletion,
         [string]$BucketPath
@@ -89,7 +127,7 @@ function Update-Package {
     # straight to each engine's native bulk-upgrade command. The hint at
     # the end of the run reminds users to run Update-PackageCompletion
     # manually since we can't tell which CLIs (if any) version-bumped.
-    if ($All) {
+    if ($AllInstalled) {
         Invoke-AllEnginesUpdate -DryRun:$DryRun
         return
     }


### PR DESCRIPTION
## Summary

Renames `Update-Package -All` (shipped in #260) to `-AllInstalled` with substantially clearer help. Preserves `-All` as a back-compat alias.

Closes #261. Follow-up to #260 / #259.

## Why

Post-merge feedback on #260:

> 1. I don't think -all should only apply to winget. Why not scoop and chocolatey as well?
> 2. -all perhaps isn't clear enough. perhaps something related to all installed programs with help explicitly pointing out even if they are not installed by this bucket

Feedback #1 is a misread — `-All` already swept all five engines. **That a careful reader misread it is itself the bug**: the parameter name, SYNOPSIS, DESCRIPTION, and EXAMPLE didn't make the scope obvious. This PR fixes #2 (rename + much-improved help) which fixes #1 implicitly by enumerating all five engines verbatim in the parameter help.

## What changed

### Parameter rename
- `[switch]$All` → `[Alias('All')][switch]$AllInstalled` in the `MachineWide` parameter set on `Update-Package`.
- `Update-Package -All` continues to work byte-for-byte via the alias (no deprecation warning — too soon).

### Help block rewrite (`Update-Package.ps1`)
- **SYNOPSIS** now contrasts both modes in one line.
- **DESCRIPTION** has a dedicated `-AllInstalled` paragraph that says, verbatim: _"This updates EVERY installed package the engine knows about on the local machine, INCLUDING packages that were NOT installed by this bucket."_ — directly addressing Mark's feedback #2.
- **PARAMETER AllInstalled** enumerates all five engine commands verbatim:
  - `winget upgrade --all --include-unknown --silent --accept-package-agreements --accept-source-agreements`
  - `scoop update *`
  - `choco upgrade all -y --no-progress`
  - `npm update -g`
  - `dotnet tool update -g --all` (with per-tool fallback)
- **PARAMETER Name** contrasts bucket-scoped vs machine-wide.
- New **EXAMPLEs** for `-AllInstalled -DryRun` and the `-All` alias.

### Minor consistency tweak
- `Invoke-AllEnginesUpdate` post-sweep "Note: completers were not auto-refreshed for ..." line updated from `-All` to `-AllInstalled` to match the new canonical name.

### Tests
- 5 new Pester tests added (`bucket/UpdatePackage.Tests.ps1`):
  1. `-AllInstalled` dispatches to `Invoke-AllEnginesUpdate`.
  2. `-All` alias still routes to the same code path without a warning.
  3. `-Name foo -AllInstalled` throws (param-set conflict).
  4. `Get-Help ... -Parameter AllInstalled` enumerates all 5 engine names — guards against regressing the explicit-engine documentation.
  5. `Get-Help ... -Full` description contains _"not installed by this bucket"_ — guards the disclaimer.
- All 22 existing `-All` tests pass unchanged via the alias.
- **Total: 59 tests, 0 failures.**

## Evidence

`Get-Help Update-Package -Full` now shows the canonical form in SYNTAX:

```
Update-Package [-Name] <String[]> [-DryRun] ...
Update-Package -AllInstalled    [-DryRun] ...
```

Captured `Update-Package -AllInstalled -DryRun` and `Update-Package -All -DryRun` produce identical 5-engine sweep transcripts:

```
=== Invoke-AllEnginesUpdate: machine-wide sweep across 5 engines ===
[update-all] [scoop]      [WhatIf] scoop update *
[update-all] [winget]     [WhatIf] winget upgrade --all --include-unknown --silent ...
[update-all] [choco]      [WhatIf] choco upgrade all -y --no-progress
[update-all] [npmGlobal]  [WhatIf] npm update -g
[update-all] [dotnetTool] [WhatIf] dotnet tool update -g --all

=== Machine-wide update summary ===
  ✓ Updated  scoop      -- (WhatIf)
  ✓ Updated  winget     -- (WhatIf)
  ✓ Updated  choco      -- (WhatIf)
  ✓ Updated  npmGlobal  -- (WhatIf)
  ✓ Updated  dotnetTool -- (WhatIf)
```

## Back-Compat

`-All` is preserved indefinitely as an alias of `-AllInstalled`. No deprecation in this PR (PR #260 just shipped). Any script using `-All` continues to work without warning.

## Out of scope

- Removing the `-All` alias.
- Renaming the private `Update-All*Packages` functions.
- Renaming the `MachineWide` parameter set.
