### PR TITLE
fix(manifests): restore /blank placeholder broken by 577d2c2 (#265)

### DIFF
--- a/bucket/AddLocalRepoBucket.json
+++ b/bucket/AddLocalRepoBucket.json
@@ -2,9 +2,9 @@
   "$schema": "https://raw.githubusercontent.com/lukesampson/scoop/master/schema.json",
   "homepage": "https://github.com/MarkMichaelis/ScoopBucket",
   "description": "Setups my personal scoop bucket.",
-  "url": "https://raw.githubusercontent.com/MarkMichaelis/ScoopBucket/main/blank",
+  "url": "https://raw.githubusercontent.com/MarkMichaelis/ScoopBucket/main/bucket/_placeholder",
   "notes": "Of course, this script is placed in the MarkMichaelis bucket so you it presents a chicken and egg problem.",
-  "version": "1.01.000",
+  "version": "1.02.000",
   "installer": {
     "script": [
       "scoop bucket add LocalRepo https://github.com/MarkMichaelis/ScoopBucket.git"

--- a/bucket/AddMarkMichaelisScoopBucket.json
+++ b/bucket/AddMarkMichaelisScoopBucket.json
@@ -3,7 +3,7 @@
   "homepage": "https://github.com/MarkMichaelis/ScoopBucket",
   "description": "Setups my personal scoop bucket.",
   "notes": "Of course, this script is placed in the MarkMichaelis bucket so you it presents a chicken and egg problem.",
-  "version": "1.01.000",
+  "version": "1.02.000",
   "installer": {
     "script": [
       "scoop bucket add MarkMichaelis https://github.com/MarkMichaelis/ScoopBucket.git"
@@ -12,5 +12,5 @@
   "uninstaller": {
     "script": ["scoop bucket rm MarkMichaelis"]
   },
-  "url": "https://raw.githubusercontent.com/MarkMichaelis/ScoopBucket/main/blank"
+  "url": "https://raw.githubusercontent.com/MarkMichaelis/ScoopBucket/main/bucket/_placeholder"
 }

--- a/bucket/Claude.json
+++ b/bucket/Claude.json
@@ -1,7 +1,7 @@
 {
     "$schema": "https://raw.githubusercontent.com/lukesampson/scoop/master/schema.json",
-    "version": "1.01.000",
-    "url": ["https://raw.githubusercontent.com/MarkMichaelis/ScoopBucket/main/blank"],
+    "version": "1.02.000",
+    "url": ["https://raw.githubusercontent.com/MarkMichaelis/ScoopBucket/main/bucket/_placeholder"],
     "installer": {
         "script": [
             "winget install --id Anthropic.Claude -e --silent --accept-package-agreements --accept-source-agreements"

--- a/bucket/ClaudeCode.json
+++ b/bucket/ClaudeCode.json
@@ -1,7 +1,7 @@
 {
     "$schema": "https://raw.githubusercontent.com/lukesampson/scoop/master/schema.json",
-    "version": "1.01.000",
-    "url": ["https://raw.githubusercontent.com/MarkMichaelis/ScoopBucket/main/blank"],
+    "version": "1.02.000",
+    "url": ["https://raw.githubusercontent.com/MarkMichaelis/ScoopBucket/main/bucket/_placeholder"],
     "installer": {
         "script": [
             "winget install --id Anthropic.ClaudeCode -e --silent --accept-package-agreements --accept-source-agreements"

--- a/bucket/Codex.json
+++ b/bucket/Codex.json
@@ -1,7 +1,7 @@
 {
     "$schema": "https://raw.githubusercontent.com/lukesampson/scoop/master/schema.json",
-    "version": "1.01.000",
-    "url": ["https://raw.githubusercontent.com/MarkMichaelis/ScoopBucket/main/blank"],
+    "version": "1.02.000",
+    "url": ["https://raw.githubusercontent.com/MarkMichaelis/ScoopBucket/main/bucket/_placeholder"],
     "installer": {
         "script": [
             "winget install --id OpenAI.Codex -e --silent --accept-package-agreements --accept-source-agreements"

--- a/bucket/EnableHybernate.json
+++ b/bucket/EnableHybernate.json
@@ -1,7 +1,7 @@
 {
     "$schema": "https://raw.githubusercontent.com/lukesampson/scoop/master/schema.json",
-    "version": "1.01.000",
-    "url": ["https://raw.githubusercontent.com/MarkMichaelis/ScoopBucket/main/blank"],
+    "version": "1.02.000",
+    "url": ["https://raw.githubusercontent.com/MarkMichaelis/ScoopBucket/main/bucket/_placeholder"],
     "installer": {
         "script": [
             "powercfg /HIBERNATE ON"

--- a/bucket/GeminiCli.json
+++ b/bucket/GeminiCli.json
@@ -1,7 +1,7 @@
 {
     "$schema": "https://raw.githubusercontent.com/lukesampson/scoop/master/schema.json",
-    "version": "1.01.000",
-    "url": ["https://raw.githubusercontent.com/MarkMichaelis/ScoopBucket/main/blank"],
+    "version": "1.02.000",
+    "url": ["https://raw.githubusercontent.com/MarkMichaelis/ScoopBucket/main/bucket/_placeholder"],
     "installer": {
         "script": [
             "choco install -y gemini-cli"

--- a/bucket/GitHubCopilotCli.json
+++ b/bucket/GitHubCopilotCli.json
@@ -1,7 +1,7 @@
 {
     "$schema": "https://raw.githubusercontent.com/lukesampson/scoop/master/schema.json",
-    "version": "1.01.000",
-    "url": ["https://raw.githubusercontent.com/MarkMichaelis/ScoopBucket/main/blank"],
+    "version": "1.02.000",
+    "url": ["https://raw.githubusercontent.com/MarkMichaelis/ScoopBucket/main/bucket/_placeholder"],
     "installer": {
         "script": [
             "winget install --id GitHub.Copilot -e --silent --accept-package-agreements --accept-source-agreements"

--- a/bucket/ManifestUrlSelfReferences.Tests.ps1
+++ b/bucket/ManifestUrlSelfReferences.Tests.ps1
@@ -1,0 +1,54 @@
+#requires -Version 7.0
+#requires -Modules @{ ModuleName = 'Pester'; ModuleVersion = '5.0.0' }
+
+<#
+.SYNOPSIS
+    Verifies that every bucket/*.json `url` referring to a file in *this*
+    repository points at a path that actually exists on disk.
+
+.DESCRIPTION
+    Some no-op manifests (e.g. wrappers around installs handled by Windows
+    itself or by winget) still need a `url` field because Scoop requires
+    one. Those URLs typically point at a tiny placeholder file checked into
+    this bucket via raw.githubusercontent.com. If the placeholder is later
+    deleted as "unreferenced" (filename greps miss URL strings), the
+    manifests silently break with a 404 at `scoop update` time.
+
+    See #265.
+#>
+
+BeforeDiscovery {
+    $script:BucketRoot = $PSScriptRoot
+    $script:RepoRoot = Split-Path -Parent $PSScriptRoot
+
+    $script:SelfRefPrefix = 'https://raw.githubusercontent.com/MarkMichaelis/ScoopBucket/main/'
+
+    $script:UrlCases = @()
+    Get-ChildItem -Path $script:BucketRoot -Filter '*.json' -File | ForEach-Object {
+        $manifestPath = $_.FullName
+        $manifestName = $_.BaseName
+        try {
+            $json = Get-Content -Raw -LiteralPath $manifestPath | ConvertFrom-Json
+        }
+        catch {
+            return
+        }
+        $urls = @($json.url) | Where-Object { $_ -is [string] }
+        foreach ($u in $urls) {
+            if ($u.StartsWith($script:SelfRefPrefix, [System.StringComparison]::OrdinalIgnoreCase)) {
+                $relative = $u.Substring($script:SelfRefPrefix.Length)
+                $script:UrlCases += [pscustomobject]@{
+                    Manifest = $manifestName
+                    Url      = $u
+                    LocalPath = (Join-Path $script:RepoRoot $relative)
+                }
+            }
+        }
+    }
+}
+
+Describe 'Manifest self-referencing URLs resolve to files in the repo' -Tag 'Light' {
+    It 'manifest <_.Manifest> references existing local path <_.LocalPath>' -ForEach $script:UrlCases {
+        Test-Path -LiteralPath $_.LocalPath -PathType Leaf | Should -BeTrue -Because "URL $($_.Url) would 404 at scoop install/update time"
+    }
+}

--- a/bucket/MicrosoftCopilot.json
+++ b/bucket/MicrosoftCopilot.json
@@ -1,7 +1,7 @@
 {
     "$schema": "https://raw.githubusercontent.com/lukesampson/scoop/master/schema.json",
-    "version": "1.01.000",
-    "url": ["https://raw.githubusercontent.com/MarkMichaelis/ScoopBucket/main/blank"],
+    "version": "1.02.000",
+    "url": ["https://raw.githubusercontent.com/MarkMichaelis/ScoopBucket/main/bucket/_placeholder"],
     "installer": {
         "script": [
             "Write-Warning 'Microsoft Copilot consumer desktop app is built into Windows 11; no separate install required.'"

--- a/bucket/PowerShellCorePreview.json
+++ b/bucket/PowerShellCorePreview.json
@@ -1,7 +1,7 @@
 {
     "$schema": "https://raw.githubusercontent.com/lukesampson/scoop/master/schema.json",
-    "version": "1.02.000",
-    "url": ["https://raw.githubusercontent.com/MarkMichaelis/ScoopBucket/main/blank"],
+    "version": "1.03.000",
+    "url": ["https://raw.githubusercontent.com/MarkMichaelis/ScoopBucket/main/bucket/_placeholder"],
     "installer": {
         "script": [
             "choco install PowerShell-Preview",

--- a/bucket/RemapShiftLockToWindowsKey.json
+++ b/bucket/RemapShiftLockToWindowsKey.json
@@ -2,9 +2,9 @@
   "$schema": "https://raw.githubusercontent.com/lukesampson/scoop/master/schema.json",
   "homepage": "https://github.com/MarkMichaelis/ScoopBucket",
   "description": "Remap Shift-Lock key to Windows Key",
-  "url": "https://raw.githubusercontent.com/MarkMichaelis/ScoopBucket/main/blank",
+  "url": "https://raw.githubusercontent.com/MarkMichaelis/ScoopBucket/main/bucket/_placeholder",
   "notes": "Of course, this script is placed in the MarkMichaelis bucket so you it presents a chicken and egg problem.",
-  "version": "0.09.000",
+  "version": "0.10.000",
   "installer": {
     "script": [
       "reg add 'HKLM\\SYSTEM\\CurrentControlSet\\Control\\Keyboard Layout' /v 'Scancode Map' /t REG_BINARY /d 0000000000000000020000005BE03A0000000000 /f"

--- a/bucket/TotalCommander.json
+++ b/bucket/TotalCommander.json
@@ -1,7 +1,7 @@
 {
     "$schema": "https://raw.githubusercontent.com/lukesampson/scoop/master/schema.json",
-    "version": "1.01.000",
-    "url": ["https://raw.githubusercontent.com/MarkMichaelis/ScoopBucket/main/blank"],
+    "version": "1.02.000",
+    "url": ["https://raw.githubusercontent.com/MarkMichaelis/ScoopBucket/main/bucket/_placeholder"],
     "installer": {
         "script": [
             "choco install TotalCommander"

--- a/bucket/VisualStudio2026Enterprise.json
+++ b/bucket/VisualStudio2026Enterprise.json
@@ -1,7 +1,7 @@
 {
     "$schema": "https://raw.githubusercontent.com/lukesampson/scoop/master/schema.json",
-    "version": "1.01.000",
-    "url": ["https://raw.githubusercontent.com/MarkMichaelis/ScoopBucket/main/blank"],
+    "version": "1.02.000",
+    "url": ["https://raw.githubusercontent.com/MarkMichaelis/ScoopBucket/main/bucket/_placeholder"],
     "installer": {
         "script": [
             "choco install -y VisualStudio2026enterprise --package-parameters \"--includeRecommended --add Microsoft.VisualStudio.Workload.Azure --add Microsoft.VisualStudio.Workload.Data --add Microsoft.VisualStudio.Workload.DataScience --add Microsoft.VisualStudio.Component.CodeClone --add Microsoft.VisualStudio.Workload.ManagedDesktop --add Microsoft.VisualStudio.Workload.NativeCrossPlat --add Microsoft.VisualStudio.Workload.NativeDesktop --add Microsoft.VisualStudio.Workload.NetCrossPlat --add Microsoft.VisualStudio.Workload.NetWeb --add Microsoft.VisualStudio.Workload.Node --add Microsoft.VisualStudio.Workload.Office --add Microsoft.VisualStudio.Workload.Python --add Microsoft.VisualStudio.Workload.VisualStudioExtension --add Microsoft.VisualStudio.Workload.Universal --add Microsoft.VisualStudio.Component.VisualStudioData\"",

--- a/bucket/WSL-Ubuntu-1804.json
+++ b/bucket/WSL-Ubuntu-1804.json
@@ -1,7 +1,7 @@
 {
     "$schema": "https://raw.githubusercontent.com/lukesampson/scoop/master/schema.json",
-    "version": "1.02.000",
-    "url": ["https://raw.githubusercontent.com/MarkMichaelis/ScoopBucket/main/blank"],
+    "version": "1.03.000",
+    "url": ["https://raw.githubusercontent.com/MarkMichaelis/ScoopBucket/main/bucket/_placeholder"],
     "installer": {
         "script": [
             "choco install wsl-ubuntu-1804"

--- a/bucket/WSL-Ubuntu-2004.json
+++ b/bucket/WSL-Ubuntu-2004.json
@@ -1,7 +1,7 @@
 {
     "$schema": "https://raw.githubusercontent.com/lukesampson/scoop/master/schema.json",
-    "version": "1.01.000",
-    "url": ["https://raw.githubusercontent.com/MarkMichaelis/ScoopBucket/main/blank"],
+    "version": "1.02.000",
+    "url": ["https://raw.githubusercontent.com/MarkMichaelis/ScoopBucket/main/bucket/_placeholder"],
     "installer": {
         "script": [
             "choco install wsl-ubuntu-2004"

--- a/bucket/_placeholder
+++ b/bucket/_placeholder
@@ -1,0 +1,16 @@
+# Do not delete.
+#
+# This file is referenced by no-op scoop manifests that wrap installs handled
+# elsewhere (e.g., Microsoft Copilot, which ships with Windows 11; GitHub
+# Copilot CLI, which is wrapped to winget). Scoop manifests require a `url`
+# field even when the install is performed entirely by `installer.script`.
+#
+# Find current references with:
+#   grep -l 'bucket/_placeholder' bucket/*.json
+#
+# A previous attempt to remove the analogous root-level `blank` file (commit
+# 577d2c2) broke `scoop update` for 14 manifests with a 404. See #265.
+# The bucket/ManifestUrlSelfReferences.Tests.ps1 Pester test guards against
+# this regression by asserting every self-referencing `url` resolves to a
+# file checked into this repo.
+

--- a/bucket/dotnet.json
+++ b/bucket/dotnet.json
@@ -1,7 +1,7 @@
 {
     "$schema": "https://raw.githubusercontent.com/lukesampson/scoop/master/schema.json",
-    "version": "1.01.000",
-    "url": ["https://raw.githubusercontent.com/MarkMichaelis/ScoopBucket/main/blank"],
+    "version": "1.02.000",
+    "url": ["https://raw.githubusercontent.com/MarkMichaelis/ScoopBucket/main/bucket/_placeholder"],
     "installer": {
         "script": [
             "choco install dotnetcore-sdk -y;choco install dotnetcore-sdk -pre -y"


### PR DESCRIPTION
## Summary

Fixes the 404 the user hit while running `Update-Package`:

> Microsoft Copilot: Update threw: The remote server returned an error: (404) Not Found.

## Root cause

Commit 577d2c2 ("Remove stray empty 'blank' file from 2020") deleted the repo-root `blank` file claiming "No scripts, manifests, workflows, or tests reference it." That claim was wrong -- **14 manifests** reference it via raw GitHub URL, which a filename grep missed.

Affected manifests (all currently 404 on `scoop install`/`scoop update`):
AddLocalRepoBucket, AddMarkMichaelisScoopBucket, Claude, ClaudeCode, Codex, dotnet, EnableHybernate, GeminiCli, GitHubCopilotCli, MicrosoftCopilot, PowerShellCorePreview, RemapShiftLockToWindowsKey, TotalCommander, VisualStudio2026Enterprise, WSL-Ubuntu-1804, WSL-Ubuntu-2004.

Scoop requires a `url` even for installer-script-only manifests; these all used the same dummy URL.

## Fix

- Add `bucket/_placeholder` with a self-explaining "do not delete" comment block so a future cleanup grep won't miss it.
- Repoint all 14 manifests' `url` field to `bucket/_placeholder`.
- Bump `version` on each touched manifest per the version-bump rule.
- New Pester guard `bucket/ManifestUrlSelfReferences.Tests.ps1` (Light tag) asserts every manifest `url` that points at this repo's main branch resolves to a real file in the checkout.

## Behavior-first verification

- New test: 41 cases, all green.
- Anti-collusion: deleting `bucket/_placeholder` produces **16 behavioral assertion failures** ("Test-Path -> `\False`"), not compile errors. Restoring -> all 41 pass.
- Full `Invoke-Pester -Tag Light`: **1218 passed, 0 failed, 3 skipped** (vs. 1 pre-existing failure caused by the version-bump check before the auto-fix ran).

Closes #265