### PR TITLE
fix(update-package): continue sweep past failed packages with EAP=Stop (#272)

### DIFF
--- a/bucket/AIAgents.ps1
+++ b/bucket/AIAgents.ps1
@@ -129,6 +129,16 @@ Register-ArgumentCompleter -Native -CommandName npx -ScriptBlock {
         # and --disable-interactivity keeps winget itself non-interactive
         # so headless / CI runs do not stall on prompts.
         WingetExtraArgs = @('--silent', '--disable-interactivity')
+        # Warp's Squirrel installer has been observed to stall after the
+        # download phase on real-world updates (issues #269, #272). The
+        # 5-minute default sweep timeout (from Update-Package's
+        # -PackageTimeoutMinutes) was killing the install before it could
+        # finish on slower links / large deltas. Bump *this* package's
+        # ceiling to 20 minutes -- still bounded, but generous enough that
+        # a healthy download + Squirrel apply completes without being
+        # killed. Other packages are unaffected; the global default stays
+        # at 5 minutes.
+        UpdateTimeoutMinutes = 20
         # Two surfaces from a single binary:
         #   * `warp` — launches the Warp terminal UI (GUI) when run bare,
         #              or the embedded Oz CLI when run with subcommands.

--- a/bucket/UpdatePackage.Tests.ps1
+++ b/bucket/UpdatePackage.Tests.ps1
@@ -1092,3 +1092,48 @@ Describe 'Update-Package help documents -MachineWide explicitly (#263)' -Tag 'Li
         $desc | Should -Match 'not installed by this bucket'
     }
 }
+
+
+Describe 'Update-Package sweep continues past failed packages (#272)' -Tag 'Light','Module' {
+
+    It 'continues dispatching remaining bundles when an earlier package fails, even with $ErrorActionPreference=Stop' {
+        # Use REAL Invoke-PackageUpdate so that -ErrorAction Continue bound by
+        # the dispatch call is honored exactly as it is in production. Mocking
+        # Invoke-PackageUpdate directly does not faithfully reproduce
+        # common-parameter binding through Pester's mock wrapper.
+        $fakeBundles = @(
+            [pscustomobject]@{ Bundle='Alpha'; BundlePath='C:\fake\Alpha.ps1'; Packages=@([pscustomobject]@{ Name='a'; Installer='winget'; Id='A.A' }) }
+            [pscustomobject]@{ Bundle='Beta';  BundlePath='C:\fake\Beta.ps1';  Packages=@([pscustomobject]@{ Name='b'; Installer='winget'; Id='B.B' }) }
+            [pscustomobject]@{ Bundle='Gamma'; BundlePath='C:\fake\Gamma.ps1'; Packages=@([pscustomobject]@{ Name='c'; Installer='winget'; Id='C.C' }) }
+        )
+        Mock -ModuleName MarkMichaelis.ScoopBucket Get-BundlePackages { return $fakeBundles }
+        Mock -ModuleName MarkMichaelis.ScoopBucket Get-BundlePackageObjects -ParameterFilter { $BundlePath -eq 'C:\fake\Alpha.ps1' } { return @([Package]@{ Name='a'; Installer='winget'; Id='A.A' }) }
+        Mock -ModuleName MarkMichaelis.ScoopBucket Get-BundlePackageObjects -ParameterFilter { $BundlePath -eq 'C:\fake\Beta.ps1'  } { return @([Package]@{ Name='b'; Installer='winget'; Id='B.B' }) }
+        Mock -ModuleName MarkMichaelis.ScoopBucket Get-BundlePackageObjects -ParameterFilter { $BundlePath -eq 'C:\fake\Gamma.ps1' } { return @([Package]@{ Name='c'; Installer='winget'; Id='C.C' }) }
+        Mock -ModuleName MarkMichaelis.ScoopBucket Resolve-BucketPath { return $null }
+        # Simulate the Warp-style failure: first bundle's package fails (e.g., timeout).
+        # The other two should still execute despite caller's ErrorActionPreference=Stop.
+        Mock -ModuleName MarkMichaelis.ScoopBucket Update-WingetPackage -ParameterFilter { $Package.Id -eq 'A.A' } {
+            return @{ State='Failed'; Reason='winget upgrade --id A.A timed out (simulated for #272)' }
+        }
+        Mock -ModuleName MarkMichaelis.ScoopBucket Update-WingetPackage -ParameterFilter { $Package.Id -ne 'A.A' } {
+            return @{ State='Updated'; Reason='ok' }
+        }
+
+        $prior = $ErrorActionPreference
+        try {
+            # Reproduce user's setup: ErrorActionPreference=Stop in the session
+            # (common in modern PowerShell profiles). The dispatcher must still
+            # complete its sweep even though Invoke-PackageUpdate would emit
+            # a non-terminating error for the failed package.
+            $ErrorActionPreference = 'Stop'
+            Update-Package -Name '*' -SkipCompletion 2>$null
+        } finally {
+            $ErrorActionPreference = $prior
+        }
+
+        Should -Invoke -ModuleName MarkMichaelis.ScoopBucket Update-WingetPackage -Times 1 -Exactly -ParameterFilter { $Package.Id -eq 'A.A' }
+        Should -Invoke -ModuleName MarkMichaelis.ScoopBucket Update-WingetPackage -Times 1 -Exactly -ParameterFilter { $Package.Id -eq 'B.B' }
+        Should -Invoke -ModuleName MarkMichaelis.ScoopBucket Update-WingetPackage -Times 1 -Exactly -ParameterFilter { $Package.Id -eq 'C.C' }
+    }
+}

--- a/module/MarkMichaelis.ScoopBucket/Public/Update-Package.ps1
+++ b/module/MarkMichaelis.ScoopBucket/Public/Update-Package.ps1
@@ -300,6 +300,12 @@ function Update-Package {
         }
     }
 
+    # Track per-bundle errors across both dispatch loops so the sweep
+    # cannot be aborted by a caller that runs with $ErrorActionPreference='Stop'
+    # (which would otherwise upgrade Invoke-PackageUpdate's non-terminating
+    # WriteError into a terminating error at the call site). See issue #272.
+    $pkgErrors = [System.Collections.Generic.List[object]]::new()
+
     # Dispatch (a): selective per-bundle Name filter.
     foreach ($entry in $byBundle.Values) {
         $pkgObjects = @(Get-BundlePackageObjects -BundlePath $entry.BundlePath)
@@ -311,7 +317,8 @@ function Update-Package {
         Write-Host "Update-Package: dispatching $($entry.Names -join ', ') via $($entry.Bundle)..."
         Invoke-PackageUpdate -Packages $pkgObjects -Bundle $entry.Bundle `
             -Name @($entry.Names) -DryRun:$DryRun -SkipCompletion:$SkipCompletion `
-            -PackageTimeoutMinutes $PackageTimeoutMinutes
+            -PackageTimeoutMinutes $PackageTimeoutMinutes `
+            -ErrorAction Continue -ErrorVariable +pkgErrors
     }
 
     # Dispatch (b): full-bundle update.
@@ -324,7 +331,8 @@ function Update-Package {
         Write-Host "Update-Package: dispatching bundle '$($b.Bundle)' (all packages)..."
         Invoke-PackageUpdate -Packages $pkgObjects -Bundle $b.Bundle `
             -DryRun:$DryRun -SkipCompletion:$SkipCompletion `
-            -PackageTimeoutMinutes $PackageTimeoutMinutes
+            -PackageTimeoutMinutes $PackageTimeoutMinutes `
+            -ErrorAction Continue -ErrorVariable +pkgErrors
     }
 
     # Dispatch (c): bare manifests — no declarative [Package] metadata,
@@ -334,5 +342,9 @@ function Update-Package {
     # and shows up in CI logs.
     foreach ($n in $manifestNames) {
         Write-Warning "Update-Package: '$n' is a bare manifest with no declarative [Package] match; skipped because Update-Package requires declarative metadata to drive an engine update. Use 'scoop update $n' directly if needed."
+    }
+
+    if ($pkgErrors.Count -gt 0) {
+        Write-Warning "Update-Package: $($pkgErrors.Count) package update(s) failed; the sweep continued past each failure. See errors above for details."
     }
 }


### PR DESCRIPTION
## Summary

When the user's session has `$ErrorActionPreference='Stop'` (common in modern PowerShell profiles), `Invoke-PackageUpdate`'s non-terminating `WriteError` gets upgraded to a terminating error at the dispatch call site in `Update-Package`, aborting the bundle sweep after the first failure. The user reported this with Warp: when winget hung and was killed by the per-package timeout, no further bundles were attempted.

### Fix

- `module/MarkMichaelis.ScoopBucket/Public/Update-Package.ps1`: pass `-ErrorAction Continue -ErrorVariable +pkgErrors` on both `Invoke-PackageUpdate` dispatch calls so the sweep proceeds regardless of caller preference; emit a summary `Write-Warning` with the failure count so failures still get noticed.
- `bucket/AIAgents.ps1`: bump Warp's `UpdateTimeoutMinutes` to 20 (from the 5-minute global default). Warp's Squirrel installer stalls on slower links / large deltas after the download phase, so it needs a more generous per-package ceiling without raising the global default.

### Test

`bucket/UpdatePackage.Tests.ps1` adds a regression test in a dedicated `Describe` (so the parent `BeforeEach` mock of `Invoke-PackageUpdate` does not intercept the real call). With `$ErrorActionPreference='Stop'` and a failing first bundle, the test asserts that all three bundles are still dispatched. Verified RED on main, GREEN with fix.

Light suite: **1236 passed / 0 failed** (was 1235; +1 regression test).

Closes #272