### PR TITLE
feat(update): standardize Update-Package summary table (Status/Installer/Scope/Id/Name)

### DIFF
--- a/bucket/UpdatePackage.Tests.ps1
+++ b/bucket/UpdatePackage.Tests.ps1
@@ -484,6 +484,65 @@ Describe 'Invoke-PackageUpdate pipeline' -Tag 'Light','Module' {
     }
 }
 
+Describe 'Invoke-PackageUpdate standardized summary table (#274)' -Tag 'Light','Module' {
+
+    It 'renders a header row and per-package Status/Installer/Scope/Id/Name' {
+        InModuleScope MarkMichaelis.ScoopBucket {
+            Mock Update-WingetPackage    { return @{ State='Updated'; Reason=$null } }
+            Mock Update-PathFromRegistry { }
+            Mock Register-PackageCompletion { }
+            $captured = New-Object System.Collections.Generic.List[object]
+            Mock Write-Host -MockWith {
+                $captured.Add([pscustomobject]@{ Message = $Object; Color = $ForegroundColor })
+            }
+
+            $pkgs = [Package[]]@(
+                [Package]@{ Name='Claude Desktop'; Installer='winget'; Id='Anthropic.Claude'; Scope='user' }
+            )
+            $null = Invoke-PackageUpdate -Packages $pkgs -Bundle 'Test' -SkipCompletion
+
+            $lines = @($captured | ForEach-Object { [string]$_.Message })
+
+            # A header row naming every standardized column must appear.
+            $header = $lines | Where-Object {
+                $_ -match 'Status' -and $_ -match 'Installer' -and
+                $_ -match 'Scope'  -and $_ -match 'Id'        -and $_ -match 'Name'
+            }
+            $header | Should -Not -BeNullOrEmpty
+
+            # The data row must carry Scope and Id (the chocolatey-style
+            # fields) alongside the Name on a single line.
+            $row = $lines | Where-Object {
+                $_ -match 'Anthropic\.Claude' -and $_ -match 'user' -and $_ -match 'Claude Desktop'
+            }
+            $row | Should -Not -BeNullOrEmpty
+        }
+    }
+
+    It 'renders Failed packages as a red, glyph-marked row carrying their reason in the same table' {
+        InModuleScope MarkMichaelis.ScoopBucket {
+            Mock Update-WingetPackage    { return @{ State='Failed'; Reason='winget upgrade timed out' } }
+            Mock Update-PathFromRegistry { }
+            $captured = New-Object System.Collections.Generic.List[object]
+            Mock Write-Host -MockWith {
+                $captured.Add([pscustomobject]@{ Message = $Object; Color = $ForegroundColor })
+            }
+
+            $pkgs = [Package[]]@(
+                [Package]@{ Name='Warp'; Installer='winget'; Id='Warp.Warp'; Scope='user' }
+            )
+            $null = Invoke-PackageUpdate -Packages $pkgs -Bundle 'Test' -SkipCompletion -ErrorAction SilentlyContinue
+
+            $failRow = $captured |
+                Where-Object { $_.Message -match 'Warp\.Warp' -and $_.Message -match 'winget upgrade timed out' } |
+                Select-Object -Last 1
+            $failRow         | Should -Not -BeNullOrEmpty
+            $failRow.Color   | Should -Be 'Red'
+            $failRow.Message | Should -Match ([char]0x2717)   # ✗ glyph carries the signal when color is stripped
+        }
+    }
+}
+
 Describe 'Update-Package dispatcher' -Tag 'Light','Module' {
 
     BeforeEach {

--- a/module/MarkMichaelis.ScoopBucket/Public/Invoke-PackageUpdate.ps1
+++ b/module/MarkMichaelis.ScoopBucket/Public/Invoke-PackageUpdate.ps1
@@ -72,6 +72,13 @@ function Invoke-PackageUpdate {
     Write-Host "=== Invoke-PackageUpdate: $Bundle ($($ordered.Count) packages) ==="
 
     $states = New-Object System.Collections.Generic.List[object]
+    # Success-stream emission is deferred until after the summary so that
+    # interactive (uncaptured) runs render the [Package] objects as a
+    # single table instead of one repeated, header-per-row mini-table
+    # interleaved with each engine's live progress output. Pipeline
+    # consumers are unaffected -- every [Package] still reaches the
+    # success stream, just batched at the end of the run.
+    $emit = New-Object System.Collections.Generic.List[object]
     $isCi = [bool]$env:CI
 
     foreach ($pkg in $ordered) {
@@ -83,7 +90,7 @@ function Invoke-PackageUpdate {
             $reason = "CISkip: $($pkg.CISkip)"
             Write-Host "[skip] $($pkg.Name) -- $reason"
             $states.Add([pscustomobject]@{ Pkg = $pkg; State = $state; Reason = $reason })
-            Write-Output $pkg
+            [void]$emit.Add($pkg)
             continue
         }
 
@@ -111,7 +118,7 @@ function Invoke-PackageUpdate {
                     $reason = 'No update path for CustomInstallScript packages (consider adding PostUpdateScript).'
                     Write-Host "  $reason"
                     $states.Add([pscustomobject]@{ Pkg = $pkg; State = $state; Reason = $reason })
-                    Write-Output $pkg
+                    [void]$emit.Add($pkg)
                     continue
                 }
                 $result = @{ State = 'Updated'; Reason = '(PostUpdateScript-only)' }
@@ -158,7 +165,7 @@ function Invoke-PackageUpdate {
         # after a real version bump.
         if ($state -in @('NotInstalled', 'Skipped', 'AlreadyLatest')) {
             $states.Add([pscustomobject]@{ Pkg = $pkg; State = $state; Reason = $reason })
-            Write-Output $pkg
+            [void]$emit.Add($pkg)
             continue
         }
 
@@ -202,11 +209,22 @@ function Invoke-PackageUpdate {
         }
 
         $states.Add([pscustomobject]@{ Pkg = $pkg; State = $state; Reason = $reason })
-        Write-Output $pkg
+        [void]$emit.Add($pkg)
     }
 
     Write-Host ""
     Write-Host "=== $Bundle update summary ==="
+
+    # Standardized result table. Every engine returns a uniform
+    # @{ State; Reason } record, so the summary needs no per-installer
+    # special-casing: glyph + State, then the chocolatey-style Installer /
+    # Scope / Id / Name columns, then the Reason as inline Detail. Failed
+    # packages render here as red ✗ rows carrying their reason, so an error
+    # is just another row in the same table rather than only a raw
+    # ErrorRecord. Columns are width-aligned with a header; the glyph
+    # keeps the State signal colorblind-safe when color is stripped.
+    $fmt = "  {0} {1,-13} {2,-10} {3,-7} {4,-34} {5}"
+    Write-Host ($fmt -f ' ', 'Status', 'Installer', 'Scope', 'Id', 'Name')
     foreach ($s in $states) {
         $glyph = switch ($s.State) {
             'Updated'       { [char]0x2713 }   # ✓
@@ -224,9 +242,12 @@ function Invoke-PackageUpdate {
             'NotInstalled'  { 'Yellow' }
             default         { $Host.UI.RawUI.ForegroundColor }
         }
-        $line = "  {0} {1,-14} {2,-12} {3}" -f $glyph, $s.State, $s.Pkg.Installer, $s.Pkg.Name
+        $line = $fmt -f $glyph, $s.State, $s.Pkg.Installer, $s.Pkg.Scope, $s.Pkg.Id, $s.Pkg.Name
         if ($s.Reason) { $line += "  -- $($s.Reason)" }
         Write-Host $line -ForegroundColor $color
     }
     Write-Host ""
+
+    # Deferred success-stream emission (see the $emit comment above).
+    foreach ($p in $emit) { Write-Output $p }
 }


### PR DESCRIPTION
## Summary

Standardizes the on-screen result of `Update-Package` (via `Invoke-PackageUpdate`)
into a single, uniform status table across every installer.

Before, each package emitted its own one-row `[Package]` table (Name / Installer /
Id / Scope), so the header repeated once per package and the run interleaved
mismatched mini-tables with each engine's raw progress output. The end-of-run
summary was the only standardized view but omitted Scope and Id.

### What changed

- The per-bundle summary now has a **header row** and standardized columns:
  `Status  Installer  Scope  Id  Name` (+ `-- Detail` from the engine reason).
- Each engine already returns a uniform `@{ State; Reason }` record, so the table
  is built from those structured records -- no per-installer special-casing.
- **Failed packages render inline** as red `x` rows carrying their reason, so an
  error is just another row in the same table rather than only a raw error record.
- Success-stream `[Package]` emission is **batched at the end** of the run, so
  interactive (uncaptured) runs no longer print a repeated, header-per-row
  `[Package]` table interleaved with live engine output. The pipeline contract is
  unchanged -- every `[Package]` still reaches the success stream, and the
  `PackageUpdateFailed` ErrorRecord is still written per failure.

### Example

```
=== AIAgents update summary ===
    Status        Installer  Scope   Id                                 Name
  v Updated       choco      global  nodejs                             Node.js
  v Updated       winget     user    Anthropic.Claude                   Claude Desktop
  o AlreadyLatest scoop      global  MarkMichaelis/ChatGPT              ChatGPT
  x Failed        winget     user    Warp.Warp                          Warp  -- winget upgrade --id Warp.Warp timed out
```

## Tests

Added two Light Pester tests in `bucket/UpdatePackage.Tests.ps1`:

- Summary renders a header and per-package Status / Installer / Scope / Id / Name.
- Failed packages render as a red, glyph-marked row carrying their reason.

Both fail for a behavioral reason when the production change is reverted. Full
`UpdatePackage.Tests.ps1` suite passes (77/77).

Closes #274
