### PR TITLE
feat(update): per-package winget timeout to recover from installer hangs (#269)

### DIFF
--- a/bucket/UpdatePackage.Tests.ps1
+++ b/bucket/UpdatePackage.Tests.ps1
@@ -35,7 +35,7 @@ Describe 'Update engine dispatchers' -Tag 'Light','Module' {
                 return ''
             }
             $pkg = [Package]@{ Name='Test'; Installer='winget'; Id='Test.Id'; Scope='global' }
-            $r = & $script:Engine -Package $pkg
+            $r = & $script:Engine -Package $pkg -TimeoutMinutes 0
             $r.State | Should -Be 'Updated'
             $script:captured[0] | Should -Be 'upgrade'
             ($script:captured -contains '--id')                          | Should -BeTrue
@@ -70,7 +70,7 @@ Describe 'Update engine dispatchers' -Tag 'Light','Module' {
                 return ''
             }
             $pkg = [Package]@{ Name='Test'; Installer='winget'; Id='Test.Id'; WingetExtraArgs=@('--skip-dependencies') }
-            $null = & $script:Engine -Package $pkg
+            $null = & $script:Engine -Package $pkg -TimeoutMinutes 0
             ($script:captured -contains '--skip-dependencies') | Should -BeTrue
         }
 
@@ -81,9 +81,63 @@ Describe 'Update engine dispatchers' -Tag 'Light','Module' {
                 return 'oops'
             }
             $pkg = [Package]@{ Name='Test'; Installer='winget'; Id='Test.Id' }
-            $r = & $script:Engine -Package $pkg
+            $r = & $script:Engine -Package $pkg -TimeoutMinutes 0
             $r.State  | Should -Be 'Failed'
             $r.Reason | Should -Match '7'
+        }
+
+        It 'returns Failed with "timed out" when Invoke-WingetWithTimeout reports timeout (#269)' {
+            # Update-WingetPackage normally calls winget directly via `&`,
+            # but with a non-zero timeout it must route through
+            # Invoke-WingetWithTimeout so a hang on one app does not block
+            # the rest of the bucket-scoped sweep.
+            Mock -ModuleName MarkMichaelis.ScoopBucket winget {
+                if ($args[0] -eq 'list') { $global:LASTEXITCODE = 0; return 'row' }
+                throw 'should not be called when timeout is in effect; route through Invoke-WingetWithTimeout'
+            }
+            Mock -ModuleName MarkMichaelis.ScoopBucket Invoke-WingetWithTimeout {
+                return @{ ExitCode = -1; TimedOut = $true; DurationSeconds = 900 }
+            }
+            $pkg = [Package]@{ Name='Warp'; Installer='winget'; Id='Warp.Warp' }
+            $r = & $script:Engine -Package $pkg -TimeoutMinutes 15
+            $r.State  | Should -Be 'Failed'
+            $r.Reason | Should -Match 'timed out'
+            $r.Reason | Should -Match '15'
+        }
+
+        It 'threads the upgrade args through Invoke-WingetWithTimeout when timeout is enabled (#269)' {
+            $script:passed = $null
+            Mock -ModuleName MarkMichaelis.ScoopBucket Invoke-WingetWithTimeout {
+                $script:passed = @{ Args = $Arguments; TimeoutSeconds = $TimeoutSeconds }
+                return @{ ExitCode = 0; TimedOut = $false }
+            }
+            Mock -ModuleName MarkMichaelis.ScoopBucket winget {
+                if ($args[0] -eq 'list') { $global:LASTEXITCODE = 0; return 'row' }
+                $global:LASTEXITCODE = 0; return ''
+            }
+            $pkg = [Package]@{ Name='Warp'; Installer='winget'; Id='Warp.Warp'; Scope='user' }
+            $r = & $script:Engine -Package $pkg -TimeoutMinutes 7
+            $r.State                       | Should -Be 'Updated'
+            $script:passed.TimeoutSeconds  | Should -Be (7 * 60)
+            $script:passed.Args[0]         | Should -Be 'upgrade'
+            ($script:passed.Args -contains 'Warp.Warp') | Should -BeTrue
+        }
+
+        It 'with -TimeoutMinutes 0 calls winget directly (timeout disabled, #269)' {
+            $script:captured = $null
+            Mock -ModuleName MarkMichaelis.ScoopBucket Invoke-WingetWithTimeout {
+                throw 'should not be called when timeout is disabled'
+            }
+            Mock -ModuleName MarkMichaelis.ScoopBucket winget {
+                if ($args[0] -eq 'list') { $global:LASTEXITCODE = 0; return 'row' }
+                $script:captured = $args
+                $global:LASTEXITCODE = 0; return ''
+            }
+            $pkg = [Package]@{ Name='Test'; Installer='winget'; Id='Test.Id' }
+            $r = & $script:Engine -Package $pkg -TimeoutMinutes 0
+            $r.State            | Should -Be 'Updated'
+            $script:captured[0] | Should -Be 'upgrade'
+            Should -Invoke -ModuleName MarkMichaelis.ScoopBucket Invoke-WingetWithTimeout -Times 0 -Exactly
         }
     }
 
@@ -259,6 +313,17 @@ Describe 'Invoke-PackageUpdate pipeline' -Tag 'Light','Module' {
         Mock -ModuleName MarkMichaelis.ScoopBucket Update-DotnetToolPackage { return @{ State='Updated'; Reason=$null } }
         Mock -ModuleName MarkMichaelis.ScoopBucket Update-PathFromRegistry  { }
         Mock -ModuleName MarkMichaelis.ScoopBucket Register-PackageCompletion { }
+    }
+
+    It 'threads -PackageTimeoutMinutes to Update-WingetPackage (#269)' {
+        $script:capturedTimeout = $null
+        Mock -ModuleName MarkMichaelis.ScoopBucket Update-WingetPackage {
+            $script:capturedTimeout = $TimeoutMinutes
+            return @{ State='Updated'; Reason=$null }
+        }
+        $pkgs = [Package[]]@([Package]@{ Name='A'; Installer='winget'; Id='Foo.A' })
+        $null = Invoke-PackageUpdate -Packages $pkgs -Bundle 'Test' -SkipCompletion -PackageTimeoutMinutes 9
+        $script:capturedTimeout | Should -Be 9
     }
 
     It 'dispatches packages to the correct per-installer update' {
@@ -627,6 +692,50 @@ Describe 'Update-Package dispatcher' -Tag 'Light','Module' {
 
             Should -Invoke -ModuleName MarkMichaelis.ScoopBucket Update-ScoopBucket -Times 1 -Exactly
             Should -Invoke -ModuleName MarkMichaelis.ScoopBucket Invoke-PackageUpdate -Times 2 -Exactly
+        }
+    }
+
+    Context 'per-package winget timeout (#269)' {
+        BeforeEach {
+            Mock -ModuleName MarkMichaelis.ScoopBucket Update-ScoopBucket { return @{ State='Skipped'; Reason='test' } }
+        }
+
+        It 'threads -PackageTimeoutMinutes through to Invoke-PackageUpdate' {
+            $fakeBundles = @(
+                [pscustomobject]@{ Bundle='Alpha'; BundlePath='C:\fake\Alpha.ps1'; Packages=@(
+                    [pscustomobject]@{ Name='a'; Installer='winget'; Id='A.A' }
+                )}
+            )
+            Mock -ModuleName MarkMichaelis.ScoopBucket Get-BundlePackages       { return $fakeBundles }
+            Mock -ModuleName MarkMichaelis.ScoopBucket Get-BundlePackageObjects { return @([Package]@{ Name='a'; Installer='winget'; Id='A.A' }) }
+            Mock -ModuleName MarkMichaelis.ScoopBucket Resolve-BucketPath       { return $null }
+            $script:capturedTimeout = $null
+            Mock -ModuleName MarkMichaelis.ScoopBucket Invoke-PackageUpdate {
+                $script:capturedTimeout = $PackageTimeoutMinutes
+            }
+
+            Update-Package -Name 'a' -SkipCompletion -PackageTimeoutMinutes 7
+
+            $script:capturedTimeout | Should -Be 7
+        }
+
+        It 'default -PackageTimeoutMinutes is 15' {
+            $fakeBundles = @(
+                [pscustomobject]@{ Bundle='Alpha'; BundlePath='C:\fake\Alpha.ps1'; Packages=@(
+                    [pscustomobject]@{ Name='a'; Installer='winget'; Id='A.A' }
+                )}
+            )
+            Mock -ModuleName MarkMichaelis.ScoopBucket Get-BundlePackages       { return $fakeBundles }
+            Mock -ModuleName MarkMichaelis.ScoopBucket Get-BundlePackageObjects { return @([Package]@{ Name='a'; Installer='winget'; Id='A.A' }) }
+            Mock -ModuleName MarkMichaelis.ScoopBucket Resolve-BucketPath       { return $null }
+            $script:capturedTimeout = $null
+            Mock -ModuleName MarkMichaelis.ScoopBucket Invoke-PackageUpdate {
+                $script:capturedTimeout = $PackageTimeoutMinutes
+            }
+
+            Update-Package -Name 'a' -SkipCompletion
+
+            $script:capturedTimeout | Should -Be 15
         }
     }
 }

--- a/module/MarkMichaelis.ScoopBucket/Private/Invoke-WingetWithTimeout.ps1
+++ b/module/MarkMichaelis.ScoopBucket/Private/Invoke-WingetWithTimeout.ps1
@@ -1,0 +1,50 @@
+# Per-call winget wrapper with a hard timeout (#269).
+#
+# Why this exists:
+#   `winget upgrade --silent --disable-interactivity` can still wedge on
+#   installers that wait for the running app to exit (Squirrel-based apps
+#   such as Warp.Warp). Without a hard timeout, a single hung package
+#   stalls an entire bucket-scoped Update-Package sweep indefinitely (the
+#   user has to Ctrl+C and lose progress on the rest of the bundle).
+#
+# Behavior:
+#   * Launches winget via Start-Process -NoNewWindow -PassThru so its
+#     stdout/stderr inherit the parent console (preserves the progress
+#     spinner and user-visible output -- we don't want to swallow it the
+#     way the install-time helper in .github/scripts does, because this
+#     runs interactively).
+#   * Waits up to $TimeoutSeconds for the process to exit. On timeout,
+#     kills the process tree and returns @{ ExitCode = -1; TimedOut = $true }.
+#   * On normal exit, returns @{ ExitCode = $proc.ExitCode; TimedOut = $false }.
+#
+# Callers should pass $TimeoutMinutes * 60 (Update-WingetPackage gates
+# the call entirely when its -TimeoutMinutes is 0, so this helper is
+# never invoked with TimeoutSeconds <= 0 in practice; the guard below
+# is purely defensive).
+
+function Invoke-WingetWithTimeout {
+    [CmdletBinding()]
+    [OutputType([hashtable])]
+    param(
+        [Parameter(Mandatory)][string[]]$Arguments,
+        [Parameter(Mandatory)][int]$TimeoutSeconds
+    )
+
+    if ($TimeoutSeconds -le 0) {
+        # Defensive: a caller passed a non-positive timeout. Run with no
+        # cap and report the real exit code; do not advertise TimedOut.
+        & winget @Arguments
+        return @{ ExitCode = $LASTEXITCODE; TimedOut = $false }
+    }
+
+    $proc = Start-Process -FilePath 'winget' -ArgumentList $Arguments `
+        -NoNewWindow -PassThru
+    $finished = $proc.WaitForExit([int]([math]::Min(2147483647L, [long]$TimeoutSeconds * 1000L)))
+
+    if (-not $finished) {
+        try { Stop-Process -Id $proc.Id -Force -ErrorAction SilentlyContinue } catch { }
+        return @{ ExitCode = -1; TimedOut = $true; DurationSeconds = $TimeoutSeconds }
+    }
+
+    return @{ ExitCode = $proc.ExitCode; TimedOut = $false }
+}

--- a/module/MarkMichaelis.ScoopBucket/Private/Update-WingetPackage.ps1
+++ b/module/MarkMichaelis.ScoopBucket/Private/Update-WingetPackage.ps1
@@ -14,7 +14,13 @@ function Update-WingetPackage {
     [OutputType([hashtable])]
     param(
         [Parameter(Mandatory)][object]$Package,
-        [switch]$WhatIf
+        [switch]$WhatIf,
+        # Per-call hard cap on winget runtime. Set to 0 to disable (the
+        # legacy behavior). Default 15 minutes matches Invoke-WithTimeout
+        # in .github/scripts/Test-Installs.ps1 and is enough headroom for
+        # large MSI installers without leaving a Squirrel-style hang
+        # blocking the rest of the sweep. See #269.
+        [int]$TimeoutMinutes = 15
     )
 
     $id = $Package.Id
@@ -52,8 +58,16 @@ function Update-WingetPackage {
     }
 
     Write-Host "  winget $($upgradeArgs -join ' ')"
-    & winget @upgradeArgs
-    $exit = $LASTEXITCODE
+    if ($TimeoutMinutes -gt 0) {
+        $r = Invoke-WingetWithTimeout -Arguments $upgradeArgs -TimeoutSeconds ($TimeoutMinutes * 60)
+        if ($r.TimedOut) {
+            return @{ State = 'Failed'; Reason = "winget upgrade --id $id timed out after $TimeoutMinutes minute(s) and was killed (see #269)." }
+        }
+        $exit = $r.ExitCode
+    } else {
+        & winget @upgradeArgs
+        $exit = $LASTEXITCODE
+    }
     if ($exit -eq 0) {
         return @{ State = 'Updated'; Reason = $null }
     }

--- a/module/MarkMichaelis.ScoopBucket/Public/Invoke-PackageUpdate.ps1
+++ b/module/MarkMichaelis.ScoopBucket/Public/Invoke-PackageUpdate.ps1
@@ -39,7 +39,12 @@ function Invoke-PackageUpdate {
         [string[]]$Name,
         [string[]]$Skip,
         [switch]$DryRun,
-        [switch]$SkipCompletion
+        [switch]$SkipCompletion,
+        # Per-package winget timeout in minutes (0 disables). Forwarded
+        # to Update-WingetPackage only; other engines are unaffected.
+        # See #269 for the Warp.Warp Squirrel-installer hang that motivates
+        # this knob.
+        [int]$PackageTimeoutMinutes = 15
     )
 
     # Fold -WhatIf into -DryRun. The driver advertises
@@ -112,7 +117,7 @@ function Invoke-PackageUpdate {
                 $result = @{ State = 'Updated'; Reason = '(PostUpdateScript-only)' }
             } else {
                 $result = switch ($pkg.Installer) {
-                    'winget'      { Update-WingetPackage     -Package $pkg -WhatIf:$DryRun }
+                    'winget'      { Update-WingetPackage     -Package $pkg -WhatIf:$DryRun -TimeoutMinutes $PackageTimeoutMinutes }
                     'scoop'       { Update-ScoopPackage      -Package $pkg -WhatIf:$DryRun }
                     'choco'       { Update-ChocoPackage      -Package $pkg -WhatIf:$DryRun }
                     'npmGlobal'   { Update-NpmGlobalPackage  -Package $pkg -WhatIf:$DryRun }

--- a/module/MarkMichaelis.ScoopBucket/Public/Update-Package.ps1
+++ b/module/MarkMichaelis.ScoopBucket/Public/Update-Package.ps1
@@ -121,7 +121,11 @@ function Update-Package {
         [switch]$DryRun,
         [switch]$SkipCompletion,
         [switch]$SkipBucketRefresh,
-        [string]$BucketPath
+        [string]$BucketPath,
+        # Hard cap on per-package winget upgrade time (minutes). Default
+        # 15 minutes; pass 0 to disable. Forwarded to Invoke-PackageUpdate
+        # and only affects the winget engine. See #269.
+        [int]$PackageTimeoutMinutes = 15
     )
 
     # Fold -WhatIf into -DryRun. Update-Package advertises
@@ -303,7 +307,8 @@ function Update-Package {
         Write-Host ""
         Write-Host "Update-Package: dispatching $($entry.Names -join ', ') via $($entry.Bundle)..."
         Invoke-PackageUpdate -Packages $pkgObjects -Bundle $entry.Bundle `
-            -Name @($entry.Names) -DryRun:$DryRun -SkipCompletion:$SkipCompletion
+            -Name @($entry.Names) -DryRun:$DryRun -SkipCompletion:$SkipCompletion `
+            -PackageTimeoutMinutes $PackageTimeoutMinutes
     }
 
     # Dispatch (b): full-bundle update.
@@ -315,7 +320,8 @@ function Update-Package {
         Write-Host ""
         Write-Host "Update-Package: dispatching bundle '$($b.Bundle)' (all packages)..."
         Invoke-PackageUpdate -Packages $pkgObjects -Bundle $b.Bundle `
-            -DryRun:$DryRun -SkipCompletion:$SkipCompletion
+            -DryRun:$DryRun -SkipCompletion:$SkipCompletion `
+            -PackageTimeoutMinutes $PackageTimeoutMinutes
     }
 
     # Dispatch (c): bare manifests — no declarative [Package] metadata,


### PR DESCRIPTION
## Summary

Adds a hard per-package timeout to `Update-WingetPackage` so one hung winget installer can no longer stall an entire `Update-Package` bucket sweep. The motivating reproduction is `Warp.Warp`'s Squirrel installer hanging on the running Warp app even with `--silent --disable-interactivity`.

## Changes

- **New** `module/.../Private/Invoke-WingetWithTimeout.ps1`: runs winget via `Start-Process -NoNewWindow -PassThru` (stdout/stderr inherit the console), waits up to N seconds, kills on timeout, returns `@{ExitCode; TimedOut; DurationSeconds}`.
- **Update-WingetPackage**: new `[int]$TimeoutMinutes = 15` parameter. On timeout returns `State='Failed'` with a clear `Reason` mentioning #269. `0` disables (legacy direct-call path, still mockable in Pester).
- **Invoke-PackageUpdate**: new `[int]$PackageTimeoutMinutes = 15`, threaded to the winget engine only.
- **Update-Package**: new `[int]$PackageTimeoutMinutes = 15`, forwarded to both dispatch branches.

## Behavior

- Default sweep now self-recovers from hangs in 15 minutes per package, continuing the bundle.
- `Update-Package -PackageTimeoutMinutes 0` restores the pre-#269 unbounded behavior for one-off interactive use.

## Tests

`bucket/UpdatePackage.Tests.ps1` (+6 new cases, 3 legacy cases gain explicit `-TimeoutMinutes 0` to keep exercising the mockable path):

- Timeout reported by helper -> `Failed` with `'timed out'` and the minutes in the reason.
- `-TimeoutSeconds` and `-Arguments` correctly threaded to `Invoke-WingetWithTimeout`.
- `-TimeoutMinutes 0` bypasses the helper entirely.
- `Invoke-PackageUpdate -PackageTimeoutMinutes` threaded to `Update-WingetPackage`.
- `Update-Package -PackageTimeoutMinutes` threaded to `Invoke-PackageUpdate`.
- Default `-PackageTimeoutMinutes` is `15`.

Light suite: **1234 passed, 0 failed** (was 1228 before this PR).

Anti-collusion verified: with the implementation reverted but the tests intact, all 6 new tests fail behaviorally (CommandNotFound / ParameterBinding / wrong default).

## Test command

```powershell
Invoke-Pester -Path .\bucket\UpdatePackage.Tests.ps1 -Output Minimal
```

Closes #269