### PR TITLE
feat(update)!: rename -AllInstalled to -MachineWide, remove -All alias (#263)

### DIFF
--- a/bucket/UpdatePackage.Tests.ps1
+++ b/bucket/UpdatePackage.Tests.ps1
@@ -728,74 +728,65 @@ Describe 'Invoke-AllEnginesUpdate orchestrator' -Tag 'Light','Module' {
     }
 }
 
-Describe 'Update-Package -All dispatcher' -Tag 'Light','Module' {
+Describe 'Update-Package -MachineWide dispatcher (#263)' -Tag 'Light','Module' {
 
     BeforeEach {
         Mock -ModuleName MarkMichaelis.ScoopBucket Invoke-AllEnginesUpdate { }
-        Mock -ModuleName MarkMichaelis.ScoopBucket Get-BundlePackages      { throw 'should not be called under -All' }
+        Mock -ModuleName MarkMichaelis.ScoopBucket Get-BundlePackages      { throw 'should not be called under -MachineWide' }
     }
 
-    It '-All skips bundle resolution entirely (Get-BundlePackages NOT called)' {
-        Update-Package -All -SkipCompletion
+    It '-MachineWide skips bundle resolution entirely (Get-BundlePackages NOT called)' {
+        Update-Package -MachineWide -SkipCompletion
         Should -Invoke -ModuleName MarkMichaelis.ScoopBucket Get-BundlePackages -Times 0 -Exactly
         Should -Invoke -ModuleName MarkMichaelis.ScoopBucket Invoke-AllEnginesUpdate -Times 1 -Exactly
     }
 
-    It '-All -DryRun propagates DryRun to Invoke-AllEnginesUpdate' {
+    It '-MachineWide -DryRun propagates DryRun to Invoke-AllEnginesUpdate' {
         Mock -ModuleName MarkMichaelis.ScoopBucket Invoke-AllEnginesUpdate -ParameterFilter { $DryRun } { }
-        Update-Package -All -DryRun -SkipCompletion
+        Update-Package -MachineWide -DryRun -SkipCompletion
         Should -Invoke -ModuleName MarkMichaelis.ScoopBucket Invoke-AllEnginesUpdate -Times 1 -Exactly -ParameterFilter { $DryRun }
     }
 
-    It '-Name foo -All errors with parameter-set ambiguity (mutually exclusive)' {
-        { Update-Package -Name 'foo' -All -SkipCompletion } | Should -Throw
+    It '-Name foo -MachineWide errors (mutually exclusive parameter sets)' {
+        { Update-Package -Name 'foo' -MachineWide -SkipCompletion } | Should -Throw
     }
 
-    It '-All -WhatIf folds into -DryRun (orchestrator sees DryRun)' {
+    It '-MachineWide -WhatIf folds into -DryRun (orchestrator sees DryRun)' {
         Mock -ModuleName MarkMichaelis.ScoopBucket Invoke-AllEnginesUpdate -ParameterFilter { $DryRun } { }
-        Update-Package -All -WhatIf -SkipCompletion
+        Update-Package -MachineWide -WhatIf -SkipCompletion
         Should -Invoke -ModuleName MarkMichaelis.ScoopBucket Invoke-AllEnginesUpdate -Times 1 -Exactly -ParameterFilter { $DryRun }
     }
 }
 
-Describe 'Update-Package -AllInstalled rename (#261)' -Tag 'Light','Module' {
+Describe 'Update-Package legacy names are removed (#263)' -Tag 'Light','Module' {
 
+    # Safety net: if production still has the old parameters (e.g. mid-rename),
+    # mock the orchestrator so an accidental successful bind cannot trigger a
+    # real machine-wide sweep on the developer's box.
     BeforeEach {
         Mock -ModuleName MarkMichaelis.ScoopBucket Invoke-AllEnginesUpdate { }
-        Mock -ModuleName MarkMichaelis.ScoopBucket Get-BundlePackages      { throw 'should not be called under -AllInstalled' }
     }
 
-    It '-AllInstalled is the primary parameter name and dispatches to Invoke-AllEnginesUpdate' {
-        Update-Package -AllInstalled -SkipCompletion
-        Should -Invoke -ModuleName MarkMichaelis.ScoopBucket Invoke-AllEnginesUpdate -Times 1 -Exactly
-        Should -Invoke -ModuleName MarkMichaelis.ScoopBucket Get-BundlePackages      -Times 0 -Exactly
+    It '-All throws ParameterBindingException (alias removed)' {
+        { Update-Package -All -SkipCompletion -ErrorAction Stop } |
+            Should -Throw -ErrorId 'NamedParameterNotFound,Update-Package'
     }
 
-    It '-All (back-compat alias) still routes to Invoke-AllEnginesUpdate without a warning' {
-        Update-Package -All -SkipCompletion 3>&1 | Out-Null
-        Should -Invoke -ModuleName MarkMichaelis.ScoopBucket Invoke-AllEnginesUpdate -Times 1 -Exactly
-    }
-
-    It '-Name foo -AllInstalled errors (mutually exclusive parameter sets)' {
-        { Update-Package -Name 'foo' -AllInstalled -SkipCompletion } | Should -Throw
-    }
-
-    It '-AllInstalled -DryRun propagates DryRun to the orchestrator' {
-        Mock -ModuleName MarkMichaelis.ScoopBucket Invoke-AllEnginesUpdate -ParameterFilter { $DryRun } { }
-        Update-Package -AllInstalled -DryRun -SkipCompletion
-        Should -Invoke -ModuleName MarkMichaelis.ScoopBucket Invoke-AllEnginesUpdate -Times 1 -Exactly -ParameterFilter { $DryRun }
+    It '-AllInstalled throws ParameterBindingException (old name removed)' {
+        { Update-Package -AllInstalled -SkipCompletion -ErrorAction Stop } |
+            Should -Throw -ErrorId 'NamedParameterNotFound,Update-Package'
     }
 }
 
-Describe 'Update-Package help documents -AllInstalled explicitly (#261)' -Tag 'Light','Module' {
+Describe 'Update-Package help documents -MachineWide explicitly (#263)' -Tag 'Light','Module' {
 
     BeforeAll {
         $script:help = Get-Help Update-Package -Full
     }
 
-    It 'AllInstalled parameter help enumerates all five engines verbatim' {
-        $param = $script:help.parameters.parameter | Where-Object { $_.name -eq 'AllInstalled' }
-        $param | Should -Not -BeNullOrEmpty -Because '-AllInstalled must be the documented parameter name'
+    It 'MachineWide parameter help enumerates all five engines verbatim' {
+        $param = $script:help.parameters.parameter | Where-Object { $_.name -eq 'MachineWide' }
+        $param | Should -Not -BeNullOrEmpty -Because '-MachineWide must be the documented parameter name'
         $text = ($param.description | ForEach-Object { $_.Text }) -join "`n"
         $text | Should -Match 'winget'
         $text | Should -Match 'scoop'

--- a/docs/designs/2026-05-31-rename-machinewide-plan.md
+++ b/docs/designs/2026-05-31-rename-machinewide-plan.md
@@ -1,0 +1,56 @@
+# Rename Update-Package -AllInstalled → -MachineWide (and drop -All alias) — Plan
+
+Issue: #263. Worktree: `.worktrees/263-rename-machinewide`.
+Branch: `feat/263-rename-machinewide`.
+
+## Goal
+
+Single clear name for the machine-wide sweep switch: `-MachineWide`.
+Both prior spellings (`-AllInstalled`, `-All`) removed outright — no alias,
+no deprecation.
+
+## TDD task list
+
+1. **RED — rewrite the existing test suites in-place.**
+   - In `bucket/UpdatePackage.Tests.ps1`:
+     - Delete the entire `Describe 'Update-Package -All dispatcher'` block (lines ~731-759).
+     - In the `Describe 'Update-Package -AllInstalled rename (#261)'` block (lines ~761-788):
+       - Rename to `Describe 'Update-Package -MachineWide dispatcher (#263)'`.
+       - Replace every `-AllInstalled` token with `-MachineWide`.
+       - Update the "should not be called under" message string.
+       - Delete the `-All (back-compat alias)` It-block.
+     - In the help-doc block (lines ~790-...):
+       - Rename to `Describe 'Update-Package help documents -MachineWide explicitly (#263)'`.
+       - Replace `'AllInstalled'` with `'MachineWide'` in the parameter Where-Object.
+   - Add a new `Describe 'Update-Package legacy names are removed (#263)'` block with two `It` blocks:
+     - `-All throws ParameterBindingException`.
+     - `-AllInstalled throws ParameterBindingException`.
+   - Run Pester → confirm reds.
+
+2. **GREEN — rename in production.**
+   - `module/.../Public/Update-Package.ps1`:
+     - Param: `[Alias('All')] [switch]$AllInstalled` → `[switch]$MachineWide` (no alias).
+     - Guard: `if ($AllInstalled)` → `if ($MachineWide)`.
+     - Help SYNOPSIS / DESCRIPTION / .PARAMETER / .EXAMPLE blocks: replace every `-AllInstalled` and `-All` with `-MachineWide`. Drop the back-compat note ("`-All` is preserved as a back-compat alias of `-AllInstalled`"). Drop the `Update-Package -All` example added in #262. Keep the verbatim disclaimer "**This updates EVERY installed package the engine knows about on the local machine, INCLUDING packages that were NOT installed by this bucket.**" and the five-engine command list.
+     - On `-Name` parameter: contrast sentence reads "To update every installed package on the machine regardless of source, use **-MachineWide**."
+   - `module/.../Private/Invoke-AllEnginesUpdate.ps1`:
+     - File header comment: `Update-Package -All` → `Update-Package -MachineWide`.
+     - Completer-refresh note: `-AllInstalled` → `-MachineWide`.
+   - Run full suite → green.
+
+3. **Refactor (Phase 4).** No structural changes expected; the rename is mechanical.
+
+4. **Functional / evidence (Phase 5b).**
+   - `Get-Help Update-Package -Full` shows `-MachineWide` parameter with five-engine list.
+   - `Update-Package -MachineWide -DryRun` plans across all five engines.
+   - `Update-Package -All` errors with ParameterBindingException.
+   - `Update-Package -AllInstalled` errors with ParameterBindingException.
+
+5. **PR.** Body includes "## Breaking change" section listing removed identifiers.
+   `Closes #263`.
+
+## Out of scope
+
+- Renaming the internal `Update-All*Packages` private functions.
+- Touching the bucket-scoped `-Name` / `*` parameter set.
+- Any further naming churn.

--- a/module/MarkMichaelis.ScoopBucket/Private/Invoke-AllEnginesUpdate.ps1
+++ b/module/MarkMichaelis.ScoopBucket/Private/Invoke-AllEnginesUpdate.ps1
@@ -1,4 +1,4 @@
-# Orchestrator for `Update-Package -All`: runs the five per-engine bulk
+# Orchestrator for `Update-Package -MachineWide`: runs the five per-engine bulk
 # sweeps in a deterministic order and prints a one-row-per-engine summary
 # table using the same glyph scheme as Invoke-PackageUpdate.
 #
@@ -57,5 +57,5 @@ function Invoke-AllEnginesUpdate {
     }
 
     Write-Host ""
-    Write-Host "Note: completers were not auto-refreshed for -AllInstalled. Run Update-PackageCompletion if a CLI version bumped." -ForegroundColor DarkGray
+    Write-Host "Note: completers were not auto-refreshed for -MachineWide. Run Update-PackageCompletion if a CLI version bumped." -ForegroundColor DarkGray
 }

--- a/module/MarkMichaelis.ScoopBucket/Public/Update-Package.ps1
+++ b/module/MarkMichaelis.ScoopBucket/Public/Update-Package.ps1
@@ -3,7 +3,7 @@ function Update-Package {
     .SYNOPSIS
         Update packages declared by this bucket (default), or update every
         installed package on the machine across all supported engines
-        (-AllInstalled).
+        (-MachineWide).
 
     .DESCRIPTION
         Two operating modes:
@@ -20,14 +20,14 @@ function Update-Package {
 
            This mode operates ONLY on packages declared in this bucket's
            bundles. To update every installed package on the machine
-           regardless of source, use -AllInstalled.
+           regardless of source, use -MachineWide.
 
-        2) Machine-wide (-AllInstalled, mutually exclusive with -Name).
+        2) Machine-wide (-MachineWide, mutually exclusive with -Name).
            Sweeps every package manager this module knows about — winget,
            scoop, chocolatey, npm (global), and dotnet tools — and runs
-           that engine's bulk-upgrade command. This updates EVERY installed
+           that engine's bulk-upgrade command. **This updates EVERY installed
            package the engine knows about on the local machine, INCLUDING
-           packages that were NOT installed by this bucket. Bundle metadata
+           packages that were NOT installed by this bucket.** Bundle metadata
            is bypassed entirely; DependsOn, PostInstallScript,
            PostUpdateScript, and CISkip have no effect in this mode.
            Tab-completers are not refreshed automatically — run
@@ -35,8 +35,6 @@ function Update-Package {
            completers. Engines that aren't installed on the machine are
            skipped silently with a Skipped row in the summary; a per-engine
            failure does not abort the remaining sweeps.
-
-           `-All` is preserved as a back-compat alias of `-AllInstalled`.
 
         For each resolved package in bucket-scoped mode the dispatch goes
         through Invoke-PackageUpdate which:
@@ -50,16 +48,15 @@ function Update-Package {
     .PARAMETER Name
         One or more package names, bundle names, or the literal '*'.
         Operates ONLY on packages declared in this bucket's bundles.
-        Mutually exclusive with -AllInstalled. To update every installed
-        package on the machine regardless of source, use -AllInstalled.
+        Mutually exclusive with -MachineWide. To update every installed
+        package on the machine regardless of source, use **-MachineWide**.
 
-    .PARAMETER AllInstalled
+    .PARAMETER MachineWide
         Run a machine-wide update sweep across every engine this module
         knows about, independent of bundle metadata. This updates EVERY
         installed package the engine knows about on the local machine,
-        including packages that were NOT installed by this bucket.
-        Mutually exclusive with -Name. `-All` is accepted as a back-compat
-        alias.
+        INCLUDING packages that were NOT installed by this bucket.
+        Mutually exclusive with -Name.
 
         The five engine commands invoked (in order: scoop, winget, choco,
         npmGlobal, dotnetTool) are:
@@ -71,7 +68,7 @@ function Update-Package {
 
         An engine that is not installed on the machine is skipped silently
         with a Skipped row in the summary. Completers are NOT auto-refreshed
-        under -AllInstalled; run `Update-PackageCompletion` manually if a
+        under -MachineWide; run `Update-PackageCompletion` manually if a
         CLI version bumped.
 
     .PARAMETER DryRun
@@ -93,24 +90,20 @@ function Update-Package {
         Update-Package -Name 'OSBasePackages'
 
     .EXAMPLE
-        Update-Package -AllInstalled -DryRun
+        Update-Package -MachineWide -DryRun
         # Plan a machine-wide update across every engine this module knows
         # about (winget, scoop, chocolatey, npm global, dotnet tools).
         # Mutually exclusive with -Name. Bundle metadata is bypassed --
         # each engine's native bulk-upgrade command runs against every
         # package it knows about on the machine, INCLUDING packages NOT
         # installed by this bucket.
-
-    .EXAMPLE
-        Update-Package -All           # alias for -AllInstalled (back-compat)
     #>
     [CmdletBinding(DefaultParameterSetName = 'ByName', SupportsShouldProcess, ConfirmImpact = 'Medium')]
     [OutputType([Package])]
     param(
         [Parameter(ParameterSetName = 'ByName', Mandatory, Position = 0)][string[]]$Name,
         [Parameter(ParameterSetName = 'MachineWide', Mandatory)]
-        [Alias('All')]
-        [switch]$AllInstalled,
+        [switch]$MachineWide,
         [switch]$DryRun,
         [switch]$SkipCompletion,
         [string]$BucketPath
@@ -127,7 +120,7 @@ function Update-Package {
     # straight to each engine's native bulk-upgrade command. The hint at
     # the end of the run reminds users to run Update-PackageCompletion
     # manually since we can't tell which CLIs (if any) version-bumped.
-    if ($AllInstalled) {
+    if ($MachineWide) {
         Invoke-AllEnginesUpdate -DryRun:$DryRun
         return
     }


### PR DESCRIPTION
## Summary

Renames `Update-Package -AllInstalled` → `-MachineWide` and **removes the `-All` alias entirely**. This closes the loop on Mark''s three rounds of review feedback on #260/#262:

> [Round 1] -all perhaps isn''t clear enough. perhaps something related to all installed programs with help explicitly pointing out even if they are not installed by this bucket
>
> [Round 2] you don''t need to keep the alias -all
>
> [Round 3] allinstalled could still be all this scoop bucket installed. we need to find a clear name

`MachineWide` describes the *scope* — the whole machine — which is the actual semantic differentiator vs. the bucket-scoped (`-Name` / `*`) path. It also already matches the internal parameter-set name (`ParameterSetName = ''MachineWide''`).

## Breaking change

Both prior spellings are removed with **no deprecation period**. Both shipped within the last few hours (#260, #262) and have no external consumers; a clean break is cheaper than compounding two aliases.

Removed identifiers:
- `Update-Package -AllInstalled` (introduced #262)
- `Update-Package -All` (introduced #260, aliased in #262)

Replacement (single canonical spelling):
- `Update-Package -MachineWide`

After this PR, both removed names throw `System.Management.Automation.ParameterBindingException: A parameter cannot be found that matches parameter name ''<old-name>''.`

## Surface

```pwsh
# Before
Update-Package -AllInstalled
Update-Package -All           # alias

# After
Update-Package -MachineWide
```

The five-engine list, the ordering (scoop → winget → choco → npmGlobal → dotnetTool), the verbatim disclaimer ("**INCLUDING packages that were NOT installed by this bucket.**"), and the completer-refresh note are all preserved — only the parameter spelling changed.

## Tests

- Deleted the `-All dispatcher` Describe block and the `-All (back-compat alias)` It-block (alias is gone).
- Renamed `Describe ''Update-Package -AllInstalled rename (#261)''` → `Describe ''Update-Package -MachineWide dispatcher (#263)''`.
- Renamed `Describe ''Update-Package help documents -AllInstalled explicitly (#261)''` → `Describe ''... -MachineWide explicitly (#263)''`; help-parameter lookup changed from `''AllInstalled''` to `''MachineWide''`.
- **Added** `Describe ''Update-Package legacy names are removed (#263)''` with two `It` blocks pinning that `-All` and `-AllInstalled` both throw `ParameterBindingException` (Red → Green confirmed: tests fail with "A parameter cannot be found that matches parameter name ''MachineWide''" before the production rename, then pass after).

**57/57 tests pass** (including all 22 pre-existing machine-wide behavior tests under the new parameter name).

## Evidence (Phase 5b)

Artifacts in `.evidence/phase-5b-20260531T035233Z/` (PASSED):

1. **`help.txt`** — `Get-Help Update-Package -Full` shows `Update-Package -MachineWide [-DryRun] ...` in SYNTAX and the verbatim five-engine list under `.PARAMETER MachineWide`.
2. **`dry-run.txt`** — `Update-Package -MachineWide -DryRun` runs all five engines with `[WhatIf]` prefixes and prints "Note: completers were not auto-refreshed for **-MachineWide**."
3. **`legacy-errors.txt`** — both `Update-Package -All` and `Update-Package -AllInstalled` raise `System.Management.Automation.ParameterBindingException: A parameter cannot be found that matches parameter name ''All''` (and `''AllInstalled''` respectively) — confirming the rename is total, not aliased.

## Out of scope

- Renaming the internal `Update-All*Packages` private functions.
- Touching the bucket-scoped (`-Name` / `*` / bundle-name) parameter set.

Closes #263.
