### PR TITLE
feat(powershell): install PowerShell via winget MSI, not the sealed Store build

### DIFF
--- a/bucket/PowerShell.ps1
+++ b/bucket/PowerShell.ps1
@@ -3,6 +3,20 @@ Write-Host 'Installing and configuring PowerShell...'
 $scoopBucketPsd1 = Join-Path $PSScriptRoot '..\module\MarkMichaelis.ScoopBucket\MarkMichaelis.ScoopBucket.psd1'
 if (Test-Path $scoopBucketPsd1) { Import-Module $scoopBucketPsd1 -Force } else { Import-Module MarkMichaelis.ScoopBucket -Force }
 
+# Remove the Microsoft Store / MSIX build of PowerShell 7 so the first-party
+# MSI build (C:\Program Files\PowerShell\7) is the resolved `pwsh` and its
+# AllUsersAllHosts profile is admin-writable (#281). Only relevant when this
+# script runs under PowerShell 7+ (the PowerShellCore install path); skipped
+# under Windows PowerShell 5.1 (the PowerShellWindows path). Best-effort:
+# Remove-StorePwsh warns instead of throwing when the Store build is absent.
+if ($IsWindows -and $PSVersionTable.PSEdition -eq 'Core') {
+    try {
+        Remove-StorePwsh -Confirm:$false | Out-Null
+    } catch {
+        Write-Warning "Skipping Store PowerShell removal: $($_.Exception.Message)"
+    }
+}
+
 Update-Help -ErrorAction Ignore
 if((Get-PSRepository PSGallery).InstallationPolicy -ne 'Trusted') {
     Set-PSRepository -Name PSGallery -InstallationPolicy 'Trusted'

--- a/bucket/PowerShellCore.Tests.ps1
+++ b/bucket/PowerShellCore.Tests.ps1
@@ -1,0 +1,48 @@
+#requires -Version 7.0
+#requires -Modules @{ ModuleName = 'Pester'; ModuleVersion = '5.0.0' }
+
+# ----------------------------------------------------------------------------
+# PowerShellCore install-source policy (#281).
+#
+# The Microsoft Store / MSIX build of PowerShell 7 installs into a sealed
+# TrustedInstaller-owned WindowsApps directory whose AllUsersAllHosts profile
+# can't be written even when elevated, breaking machine-wide completion
+# registration. The bucket must therefore install the first-party signed MSI
+# via the winget *default* source -- never `choco install powershell-core`
+# (which let the Store build shadow it) and never the `msstore` source.
+#
+# Tagged 'Light' -- parses the manifest JSON only; no install side effects.
+# ----------------------------------------------------------------------------
+
+BeforeDiscovery {
+    $script:ManifestPath = Join-Path $PSScriptRoot 'PowerShellCore.json'
+}
+
+Describe 'PowerShellCore install source policy' -Tag 'Light' {
+    BeforeAll {
+        $script:ManifestPath = Join-Path $PSScriptRoot 'PowerShellCore.json'
+        $script:Manifest = Get-Content -Raw -LiteralPath $script:ManifestPath | ConvertFrom-Json
+        $script:Script = ($script:Manifest.installer.script -join "`n")
+    }
+
+    It 'installs PowerShell from the winget default source' {
+        $script:Script | Should -Match '(?i)winget\s+install\b' `
+            -Because 'PowerShell must be installed as the first-party signed MSI via winget'
+        $script:Script | Should -Match '(?i)--id\s+Microsoft\.PowerShell\b' `
+            -Because 'the winget package id pins the official PowerShell package'
+        $script:Script | Should -Match '(?i)--source\s+winget\b' `
+            -Because 'the winget source serves the MSI; the msstore source serves the sealed MSIX'
+    }
+
+    It 'does not install PowerShell via choco (which let the Store build shadow the MSI)' {
+        $script:Script | Should -Not -Match '(?i)choco\s+install\s+powershell-core' `
+            -Because 'choco install powershell-core regressed to a Store-shadowed pwsh'
+    }
+
+    It 'never sources PowerShell from msstore' {
+        $script:Script | Should -Not -Match '(?i)--source\s+msstore' `
+            -Because 'msstore serves the sealed MSIX build with an unwritable AllUsers profile'
+        $script:Script | Should -Not -Match '(?i)\bmsstore\b' `
+            -Because 'msstore is the last-resort source and must not be used for PowerShell'
+    }
+}

--- a/bucket/PowerShellCore.json
+++ b/bucket/PowerShellCore.json
@@ -1,12 +1,12 @@
 {
     "$schema": "https://raw.githubusercontent.com/lukesampson/scoop/master/schema.json",
-    "version": "1.13.000",
+    "version": "1.14.000",
     "url": [
         "https://raw.githubusercontent.com/MarkMichaelis/ScoopBucket/main/bucket/PowerShell.ps1"
     ],
     "installer": {
         "script":  [
-            "winget install --id Microsoft.PowerShell --source winget --scope machine --silent --accept-package-agreements --accept-source-agreements",
+            "winget install --id Microsoft.PowerShell -e --source winget --scope machine --silent --accept-package-agreements --accept-source-agreements",
             "$pwsh = Join-Path $env:ProgramFiles 'PowerShell\\7\\pwsh.exe'; if (-not (Test-Path $pwsh)) { $pwsh = 'pwsh.exe' }; & $pwsh -File \"$dir\\PowerShell.ps1\""
         ]
     }

--- a/bucket/PowerShellCore.json
+++ b/bucket/PowerShellCore.json
@@ -1,13 +1,13 @@
 {
     "$schema": "https://raw.githubusercontent.com/lukesampson/scoop/master/schema.json",
-    "version": "1.12.000",
+    "version": "1.13.000",
     "url": [
         "https://raw.githubusercontent.com/MarkMichaelis/ScoopBucket/main/bucket/PowerShell.ps1"
     ],
     "installer": {
         "script":  [
-            "choco install powershell-core",
-            "Pwsh.exe -File \"$dir\\PowerShell.ps1\""
+            "winget install --id Microsoft.PowerShell --source winget --scope machine --silent --accept-package-agreements --accept-source-agreements",
+            "$pwsh = Join-Path $env:ProgramFiles 'PowerShell\\7\\pwsh.exe'; if (-not (Test-Path $pwsh)) { $pwsh = 'pwsh.exe' }; & $pwsh -File \"$dir\\PowerShell.ps1\""
         ]
     }
 }

--- a/bucket/PowerShellWindows.json
+++ b/bucket/PowerShellWindows.json
@@ -1,6 +1,6 @@
 {
     "$schema": "https://raw.githubusercontent.com/lukesampson/scoop/master/schema.json",
-    "version": "1.15.000",
+    "version": "1.16.000",
     "url": [
         "https://raw.githubusercontent.com/MarkMichaelis/ScoopBucket/main/bucket/PowerShell.ps1"
     ],

--- a/bucket/RemoveStorePwsh.Tests.ps1
+++ b/bucket/RemoveStorePwsh.Tests.ps1
@@ -41,6 +41,17 @@ Describe 'De-Store PowerShell helpers' -Tag 'Light' {
                 Remove-StorePwshFromPathString -PathValue $path | Should -Be $path
             }
         }
+
+        It 'drops a sealed entry even when padded with whitespace and prunes blank segments' {
+            InModuleScope MarkMichaelis.ScoopBucket {
+                $path = 'C:\Windows; C:\Program Files\WindowsApps\Microsoft.PowerShell_7.6.2.0_x64__8wekyb3d8bbwe ;   ;C:\Tools'
+                $result = Remove-StorePwshFromPathString -PathValue $path
+                $result | Should -Not -Match '(?i)WindowsApps\\Microsoft\.PowerShell_' `
+                    -Because 'a whitespace-padded sealed entry must still be removed'
+                $result | Should -Be 'C:\Windows;C:\Tools' `
+                    -Because 'blank/whitespace-only segments are pruned and other entries preserved'
+            }
+        }
     }
 
     Context 'Resolve-StorePwshRemoval' {
@@ -104,6 +115,24 @@ Describe 'De-Store PowerShell helpers' -Tag 'Light' {
                 Should -Invoke Remove-StorePwshPathEntry -Times 0 -Exactly
                 $result.StoreBuildFound | Should -BeFalse
                 $result.Removed | Should -BeFalse
+            }
+        }
+
+        It 'performs no side effects under -WhatIf' {
+            InModuleScope MarkMichaelis.ScoopBucket {
+                Mock Get-AppxPackage { [pscustomobject]@{ Name = 'Microsoft.PowerShell' } }
+                Mock Remove-AppxPackage { }
+                Mock Test-Path { $true } -ParameterFilter { $LiteralPath -like '*PowerShell\7\pwsh.exe' }
+                Mock Add-MachinePath { }
+                Mock Remove-StorePwshPathEntry { }
+                Mock Get-Command { $true } -ParameterFilter { $Name -eq 'Get-AppxPackage' }
+
+                Remove-StorePwsh -WhatIf | Out-Null
+
+                Should -Invoke Remove-AppxPackage -Times 0 -Exactly `
+                    -Because '-WhatIf must not remove the Appx package'
+                Should -Invoke Add-MachinePath -Times 0 -Exactly `
+                    -Because '-WhatIf must not mutate PATH via Add-MachinePath'
             }
         }
     }

--- a/bucket/RemoveStorePwsh.Tests.ps1
+++ b/bucket/RemoveStorePwsh.Tests.ps1
@@ -1,0 +1,105 @@
+#requires -Version 7.0
+#requires -Modules @{ ModuleName = 'Pester'; ModuleVersion = '5.0.0' }
+
+# ----------------------------------------------------------------------------
+# De-Store helpers (#281).
+#
+# Remove-StorePwsh removes the sealed Microsoft Store / MSIX build of
+# PowerShell 7 so the first-party MSI build wins and its AllUsersAllHosts
+# profile is admin-writable. The removal *policy* (Resolve-StorePwshRemoval)
+# and the PATH scrub (Remove-StorePwshFromPathString) are pure functions so
+# they are unit-testable without the Appx cmdlets (which exist only on
+# Windows) and without mutating the real environment.
+#
+# Tagged 'Light' -- pure functions, no processes, no environment writes.
+# ----------------------------------------------------------------------------
+
+Describe 'De-Store PowerShell helpers' -Tag 'Light' {
+    BeforeAll {
+        $psd1 = Join-Path $PSScriptRoot '..\module\MarkMichaelis.ScoopBucket\MarkMichaelis.ScoopBucket.psd1'
+        if (Test-Path $psd1) { Import-Module $psd1 -Force } else { Import-Module MarkMichaelis.ScoopBucket -Force }
+    }
+
+    Context 'Remove-StorePwshFromPathString' {
+        It 'drops the sealed WindowsApps PowerShell directory and preserves order' {
+            InModuleScope MarkMichaelis.ScoopBucket {
+                $sealed = 'C:\Program Files\WindowsApps\Microsoft.PowerShell_7.6.2.0_x64__8wekyb3d8bbwe'
+                $path = "C:\Windows;$sealed;C:\Program Files\PowerShell\7;C:\Tools"
+
+                $result = Remove-StorePwshFromPathString -PathValue $path
+
+                $result | Should -Not -Match '(?i)WindowsApps\\Microsoft\.PowerShell_' `
+                    -Because 'the sealed Store package directory must be removed from PATH'
+                $result | Should -Be 'C:\Windows;C:\Program Files\PowerShell\7;C:\Tools' `
+                    -Because 'every other entry must be preserved in original order'
+            }
+        }
+
+        It 'is a no-op when no sealed PowerShell directory is present' {
+            InModuleScope MarkMichaelis.ScoopBucket {
+                $path = 'C:\Windows;C:\Program Files\PowerShell\7;C:\Tools'
+                Remove-StorePwshFromPathString -PathValue $path | Should -Be $path
+            }
+        }
+    }
+
+    Context 'Resolve-StorePwshRemoval' {
+        It 'requests removal when the Store build is present and the MSI build exists' {
+            InModuleScope MarkMichaelis.ScoopBucket {
+                $decision = Resolve-StorePwshRemoval -StorePackage ([pscustomobject]@{ Name = 'Microsoft.PowerShell' }) -MsiPresent $true
+                $decision.ShouldRemove | Should -BeTrue
+                $decision.StoreBuildFound | Should -BeTrue
+            }
+        }
+
+        It 'refuses removal when the MSI build is missing (would leave no pwsh)' {
+            InModuleScope MarkMichaelis.ScoopBucket {
+                $decision = Resolve-StorePwshRemoval -StorePackage ([pscustomobject]@{ Name = 'Microsoft.PowerShell' }) -MsiPresent $false
+                $decision.ShouldRemove | Should -BeFalse `
+                    -Because 'removing the only pwsh on the machine would be destructive'
+                $decision.StoreBuildFound | Should -BeTrue
+            }
+        }
+
+        It 'is a no-op when no Store build is present' {
+            InModuleScope MarkMichaelis.ScoopBucket {
+                $decision = Resolve-StorePwshRemoval -StorePackage $null -MsiPresent $true
+                $decision.ShouldRemove | Should -BeFalse
+                $decision.StoreBuildFound | Should -BeFalse
+            }
+        }
+    }
+
+    Context 'Remove-StorePwsh orchestration' -Skip:(-not $IsWindows) {
+        It 'removes the Appx package when the Store build is present and MSI exists' {
+            InModuleScope MarkMichaelis.ScoopBucket {
+                Mock Get-AppxPackage { [pscustomobject]@{ Name = 'Microsoft.PowerShell' } }
+                Mock Remove-AppxPackage { }
+                Mock Test-Path { $true } -ParameterFilter { $LiteralPath -like '*PowerShell\7\pwsh.exe' }
+                Mock Add-MachinePath { }
+                Mock Get-Command { $true } -ParameterFilter { $Name -eq 'Get-AppxPackage' }
+
+                $result = Remove-StorePwsh -Confirm:$false
+
+                Should -Invoke Remove-AppxPackage -Times 1 -Exactly `
+                    -Because 'the sealed Store build must be removed'
+                $result.Removed | Should -BeTrue
+            }
+        }
+
+        It 'does not remove anything when the Store build is absent' {
+            InModuleScope MarkMichaelis.ScoopBucket {
+                Mock Get-AppxPackage { $null }
+                Mock Remove-AppxPackage { }
+                Mock Test-Path { $true } -ParameterFilter { $LiteralPath -like '*PowerShell\7\pwsh.exe' }
+                Mock Get-Command { $true } -ParameterFilter { $Name -eq 'Get-AppxPackage' }
+
+                $result = Remove-StorePwsh -Confirm:$false
+
+                Should -Invoke Remove-AppxPackage -Times 0 -Exactly
+                $result.StoreBuildFound | Should -BeFalse
+                $result.Removed | Should -BeFalse
+            }
+        }
+    }
+}

--- a/bucket/RemoveStorePwsh.Tests.ps1
+++ b/bucket/RemoveStorePwsh.Tests.ps1
@@ -77,12 +77,15 @@ Describe 'De-Store PowerShell helpers' -Tag 'Light' {
                 Mock Remove-AppxPackage { }
                 Mock Test-Path { $true } -ParameterFilter { $LiteralPath -like '*PowerShell\7\pwsh.exe' }
                 Mock Add-MachinePath { }
+                Mock Remove-StorePwshPathEntry { }
                 Mock Get-Command { $true } -ParameterFilter { $Name -eq 'Get-AppxPackage' }
 
                 $result = Remove-StorePwsh -Confirm:$false
 
                 Should -Invoke Remove-AppxPackage -Times 1 -Exactly `
                     -Because 'the sealed Store build must be removed'
+                Should -Invoke Remove-StorePwshPathEntry -Times 2 -Exactly `
+                    -Because 'both Machine and User PATH scopes are scrubbed (via the mockable helper, never the real env)'
                 $result.Removed | Should -BeTrue
             }
         }
@@ -92,11 +95,13 @@ Describe 'De-Store PowerShell helpers' -Tag 'Light' {
                 Mock Get-AppxPackage { $null }
                 Mock Remove-AppxPackage { }
                 Mock Test-Path { $true } -ParameterFilter { $LiteralPath -like '*PowerShell\7\pwsh.exe' }
+                Mock Remove-StorePwshPathEntry { }
                 Mock Get-Command { $true } -ParameterFilter { $Name -eq 'Get-AppxPackage' }
 
                 $result = Remove-StorePwsh -Confirm:$false
 
                 Should -Invoke Remove-AppxPackage -Times 0 -Exactly
+                Should -Invoke Remove-StorePwshPathEntry -Times 0 -Exactly
                 $result.StoreBuildFound | Should -BeFalse
                 $result.Removed | Should -BeFalse
             }

--- a/module/MarkMichaelis.ScoopBucket/MarkMichaelis.ScoopBucket.psd1
+++ b/module/MarkMichaelis.ScoopBucket/MarkMichaelis.ScoopBucket.psd1
@@ -31,6 +31,7 @@
         'Invoke-PackageUpdate',
         'Update-PackageCompletion',
         'Import-PackageCompletion',
+        'Remove-StorePwsh',
         'Add-MachinePath',
         'Update-PathFromRegistry',
         'Test-IsElevated',

--- a/module/MarkMichaelis.ScoopBucket/Private/Remove-StorePwsh.ps1
+++ b/module/MarkMichaelis.ScoopBucket/Private/Remove-StorePwsh.ps1
@@ -27,8 +27,9 @@ function Remove-StorePwshFromPathString {
     )
     if (-not $PathValue) { return $PathValue }
     $kept = foreach ($segment in ($PathValue -split ';')) {
-        if (-not $segment) { continue }
-        if ($segment -match '(?i)\\WindowsApps\\Microsoft\.PowerShell_') { continue }
+        $trimmed = $segment.Trim()
+        if (-not $trimmed) { continue }
+        if ($trimmed -match '(?i)\\WindowsApps\\Microsoft\.PowerShell_') { continue }
         $segment
     }
     , ($kept -join ';') | Select-Object -First 1
@@ -172,7 +173,10 @@ function Remove-StorePwsh {
     Remove-StorePwshPathEntry -Scope 'Machine'
     Remove-StorePwshPathEntry -Scope 'User'
 
-    try { Add-MachinePath -Path (Split-Path -Parent $msiPwsh) -Confirm:$false } catch { }
+    $msiDir = Split-Path -Parent $msiPwsh
+    if ($PSCmdlet.ShouldProcess($msiDir, 'Ensure on Machine PATH')) {
+        try { Add-MachinePath -Path $msiDir -Confirm:$false } catch { }
+    }
 
     return $result
 }

--- a/module/MarkMichaelis.ScoopBucket/Private/Remove-StorePwsh.ps1
+++ b/module/MarkMichaelis.ScoopBucket/Private/Remove-StorePwsh.ps1
@@ -76,23 +76,62 @@ function Resolve-StorePwshRemoval {
     }
 }
 
+function Remove-StorePwshPathEntry {
+    <#
+    .SYNOPSIS
+        Remove the sealed Store/MSIX PowerShell directory from a persisted
+        PATH scope (Machine or User), writing back only when it changed.
+    .DESCRIPTION
+        Isolates the environment side effect (the only non-pure step of the
+        de-Store flow) behind a single mockable function so callers' tests can
+        stub it out and never touch the real registry PATH.
+    .PARAMETER Scope
+        The environment-variable target: 'Machine' or 'User'.
+    #>
+    [CmdletBinding(SupportsShouldProcess, ConfirmImpact = 'High')]
+    param(
+        [Parameter(Mandatory)][ValidateSet('Machine', 'User')][string]$Scope
+    )
+    try {
+        $current = [Environment]::GetEnvironmentVariable('Path', $Scope)
+        if (-not $current) { return }
+        $cleaned = Remove-StorePwshFromPathString -PathValue $current
+        if ($cleaned -ne $current -and
+            $PSCmdlet.ShouldProcess("$Scope PATH", 'Remove sealed WindowsApps PowerShell entry')) {
+            [Environment]::SetEnvironmentVariable('Path', $cleaned, $Scope)
+        }
+    } catch {
+        Write-Warning "Remove-StorePwshPathEntry: could not scrub $Scope PATH ($($_.Exception.Message))."
+    }
+}
+
 function Remove-StorePwsh {
     <#
     .SYNOPSIS
         Remove the Microsoft Store / MSIX build of PowerShell 7 and scrub its
         sealed directory from PATH so the first-party MSI build wins.
     .DESCRIPTION
-        Idempotent and non-fatal. Detects the Microsoft.PowerShell Appx
-        package and, when the MSI build is also present, removes the MSIX
-        package for the current user (the running process keeps going even if
-        it is the Store pwsh) and scrubs the sealed WindowsApps directory from
-        the Machine and User PATH. Warns (never throws) when the Store build is
-        absent, removal fails, or the MSI build is missing. Returns a result
-        object describing what happened.
+        Windows-only, idempotent and non-fatal. Detects the
+        Microsoft.PowerShell Appx package and, when the MSI build is also
+        present, removes the MSIX package for the current user (the running
+        process keeps going even if it is the Store pwsh) and scrubs the sealed
+        WindowsApps directory from the Machine and User PATH. Warns (never
+        throws) when the Store build is absent, removal fails, or the MSI build
+        is missing. Returns a result object describing what happened.
     #>
     [CmdletBinding(SupportsShouldProcess, ConfirmImpact = 'High')]
     [OutputType([pscustomobject])]
     param()
+
+    if (-not $IsWindows) {
+        Write-Verbose 'Remove-StorePwsh: not Windows; the Store/MSIX PowerShell build does not apply.'
+        return [pscustomobject]@{
+            StoreBuildFound = $false
+            Removed         = $false
+            MsiPath         = $null
+            Reason          = 'Not Windows; nothing to do.'
+        }
+    }
 
     $msiPwsh = Join-Path $env:ProgramFiles 'PowerShell\7\pwsh.exe'
     $msiPresent = Test-Path -LiteralPath $msiPwsh
@@ -130,19 +169,8 @@ function Remove-StorePwsh {
         }
     }
 
-    foreach ($scope in 'Machine', 'User') {
-        try {
-            $current = [Environment]::GetEnvironmentVariable('Path', $scope)
-            if (-not $current) { continue }
-            $cleaned = Remove-StorePwshFromPathString -PathValue $current
-            if ($cleaned -ne $current -and
-                $PSCmdlet.ShouldProcess("$scope PATH", 'Remove sealed WindowsApps PowerShell entry')) {
-                [Environment]::SetEnvironmentVariable('Path', $cleaned, $scope)
-            }
-        } catch {
-            Write-Warning "Remove-StorePwsh: could not scrub $scope PATH ($($_.Exception.Message))."
-        }
-    }
+    Remove-StorePwshPathEntry -Scope 'Machine'
+    Remove-StorePwshPathEntry -Scope 'User'
 
     try { Add-MachinePath -Path (Split-Path -Parent $msiPwsh) -Confirm:$false } catch { }
 

--- a/module/MarkMichaelis.ScoopBucket/Private/Remove-StorePwsh.ps1
+++ b/module/MarkMichaelis.ScoopBucket/Private/Remove-StorePwsh.ps1
@@ -1,0 +1,150 @@
+# De-Store helpers (#281). The Microsoft Store / MSIX build of PowerShell 7
+# installs under C:\Program Files\WindowsApps\Microsoft.PowerShell_..._8wekyb3d8bbwe\,
+# a TrustedInstaller-owned folder where BUILTIN\Administrators hold only
+# ReadAndExecute. Because $PROFILE.AllUsersAllHosts == $PSHOME\profile.ps1, the
+# AllUsers profile can't be written even when elevated, so machine-wide
+# completion registration (Update-PackageCompletion) silently fails. Removing
+# the Store build lets the first-party MSI build (C:\Program Files\PowerShell\7)
+# win, restoring an admin-writable AllUsersAllHosts profile.
+
+function Remove-StorePwshFromPathString {
+    <#
+    .SYNOPSIS
+        Return $PathValue with any sealed Store/MSIX PowerShell package
+        directory removed, preserving the order of all other entries.
+    .DESCRIPTION
+        Pure string transform (no environment side effects) so it is fully
+        unit-testable. Drops segments that point inside a
+        WindowsApps\Microsoft.PowerShell_... package directory -- the sealed
+        path that shadows the MSI build on PATH.
+    .PARAMETER PathValue
+        A ';'-delimited PATH string (e.g. the Machine or User PATH).
+    #>
+    [OutputType([string])]
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)][AllowEmptyString()][string]$PathValue
+    )
+    if (-not $PathValue) { return $PathValue }
+    $kept = foreach ($segment in ($PathValue -split ';')) {
+        if (-not $segment) { continue }
+        if ($segment -match '(?i)\\WindowsApps\\Microsoft\.PowerShell_') { continue }
+        $segment
+    }
+    , ($kept -join ';') | Select-Object -First 1
+}
+
+function Resolve-StorePwshRemoval {
+    <#
+    .SYNOPSIS
+        Decide whether the Store/MSIX PowerShell should be removed.
+    .DESCRIPTION
+        Pure decision function (no side effects) so the removal policy is
+        unit-testable independent of the Appx cmdlets (which exist only on
+        Windows). Removal is requested only when the Store build is present
+        AND the MSI build exists -- never remove the Store build when it is
+        the only pwsh on the machine.
+    .PARAMETER StorePackage
+        The Microsoft.PowerShell Appx package object, or $null when absent.
+    .PARAMETER MsiPresent
+        $true when C:\Program Files\PowerShell\7\pwsh.exe exists.
+    #>
+    [OutputType([pscustomobject])]
+    [CmdletBinding()]
+    param(
+        [Parameter()][object]$StorePackage,
+        [Parameter()][bool]$MsiPresent
+    )
+    if (-not $StorePackage) {
+        return [pscustomobject]@{
+            ShouldRemove    = $false
+            StoreBuildFound = $false
+            Reason          = 'No Microsoft.PowerShell Store/MSIX package found.'
+        }
+    }
+    if (-not $MsiPresent) {
+        return [pscustomobject]@{
+            ShouldRemove    = $false
+            StoreBuildFound = $true
+            Reason          = 'MSI PowerShell (C:\Program Files\PowerShell\7\pwsh.exe) not found; refusing to remove the Store build (would leave no pwsh).'
+        }
+    }
+    return [pscustomobject]@{
+        ShouldRemove    = $true
+        StoreBuildFound = $true
+        Reason          = $null
+    }
+}
+
+function Remove-StorePwsh {
+    <#
+    .SYNOPSIS
+        Remove the Microsoft Store / MSIX build of PowerShell 7 and scrub its
+        sealed directory from PATH so the first-party MSI build wins.
+    .DESCRIPTION
+        Idempotent and non-fatal. Detects the Microsoft.PowerShell Appx
+        package and, when the MSI build is also present, removes the MSIX
+        package for the current user (the running process keeps going even if
+        it is the Store pwsh) and scrubs the sealed WindowsApps directory from
+        the Machine and User PATH. Warns (never throws) when the Store build is
+        absent, removal fails, or the MSI build is missing. Returns a result
+        object describing what happened.
+    #>
+    [CmdletBinding(SupportsShouldProcess, ConfirmImpact = 'High')]
+    [OutputType([pscustomobject])]
+    param()
+
+    $msiPwsh = Join-Path $env:ProgramFiles 'PowerShell\7\pwsh.exe'
+    $msiPresent = Test-Path -LiteralPath $msiPwsh
+
+    $package = $null
+    if (Get-Command -Name 'Get-AppxPackage' -ErrorAction Ignore) {
+        try { $package = Get-AppxPackage -Name 'Microsoft.PowerShell' -ErrorAction Stop } catch { $package = $null }
+    }
+
+    $decision = Resolve-StorePwshRemoval -StorePackage $package -MsiPresent ([bool]$msiPresent)
+
+    $result = [pscustomobject]@{
+        StoreBuildFound = $decision.StoreBuildFound
+        Removed         = $false
+        MsiPath         = if ($msiPresent) { $msiPwsh } else { $null }
+        Reason          = $decision.Reason
+    }
+
+    if (-not $decision.ShouldRemove) {
+        if ($decision.StoreBuildFound) {
+            Write-Warning "Remove-StorePwsh: $($decision.Reason)"
+        } else {
+            Write-Verbose "Remove-StorePwsh: $($decision.Reason)"
+        }
+        return $result
+    }
+
+    if ($PSCmdlet.ShouldProcess('Microsoft.PowerShell (Store/MSIX)', 'Remove-AppxPackage')) {
+        try {
+            $package | Remove-AppxPackage -ErrorAction Stop
+            $result.Removed = $true
+        } catch {
+            $result.Reason = "Remove-AppxPackage failed: $($_.Exception.Message)"
+            Write-Warning "Remove-StorePwsh: $($result.Reason)"
+        }
+    }
+
+    foreach ($scope in 'Machine', 'User') {
+        try {
+            $current = [Environment]::GetEnvironmentVariable('Path', $scope)
+            if (-not $current) { continue }
+            $cleaned = Remove-StorePwshFromPathString -PathValue $current
+            if ($cleaned -ne $current -and
+                $PSCmdlet.ShouldProcess("$scope PATH", 'Remove sealed WindowsApps PowerShell entry')) {
+                [Environment]::SetEnvironmentVariable('Path', $cleaned, $scope)
+            }
+        } catch {
+            Write-Warning "Remove-StorePwsh: could not scrub $scope PATH ($($_.Exception.Message))."
+        }
+    }
+
+    try { Add-MachinePath -Path (Split-Path -Parent $msiPwsh) -Confirm:$false } catch { }
+
+    return $result
+}


### PR DESCRIPTION
## Summary

The active `pwsh` on the machine was the Microsoft **Store / MSIX** build,
whose `$PSHOME` (and therefore `$PROFILE.AllUsersAllHosts` = `$PSHOME\profile.ps1`)
resolves inside the TrustedInstaller-sealed
`C:\Program Files\WindowsApps\Microsoft.PowerShell_..._8wekyb3d8bbwe\` folder.
`BUILTIN\Administrators` hold only `ReadAndExecute` there, so AllUsers profile
writes are denied **even when elevated** -- the root cause of
`Update-PackageCompletion: Skipped=51` (37 on-PATH CLIs that could not be
written to the sealed profile + 14 not installed).

## Changes

- **`bucket/PowerShellCore.json`** -- installs the first-party signed **MSI**
  via the winget default source
  (`--id Microsoft.PowerShell -e --source winget --scope machine --silent ...`)
  instead of `choco install powershell-core` (which let the Store build shadow
  the MSI on PATH). The config step runs under the MSI `pwsh` explicitly so
  completion registration targets a writable AllUsers profile.
- **`Remove-StorePwsh`** (new module function) -- removes the
  `Microsoft.PowerShell` MSIX package and scrubs its sealed `WindowsApps`
  directory from the Machine/User PATH so the MSI build
  (`C:\Program Files\PowerShell\7`) wins. Windows-only, idempotent and
  non-fatal; refuses to remove the Store build when no MSI build exists; the
  PATH write is isolated in a mockable helper and gated by `ShouldProcess`.
- **`bucket/PowerShell.ps1`** -- invokes `Remove-StorePwsh` on the PowerShell
  Core install path only (skipped under Windows PowerShell 5.1).
- Version bumps: PowerShellCore.json `1.12.000 -> 1.14.000`,
  PowerShellWindows.json `1.15.000 -> 1.16.000` (both reference the modified
  `PowerShell.ps1`; the PowerShellCore bump landed at 1.14.000 after the
  pre-push version-bump hook re-bumped it for the review fixes).

## msstore policy

`msstore` is the **last-resort** source. Audit found it used only by 6 GUI
Store-only apps (ChatGPT, VPN Unlimited, Grammarly, WhatsApp, Snagit,
Todoist), each kept with a justifying Note. The existing guard in
`Bundles.Tests.ps1` already enforces "msstore only with the winget installer".
No PowerShell path uses msstore (asserted by the new manifest test).

## Tests

- `bucket/PowerShellCore.Tests.ps1` (Light) -- asserts the winget MSI source
  policy; bans `choco install powershell-core` and the `msstore` source.
  Fails behaviorally when reverted (verified: 2 failures against the old
  manifest).
- `bucket/RemoveStorePwsh.Tests.ps1` (Light) -- pure removal policy + PATH
  scrub (including whitespace/blank-segment handling), plus Windows-only
  orchestration with mocked Appx cmdlets and a `-WhatIf` no-op test.

## Verification

```powershell
./bucket/Invoke-Tests.ps1 -Tag Light
```

CI Light suite (Windows) and the version-bump check both pass. A local full
Light run reported one failure -- the load-sensitive cold-import budget
(`ImportPerformance.Tests.ps1`, 1800 ms) -- because the dev machine was
~3.5x under load (suite ran 973 s vs the usual ~270 s). An A/B cold-import
measurement (this branch vs the same module without the new file) showed both
at ~4 s, confirming the budget miss is environmental, not caused by this
change. CI (unloaded) passes the budget.

Closes #281