### PR TITLE
feat(update): auto-refresh scoop buckets before bucket-scoped Update-Package (#267)

### DIFF
--- a/bucket/UpdatePackage.Tests.ps1
+++ b/bucket/UpdatePackage.Tests.ps1
@@ -130,6 +130,51 @@ Describe 'Update engine dispatchers' -Tag 'Light','Module' {
         }
     }
 
+    Context 'Update-ScoopBucket' {
+        BeforeAll {
+            $script:Engine = & (Get-Module MarkMichaelis.ScoopBucket) { Get-Command Update-ScoopBucket }
+        }
+
+        It 'invokes "scoop update" with no app arguments and returns Refreshed' {
+            $script:captured = $null
+            Mock -ModuleName MarkMichaelis.ScoopBucket scoop {
+                $script:captured = $args
+                $global:LASTEXITCODE = 0
+                return 'Updating Scoop...'
+            }
+            $r = & $script:Engine
+            $r.State            | Should -Be 'Refreshed'
+            $script:captured.Count | Should -Be 1
+            $script:captured[0] | Should -Be 'update'
+        }
+
+        It 'returns Skipped when scoop CLI is not on PATH' {
+            Mock -ModuleName MarkMichaelis.ScoopBucket Get-Command { return $null } -ParameterFilter { $Name -eq 'scoop' }
+            $r = & $script:Engine
+            $r.State  | Should -Be 'Skipped'
+            $r.Reason | Should -Match 'scoop'
+        }
+
+        It 'returns Failed when scoop update exits non-zero' {
+            Mock -ModuleName MarkMichaelis.ScoopBucket scoop {
+                $global:LASTEXITCODE = 1
+                return 'oops'
+            }
+            $r = & $script:Engine
+            $r.State  | Should -Be 'Failed'
+            $r.Reason | Should -Match '1'
+        }
+
+        It 'honors -WhatIf without invoking scoop' {
+            Mock -ModuleName MarkMichaelis.ScoopBucket scoop {
+                throw 'should not be called under -WhatIf'
+            }
+            $r = & $script:Engine -WhatIf
+            $r.State | Should -Be 'Refreshed'
+            Should -Invoke -ModuleName MarkMichaelis.ScoopBucket scoop -Times 0 -Exactly
+        }
+    }
+
     Context 'Update-ChocoPackage' {
         BeforeAll {
             $script:Engine = & (Get-Module MarkMichaelis.ScoopBucket) { Get-Command Update-ChocoPackage }
@@ -464,6 +509,125 @@ Describe 'Update-Package dispatcher' -Tag 'Light','Module' {
         }
         $pkg = & $helper -Metadata $meta
         $pkg.WingetExtraArgs | Should -Be @('--skip-dependencies','--silent')
+    }
+
+    Context 'auto bucket refresh (#267)' {
+        BeforeEach {
+            Mock -ModuleName MarkMichaelis.ScoopBucket Invoke-PackageUpdate { }
+            Mock -ModuleName MarkMichaelis.ScoopBucket Update-ScoopBucket { return @{ State = 'Refreshed'; Reason = $null } }
+            Mock -ModuleName MarkMichaelis.ScoopBucket Resolve-BucketPath { return $null }
+        }
+
+        It 'refreshes scoop buckets exactly once when the dispatch plan contains a scoop package' {
+            $fakeBundles = @(
+                [pscustomobject]@{ Bundle='S';  BundlePath='C:\fake\S.ps1'; Packages=@(
+                    [pscustomobject]@{ Name='s1'; Installer='scoop'; Id='main/s1' },
+                    [pscustomobject]@{ Name='s2'; Installer='scoop'; Id='main/s2' }
+                )}
+            )
+            Mock -ModuleName MarkMichaelis.ScoopBucket Get-BundlePackages       { return $fakeBundles }
+            Mock -ModuleName MarkMichaelis.ScoopBucket Get-BundlePackageObjects {
+                return @(
+                    [Package]@{ Name='s1'; Installer='scoop'; Id='main/s1' },
+                    [Package]@{ Name='s2'; Installer='scoop'; Id='main/s2' }
+                )
+            }
+
+            Update-Package -Name 'S' -SkipCompletion
+
+            Should -Invoke -ModuleName MarkMichaelis.ScoopBucket Update-ScoopBucket -Times 1 -Exactly
+        }
+
+        It 'does NOT refresh when the dispatch plan has no scoop packages' {
+            $fakeBundles = @(
+                [pscustomobject]@{ Bundle='W'; BundlePath='C:\fake\W.ps1'; Packages=@(
+                    [pscustomobject]@{ Name='w'; Installer='winget'; Id='W.W' }
+                )}
+            )
+            Mock -ModuleName MarkMichaelis.ScoopBucket Get-BundlePackages       { return $fakeBundles }
+            Mock -ModuleName MarkMichaelis.ScoopBucket Get-BundlePackageObjects {
+                return @([Package]@{ Name='w'; Installer='winget'; Id='W.W' })
+            }
+
+            Update-Package -Name 'w' -SkipCompletion
+
+            Should -Invoke -ModuleName MarkMichaelis.ScoopBucket Update-ScoopBucket -Times 0 -Exactly
+        }
+
+        It 'does NOT refresh under -DryRun' {
+            $fakeBundles = @(
+                [pscustomobject]@{ Bundle='S'; BundlePath='C:\fake\S.ps1'; Packages=@(
+                    [pscustomobject]@{ Name='s1'; Installer='scoop'; Id='main/s1' }
+                )}
+            )
+            Mock -ModuleName MarkMichaelis.ScoopBucket Get-BundlePackages       { return $fakeBundles }
+            Mock -ModuleName MarkMichaelis.ScoopBucket Get-BundlePackageObjects {
+                return @([Package]@{ Name='s1'; Installer='scoop'; Id='main/s1' })
+            }
+
+            Update-Package -Name 's1' -SkipCompletion -DryRun
+
+            Should -Invoke -ModuleName MarkMichaelis.ScoopBucket Update-ScoopBucket -Times 0 -Exactly
+        }
+
+        It 'does NOT refresh when -SkipBucketRefresh is set' {
+            $fakeBundles = @(
+                [pscustomobject]@{ Bundle='S'; BundlePath='C:\fake\S.ps1'; Packages=@(
+                    [pscustomobject]@{ Name='s1'; Installer='scoop'; Id='main/s1' }
+                )}
+            )
+            Mock -ModuleName MarkMichaelis.ScoopBucket Get-BundlePackages       { return $fakeBundles }
+            Mock -ModuleName MarkMichaelis.ScoopBucket Get-BundlePackageObjects {
+                return @([Package]@{ Name='s1'; Installer='scoop'; Id='main/s1' })
+            }
+
+            Update-Package -Name 's1' -SkipCompletion -SkipBucketRefresh
+
+            Should -Invoke -ModuleName MarkMichaelis.ScoopBucket Update-ScoopBucket -Times 0 -Exactly
+        }
+
+        It 'continues dispatch and warns when bucket refresh fails' {
+            Mock -ModuleName MarkMichaelis.ScoopBucket Update-ScoopBucket {
+                return @{ State = 'Failed'; Reason = 'scoop update exited with 1.' }
+            }
+            $fakeBundles = @(
+                [pscustomobject]@{ Bundle='S'; BundlePath='C:\fake\S.ps1'; Packages=@(
+                    [pscustomobject]@{ Name='s1'; Installer='scoop'; Id='main/s1' }
+                )}
+            )
+            Mock -ModuleName MarkMichaelis.ScoopBucket Get-BundlePackages       { return $fakeBundles }
+            Mock -ModuleName MarkMichaelis.ScoopBucket Get-BundlePackageObjects {
+                return @([Package]@{ Name='s1'; Installer='scoop'; Id='main/s1' })
+            }
+
+            $warnings = @()
+            Update-Package -Name 's1' -SkipCompletion -WarningVariable warnings -WarningAction SilentlyContinue
+
+            ($warnings -join "`n") | Should -Match 'bucket refresh'
+            Should -Invoke -ModuleName MarkMichaelis.ScoopBucket Invoke-PackageUpdate -Times 1 -Exactly
+        }
+
+        It 'refreshes exactly once across multiple bundles with scoop packages' {
+            $fakeBundles = @(
+                [pscustomobject]@{ Bundle='A'; BundlePath='C:\fake\A.ps1'; Packages=@(
+                    [pscustomobject]@{ Name='a'; Installer='scoop'; Id='main/a' }
+                )}
+                [pscustomobject]@{ Bundle='B'; BundlePath='C:\fake\B.ps1'; Packages=@(
+                    [pscustomobject]@{ Name='b'; Installer='scoop'; Id='main/b' }
+                )}
+            )
+            Mock -ModuleName MarkMichaelis.ScoopBucket Get-BundlePackages       { return $fakeBundles }
+            Mock -ModuleName MarkMichaelis.ScoopBucket Get-BundlePackageObjects {
+                param($BundlePath)
+                if ($BundlePath -like '*A.ps1') { return @([Package]@{ Name='a'; Installer='scoop'; Id='main/a' }) }
+                else                            { return @([Package]@{ Name='b'; Installer='scoop'; Id='main/b' }) }
+            }
+
+            Update-Package -Name '*' -SkipCompletion
+
+            Should -Invoke -ModuleName MarkMichaelis.ScoopBucket Update-ScoopBucket -Times 1 -Exactly
+            Should -Invoke -ModuleName MarkMichaelis.ScoopBucket Invoke-PackageUpdate -Times 2 -Exactly
+        }
     }
 }
 

--- a/module/MarkMichaelis.ScoopBucket/Private/Update-ScoopBucket.ps1
+++ b/module/MarkMichaelis.ScoopBucket/Private/Update-ScoopBucket.ps1
@@ -1,0 +1,43 @@
+# Scoop engine: refresh bucket clones once before bucket-scoped updates.
+#
+# Scoop's per-bucket git clone (under ~/scoop/buckets/<name>) is what
+# `scoop update <app>` reads its manifest from. If the upstream bucket
+# moved (e.g. a manifest's `url` field was fixed), the user's local
+# clone still serves the old manifest and the per-app update fails --
+# in the worst case with a 404 from the old `url`. See #265 and #267.
+#
+# `scoop update` with no arguments refreshes every bucket clone (it
+# does NOT update installed apps). Update-Package calls this once per
+# invocation when the dispatch plan contains a scoop package, so the
+# subsequent per-app `scoop update <app>` calls always see the latest
+# manifests.
+
+function Update-ScoopBucket {
+    [CmdletBinding()]
+    [OutputType([hashtable])]
+    param(
+        [switch]$WhatIf
+    )
+
+    if (-not (Get-Command scoop -ErrorAction SilentlyContinue)) {
+        Write-Verbose 'Update-ScoopBucket: scoop CLI not on PATH; skipping bucket refresh.'
+        return @{ State = 'Skipped'; Reason = 'scoop CLI not on PATH.' }
+    }
+
+    if ($WhatIf) {
+        Write-Host '  [WhatIf] scoop update (refresh bucket clones)'
+        return @{ State = 'Refreshed'; Reason = '(WhatIf)' }
+    }
+
+    Write-Host '  scoop update (refresh bucket clones)'
+    # Capture all streams (scoop writes progress via Write-Host which
+    # in PS7 lands on the Information stream, not stdout).
+    $out = & scoop update *>&1
+    $exit = $LASTEXITCODE
+    $joined = ($out | ForEach-Object { $_.ToString() }) -join "`n"
+    if ($joined) { Write-Host $joined }
+    if ($exit -ne 0) {
+        return @{ State = 'Failed'; Reason = "scoop update exited with $exit." }
+    }
+    return @{ State = 'Refreshed'; Reason = $null }
+}

--- a/module/MarkMichaelis.ScoopBucket/Public/Update-Package.ps1
+++ b/module/MarkMichaelis.ScoopBucket/Public/Update-Package.ps1
@@ -45,6 +45,12 @@ function Update-Package {
           - Refreshes `$env:Path` and re-registers completion when a
             CLI version actually changed.
 
+        Before any per-app scoop update runs in bucket-scoped mode, the
+        scoop bucket clones under ~/scoop/buckets/<name> are refreshed
+        once (`scoop update` with no args) so that per-app updates see
+        the latest manifests rather than a stale local mirror. See #267.
+        Suppress with -SkipBucketRefresh.
+
     .PARAMETER Name
         One or more package names, bundle names, or the literal '*'.
         Operates ONLY on packages declared in this bucket's bundles.
@@ -77,6 +83,14 @@ function Update-Package {
     .PARAMETER SkipCompletion
         Don't re-register completion blocks after a successful update.
 
+    .PARAMETER SkipBucketRefresh
+        Suppress the automatic ``scoop update`` (bucket refresh) that
+        Update-Package runs once per invocation when the dispatch plan
+        contains a scoop-engine package. Useful when callers know the
+        local bucket clones are already current and want to shave the
+        few-seconds refresh cost, or when running offline. Has no
+        effect under -DryRun or -MachineWide (which bypass it already).
+
     .PARAMETER BucketPath
         Override the auto-detected bucket directory.
 
@@ -106,6 +120,7 @@ function Update-Package {
         [switch]$MachineWide,
         [switch]$DryRun,
         [switch]$SkipCompletion,
+        [switch]$SkipBucketRefresh,
         [string]$BucketPath
     )
 
@@ -230,6 +245,51 @@ function Update-Package {
         )
         foreach ($key in @($byBundle.Keys)) {
             if ($fullPaths.Contains($key)) { [void]$byBundle.Remove($key) }
+        }
+    }
+
+    # Auto bucket refresh (#267). When the dispatch plan contains any
+    # scoop-engine package, refresh scoop's bucket clones ONCE before the
+    # per-app updates. Without this, a stale per-bucket clone under
+    # ~/scoop/buckets/<name> serves the previous manifest version, and a
+    # per-app `scoop update <app>` can fail (e.g. the 404 in #265 that
+    # persisted across user `Update-Package` runs because the local
+    # bucket clone hadn't fast-forwarded). Gated:
+    #   * Skipped under -DryRun (refresh has no plan/apply distinction;
+    #     a dry run shouldn't have engine side effects).
+    #   * Skipped under -SkipBucketRefresh (escape hatch).
+    #   * Skipped when no scoop packages are in scope.
+    # A failed refresh does not abort dispatch -- we surface a warning
+    # and continue; per-app updates may still succeed if they happen to
+    # already have the latest manifest cached.
+    if (-not $DryRun -and -not $SkipBucketRefresh) {
+        $scoopInScope = $false
+        foreach ($entry in $byBundle.Values) {
+            $pkgObjects = @(Get-BundlePackageObjects -BundlePath $entry.BundlePath)
+            if ($pkgObjects.Count -eq 0) {
+                $b = $bundles | Where-Object BundlePath -eq $entry.BundlePath | Select-Object -First 1
+                $pkgObjects = @($b.Packages | ForEach-Object { ConvertTo-PackageFromMetadata $_ })
+            }
+            if ($pkgObjects | Where-Object { $_.Installer -eq 'scoop' -and ($entry.Names -contains $_.Name) } | Select-Object -First 1) {
+                $scoopInScope = $true; break
+            }
+        }
+        if (-not $scoopInScope) {
+            foreach ($b in $fullBundles) {
+                $pkgObjects = @(Get-BundlePackageObjects -BundlePath $b.BundlePath)
+                if ($pkgObjects.Count -eq 0) {
+                    $pkgObjects = @($b.Packages | ForEach-Object { ConvertTo-PackageFromMetadata $_ })
+                }
+                if ($pkgObjects | Where-Object Installer -eq 'scoop' | Select-Object -First 1) {
+                    $scoopInScope = $true; break
+                }
+            }
+        }
+        if ($scoopInScope) {
+            $refresh = Update-ScoopBucket
+            if ($refresh.State -eq 'Failed') {
+                Write-Warning "Update-Package: scoop bucket refresh failed ($($refresh.Reason)); per-app updates may use stale manifests."
+            }
         }
     }
 


### PR DESCRIPTION
## Summary

Follow-up to #265 / PR #266. Even after that fix landed, the user still hit the same 404 on the next `Update-Package` run because scoop reads manifests from its per-bucket local clone at `~/scoop/buckets/<name>`, and that clone hadn't fast-forwarded yet. The recovery was a manual `scoop update` first.

This PR teaches `Update-Package` to do that automatically.

## Behavior

Bucket-scoped mode (default, `-Name`):
- Before any per-app dispatch, if the resolved plan contains at least one `Installer = 'scoop'` package, run `scoop update` once (no args -- refreshes bucket clones only, does not touch installed apps).
- Skip the refresh when the plan has no scoop packages, under `-DryRun`, or under the new `-SkipBucketRefresh` switch.
- A failed refresh surfaces as a `Write-Warning` and dispatch continues -- per-app updates may still succeed if the local cache happens to be current.

`-MachineWide` is unchanged -- it already runs `scoop update *` which refreshes bucket clones implicitly.

## What changed

- New private engine `module/.../Private/Update-ScoopBucket.ps1` -- shape mirrors the other `Update-*Package` engines (Refreshed / Skipped / Failed hashtable, `-WhatIf` honored).
- New `-SkipBucketRefresh` switch on `Update-Package` plus help-doc updates explaining the new behavior.
- 10 new Pester cases in `bucket/UpdatePackage.Tests.ps1` covering:
  * Engine: `scoop update` no-args call, `Skipped` when scoop missing, `Failed` on non-zero exit, `-WhatIf` honored.
  * Dispatcher: refresh fires exactly once when scope contains scoop, never when it doesn't, never under `-DryRun`, never under `-SkipBucketRefresh`, dispatch continues + warns when refresh fails, fires only once across multiple scoop-bearing bundles.

## Verification

- Anti-collusion: reverting the `Update-Package` wiring -> **4 behavioral assertion failures** (called-count mismatch, parameter-not-found, regex-no-match -- not compile errors). Restoring -> all 67 `UpdatePackage.Tests.ps1` cases pass.
- Full `Invoke-Pester -Tag Light`: **1228 passed, 0 failed, 3 skipped** (was 1218 pre-change; +10 new tests).

Closes #267