### PR TITLE
feat(update): accurate WhatIf, version transitions, and changed-only output

### DIFF
--- a/bucket/InvokePackageInstallSummary.Tests.ps1
+++ b/bucket/InvokePackageInstallSummary.Tests.ps1
@@ -64,14 +64,18 @@ Describe 'Invoke-PackageInstall result emission' -Tag 'Light','Module' {
         $goodLine | Should -Not -BeNullOrEmpty
         $badLine  | Should -Not -BeNullOrEmpty
 
-        # Glyph carries the signal even when color is stripped.
-        $goodLine | Should -Match ([regex]::Escape('+ Installed'))
-        $badLine  | Should -Match ([regex]::Escape('x Failed'))
+        # Glyph carries the signal even when color is stripped: the new view
+        # renders a glyph-only Status column (no text label), Name first.
+        $goodLine | Should -Match ([regex]::Escape('+'))
+        $goodLine | Should -Match 'GoodPkg'
+        $badLine  | Should -Match ([regex]::Escape('x'))
+        $badLine  | Should -Match 'BadPkg'
 
-        # Color reinforces it: green for Installed, red for Failed.
+        # Color reinforces it: green for Installed, red for Failed. The glyph
+        # is wrapped in the status color, so assert the colored glyph directly.
         $green = $PSStyle.Foreground.Green
         $red   = $PSStyle.Foreground.Red
-        $goodLine | Should -Match ([regex]::Escape($green))
-        $badLine  | Should -Match ([regex]::Escape($red))
+        $goodLine | Should -Match ([regex]::Escape($green + '+'))
+        $badLine  | Should -Match ([regex]::Escape($red + 'x'))
     }
 }

--- a/bucket/PackageResultDetails.Tests.ps1
+++ b/bucket/PackageResultDetails.Tests.ps1
@@ -1,0 +1,59 @@
+<#
+.SYNOPSIS
+    Pins the PackageResult.Details() presentation contract (#283) -- the single
+    merged column combining the version transition and the reason.
+#>
+
+BeforeAll {
+    $script:moduleManifest = Resolve-Path (Join-Path (Split-Path -Parent $PSScriptRoot) 'module\MarkMichaelis.ScoopBucket\MarkMichaelis.ScoopBucket.psd1')
+    Import-Module $script:moduleManifest -Force
+}
+
+Describe 'PackageResult.Details()' {
+    It 'renders a from -> to transition for a real update' {
+        $r = [PackageResult]@{ Status = 'Updated'; VersionFrom = '1.2.0'; VersionTo = '1.3.0' }
+        $r.Details() | Should -Be '1.2.0 -> 1.3.0'
+    }
+
+    It 'appends (WhatIf) to the transition on a dry run' {
+        $r = [PackageResult]@{ Status = 'Updated'; VersionFrom = '1.2.0'; VersionTo = '1.3.0'; Reason = '(WhatIf)' }
+        $r.Details() | Should -Be '1.2.0 -> 1.3.0 (WhatIf)'
+    }
+
+    It 'shows the reason when a WhatIf update has unknown versions' {
+        $r = [PackageResult]@{ Status = 'Updated'; Reason = '(WhatIf, version unknown)' }
+        $r.Details() | Should -Be '(WhatIf, version unknown)'
+    }
+
+    It 'renders Reinstalled (never a version) for a Reinstall update' {
+        $r = [PackageResult]@{ Status = 'Updated'; Reason = '(Reinstall)' }
+        $r.Details() | Should -Be 'Reinstalled'
+    }
+
+    It 'renders -> to for a fresh install with no prior version' {
+        $r = [PackageResult]@{ Status = 'Installed'; VersionTo = '2.0.0' }
+        $r.Details() | Should -Be '-> 2.0.0'
+    }
+
+    It 'renders <version> (latest) for AlreadyLatest' {
+        $r = [PackageResult]@{ Status = 'AlreadyLatest'; VersionFrom = '1.12.000' }
+        $r.Details() | Should -Be '1.12.000 (latest)'
+    }
+
+    It 'renders not installed' {
+        ([PackageResult]@{ Status = 'NotInstalled' }).Details() | Should -Be 'not installed'
+    }
+
+    It 'renders self-managed' {
+        ([PackageResult]@{ Status = 'SelfManaged' }).Details() | Should -Be 'self-managed'
+    }
+
+    It 'renders no auto-update' {
+        ([PackageResult]@{ Status = 'NoAutoUpdateSupport' }).Details() | Should -Be 'no auto-update'
+    }
+
+    It 'shows the failure reason verbatim for a Failed result' {
+        $r = [PackageResult]@{ Status = 'Failed'; Reason = 'winget upgrade exited with -1.' }
+        $r.Details() | Should -Be 'winget upgrade exited with -1.'
+    }
+}

--- a/bucket/PackageUpdateIndex.Tests.ps1
+++ b/bucket/PackageUpdateIndex.Tests.ps1
@@ -1,0 +1,167 @@
+<#
+.SYNOPSIS
+    Light-suite coverage for the version-probe helpers behind #283: the pure
+    CLI-output parsers (winget/choco/npm/scoop) and Resolve-PackageVersionInfo.
+
+.DESCRIPTION
+    These helpers make `Update-Package -WhatIf` accurate (Updated only when a
+    newer version really exists) and feed the `from -> to` version column. The
+    parsers are pure (text/JSON -> hashtable) and pinned here against canned
+    CLI fixtures so a winget/choco/scoop output-format tweak is caught by a
+    failing test rather than a silently-wrong summary.
+#>
+
+BeforeAll {
+    $script:moduleManifest = Resolve-Path (Join-Path (Split-Path -Parent $PSScriptRoot) 'module\MarkMichaelis.ScoopBucket\MarkMichaelis.ScoopBucket.psd1')
+    Import-Module $script:moduleManifest -Force
+
+    function script:InModule {
+        param([scriptblock]$Block, [object[]]$ArgumentList)
+        & (Get-Module MarkMichaelis.ScoopBucket) $Block @ArgumentList
+    }
+}
+
+Describe 'ConvertFrom-WingetVersionTable' {
+    It 'extracts Installed and Available for an upgradable row and leaves Available empty for a current row' {
+        $fixture = @(
+            'Name              Id                       Version      Available    Source',
+            '-----------------------------------------------------------------------------',
+            'Claude            Anthropic.Claude         1.9659.2     1.9712.0     winget',
+            'Warp              Warp.Warp                0.2026.05.27              winget'
+        )
+        $map = InModule { param($l) ConvertFrom-WingetVersionTable $l } @(, $fixture)
+
+        $map['anthropic.claude'].Installed | Should -Be '1.9659.2'
+        $map['anthropic.claude'].Available | Should -Be '1.9712.0'
+        $map['warp.warp'].Installed        | Should -Be '0.2026.05.27'
+        $map['warp.warp'].Available        | Should -Be ''
+    }
+
+    It 'strips a truncation ellipsis / non-ASCII mojibake from a version cell so it never leaks into the transition' {
+        $ellipsis = [char]0x2026
+        $fixture = @(
+            'Name              Id                       Version          Available        Source',
+            '---------------------------------------------------------------------------------------',
+            ("Warp              Warp.Warp                v0.2026.05.27.15 v0.2026.05.27.15$ellipsis winget")
+        )
+        $map = InModule { param($l) ConvertFrom-WingetVersionTable $l } @(, $fixture)
+
+        $map['warp.warp'].Available | Should -Not -Match '[^\x20-\x7E]'
+        $map['warp.warp'].Available | Should -Be 'v0.2026.05.27.15'
+    }
+
+    It 'returns an empty map when no header row is present' {
+        $map = InModule { param($l) ConvertFrom-WingetVersionTable $l } @(, @('no table here'))
+        $map.Keys.Count | Should -Be 0
+    }
+}
+
+Describe 'ConvertFrom-ChocoOutdated' {
+    It 'parses the pipe-delimited machine-readable rows' {
+        $fixture = @(
+            'nodejs|22.14.0|22.15.0|false',
+            'exiftool|13.10|13.11|false'
+        )
+        $map = InModule { param($l) ConvertFrom-ChocoOutdated $l } @(, $fixture)
+
+        $map['nodejs'].Installed   | Should -Be '22.14.0'
+        $map['nodejs'].Available   | Should -Be '22.15.0'
+        $map['exiftool'].Available | Should -Be '13.11'
+    }
+}
+
+Describe 'ConvertFrom-NpmOutdated' {
+    It 'maps current and latest from the JSON object' {
+        $json = '{ "typescript": { "current": "5.3.0", "wanted": "5.3.3", "latest": "5.4.2" } }'
+        $map = InModule { param($j) ConvertFrom-NpmOutdated $j } @($json)
+
+        $map['typescript'].Installed | Should -Be '5.3.0'
+        $map['typescript'].Available | Should -Be '5.4.2'
+    }
+
+    It 'returns an empty map for malformed JSON instead of throwing' {
+        $map = InModule { param($j) ConvertFrom-NpmOutdated $j } @('not json')
+        $map.Keys.Count | Should -Be 0
+    }
+}
+
+Describe 'ConvertFrom-ScoopStatus' {
+    It 'extracts Installed and Latest for an outdated app' {
+        $fixture = @(
+            'Name    Installed Version Latest Version Missing Dependencies Info',
+            '----    ----------------- -------------- -------------------- ----',
+            'ripgrep 14.1.0            14.1.1'
+        )
+        $map = InModule { param($l) ConvertFrom-ScoopStatus $l } @(, $fixture)
+
+        $map['ripgrep'].Installed | Should -Be '14.1.0'
+        $map['ripgrep'].Available | Should -Be '14.1.1'
+    }
+}
+
+Describe 'Resolve-PackageVersionInfo' {
+    BeforeAll {
+        $script:index = @{
+            winget = @{
+                'anthropic.claude' = @{ Installed = '1.9659.2'; Available = '1.9712.0' }
+                'warp.warp'        = @{ Installed = '0.2026.05.27'; Available = '' }
+            }
+            scoop = @{
+                'ripgrep' = @{ Installed = '14.1.0'; Available = '14.1.1' }
+            }
+            dotnetTool = @{
+                'aspire.cli' = @{ Installed = '9.0.0'; Available = '' }
+            }
+        }
+    }
+
+    It 'reports UpdateAvailable=true with both versions when a newer version exists' {
+        $pkg = [pscustomobject]@{ Installer = 'winget'; Id = 'Anthropic.Claude' }
+        $info = InModule { param($p, $i) Resolve-PackageVersionInfo -Package $p -Index $i } @($pkg, $script:index)
+
+        $info.Present         | Should -BeTrue
+        $info.UpdateAvailable | Should -BeTrue
+        $info.Installed       | Should -Be '1.9659.2'
+        $info.Available       | Should -Be '1.9712.0'
+    }
+
+    It 'reports UpdateAvailable=false when the installed version is already current' {
+        $pkg = [pscustomobject]@{ Installer = 'winget'; Id = 'Warp.Warp' }
+        $info = InModule { param($p, $i) Resolve-PackageVersionInfo -Package $p -Index $i } @($pkg, $script:index)
+
+        $info.Present         | Should -BeTrue
+        $info.UpdateAvailable | Should -BeFalse
+    }
+
+    It 'reports Present=false for a package absent from a winget map' {
+        $pkg = [pscustomobject]@{ Installer = 'winget'; Id = 'Not.Installed' }
+        $info = InModule { param($p, $i) Resolve-PackageVersionInfo -Package $p -Index $i } @($pkg, $script:index)
+
+        $info.Present | Should -BeFalse
+    }
+
+    It 'keys scoop by the bare app name (strips the bucket prefix)' {
+        $pkg = [pscustomobject]@{ Installer = 'scoop'; Id = 'MarkMichaelis/ripgrep' }
+        # rename the map key to the bare app so the lookup must strip the prefix
+        $info = InModule { param($p, $i) Resolve-PackageVersionInfo -Package $p -Index $i } @($pkg, $script:index)
+
+        $info.UpdateAvailable | Should -BeTrue
+        $info.Available       | Should -Be '14.1.1'
+    }
+
+    It 'returns UpdateAvailable=null (unknown) for dotnetTool' {
+        $pkg = [pscustomobject]@{ Installer = 'dotnetTool'; Id = 'Aspire.Cli' }
+        $info = InModule { param($p, $i) Resolve-PackageVersionInfo -Package $p -Index $i } @($pkg, $script:index)
+
+        $info.Present         | Should -BeTrue
+        $info.UpdateAvailable | Should -BeNullOrEmpty
+    }
+
+    It 'returns all-unknown when the installer was not probed at all' {
+        $pkg = [pscustomobject]@{ Installer = 'choco'; Id = 'nodejs' }
+        $info = InModule { param($p, $i) Resolve-PackageVersionInfo -Package $p -Index $i } @($pkg, $script:index)
+
+        $info.Present         | Should -BeNullOrEmpty
+        $info.UpdateAvailable | Should -BeNullOrEmpty
+    }
+}

--- a/bucket/UpdatePackage.Tests.ps1
+++ b/bucket/UpdatePackage.Tests.ps1
@@ -332,6 +332,10 @@ Describe 'Invoke-PackageUpdate pipeline' -Tag 'Light','Module' {
         Mock -ModuleName MarkMichaelis.ScoopBucket Update-DotnetToolPackage { return @{ State='Updated'; Reason=$null } }
         Mock -ModuleName MarkMichaelis.ScoopBucket Update-PathFromRegistry  { }
         Mock -ModuleName MarkMichaelis.ScoopBucket Register-PackageCompletion { }
+        # The version probe runs a bulk CLI query per installer. Stub it out
+        # by default so real-run pipeline tests stay fast and deterministic;
+        # individual tests that exercise -WhatIf accuracy override it (#283).
+        Mock -ModuleName MarkMichaelis.ScoopBucket Get-PackageUpdateIndex { @{} }
     }
 
     It 'threads -PackageTimeoutMinutes to Update-WingetPackage (#269)' {
@@ -469,11 +473,30 @@ Describe 'Invoke-PackageUpdate pipeline' -Tag 'Light','Module' {
         Should -Invoke -ModuleName MarkMichaelis.ScoopBucket Register-PackageCompletion -Times 2 -Exactly
     }
 
-    It 'engines receive -WhatIf when the cmdlet is called with -WhatIf' {
-        Mock -ModuleName MarkMichaelis.ScoopBucket Update-WingetPackage -ParameterFilter { $WhatIf } { return @{ State='Updated'; Reason='(WhatIf)' } }
+    It 'under -WhatIf, probes the index instead of invoking the engine and reports the version transition (#283)' {
+        # New contract: a dry run no longer calls the engine -- it consults the
+        # pre-built version index. An available upgrade reports Updated with a
+        # from -> to transition.
+        Mock -ModuleName MarkMichaelis.ScoopBucket Update-WingetPackage { throw 'engine must not run under -WhatIf' }
+        Mock -ModuleName MarkMichaelis.ScoopBucket Get-PackageUpdateIndex {
+            @{ winget = @{ 'foo.a' = @{ Installed = '1.0'; Available = '2.0' } } }
+        }
         $pkgs = [Package[]]@([Package]@{ Name='A'; Installer='winget'; Id='Foo.A' })
-        $null = Invoke-PackageUpdate -Packages $pkgs -Bundle 'Test' -WhatIf -SkipCompletion
-        Should -Invoke -ModuleName MarkMichaelis.ScoopBucket Update-WingetPackage -Times 1 -Exactly -ParameterFilter { $WhatIf }
+        $r = @(Invoke-PackageUpdate -Packages $pkgs -Bundle 'Test' -WhatIf -SkipCompletion)
+        Should -Invoke -ModuleName MarkMichaelis.ScoopBucket Update-WingetPackage -Times 0 -Exactly
+        $r[0].Status      | Should -Be 'Updated'
+        $r[0].VersionFrom | Should -Be '1.0'
+        $r[0].VersionTo   | Should -Be '2.0'
+    }
+
+    It 'under -WhatIf, an already-current package reports AlreadyLatest not Updated (#283)' {
+        Mock -ModuleName MarkMichaelis.ScoopBucket Update-WingetPackage { throw 'engine must not run under -WhatIf' }
+        Mock -ModuleName MarkMichaelis.ScoopBucket Get-PackageUpdateIndex {
+            @{ winget = @{ 'foo.a' = @{ Installed = '2.0'; Available = '' } } }
+        }
+        $pkgs = [Package[]]@([Package]@{ Name='A'; Installer='winget'; Id='Foo.A' })
+        $r = @(Invoke-PackageUpdate -Packages $pkgs -Bundle 'Test' -WhatIf -SkipCompletion)
+        $r[0].Status | Should -Be 'AlreadyLatest'
     }
 }
 
@@ -592,6 +615,7 @@ Describe 'Quiet-by-default update output (#276)' -Tag 'Light','Module' {
             Mock Update-WingetPackage    { return @{ State='Updated'; Reason=$null } }
             Mock Update-PathFromRegistry { }
             Mock Register-PackageCompletion { }
+            Mock Get-PackageUpdateIndex { @{} }
             $captured = New-Object System.Collections.Generic.List[object]
             Mock Write-Host -MockWith {
                 $captured.Add([pscustomobject]@{ Message = [string]$Object })
@@ -620,6 +644,7 @@ Describe 'Quiet-by-default update output (#276)' -Tag 'Light','Module' {
             Mock Update-WingetPackage    { return @{ State='Updated'; Reason=$null } }
             Mock Update-PathFromRegistry { }
             Mock Register-PackageCompletion { }
+            Mock Get-PackageUpdateIndex { @{} }
             Mock Write-Host { }
             $statuses = New-Object System.Collections.Generic.List[object]
             Mock Write-Progress -MockWith {
@@ -641,6 +666,7 @@ Describe 'Quiet-by-default update output (#276)' -Tag 'Light','Module' {
             Mock Update-WingetPackage    { return @{ State='Updated'; Reason=$null } }
             Mock Update-PathFromRegistry { }
             Mock Register-PackageCompletion { }
+            Mock Get-PackageUpdateIndex { @{} }
             Mock Write-Host { }
             Mock Write-Progress { }
 

--- a/module/MarkMichaelis.ScoopBucket/Classes/PackageResult.ps1
+++ b/module/MarkMichaelis.ScoopBucket/Classes/PackageResult.ps1
@@ -32,6 +32,14 @@ class PackageResult {
     # The bundle this package was dispatched from.
     [string] $Bundle
 
+    # Version transition for a real (or planned) upgrade/install. VersionFrom
+    # is the version that was installed before the operation (empty for a
+    # fresh install or when the engine couldn't be probed); VersionTo is the
+    # version after (or the target under -WhatIf). Both feed the Details
+    # column's `from -> to` rendering and stay on the object for export. See #283.
+    [string] $VersionFrom
+    [string] $VersionTo
+
     # Short human-readable detail for any status (e.g. '(WhatIf)',
     # 'CISkip: ...', or a failure's exception message). Surfaced inline by
     # the format view.
@@ -45,5 +53,47 @@ class PackageResult {
 
     [string] ToString() {
         return "[$($this.Status)] $($this.Name)$(if ($this.Id) { " ($($this.Id))" })"
+    }
+
+    # Single human-readable cell merging the version transition and the
+    # reason for the summary table's `Details` column (#283). Rules:
+    #   Updated/Installed : 'Reinstalled', or 'from -> to', or '-> to' (fresh
+    #                       install), suffixed ' (WhatIf)' on a dry run.
+    #   AlreadyLatest     : '<version> (latest)'.
+    #   NotInstalled      : 'not installed'.
+    #   SelfManaged       : 'self-managed'.
+    #   NoAutoUpdate      : 'no auto-update'.
+    #   Skipped/Failed/*  : the Reason verbatim (failure tail / skip cause).
+    # The underlying VersionFrom/VersionTo/Reason properties stay intact for
+    # export; this is presentation only.
+    [string] Details() {
+        $from = $this.VersionFrom
+        $to   = $this.VersionTo
+        $whatIf = ($this.Reason -match 'WhatIf')
+
+        switch -Regex ($this.Status) {
+            '^(Updated|Installed)$' {
+                if ($this.Reason -match 'Reinstall') { $d = 'Reinstalled' }
+                elseif ($from -and $to)              { $d = "$from -> $to" }
+                elseif ($to)                         { $d = "-> $to" }
+                elseif ($from)                       { $d = $from }
+                else                                 { $d = '' }
+                if ($whatIf) {
+                    if ($d) { return "$d (WhatIf)" }
+                    return [string]$this.Reason
+                }
+                if (-not $d) { return [string]$this.Reason }
+                return $d
+            }
+            '^(AlreadyLatest|AlreadyInstalled)$' {
+                if ($from) { return "$from (latest)" }
+                return 'latest'
+            }
+            '^NotInstalled$'        { return 'not installed' }
+            '^SelfManaged$'         { return 'self-managed' }
+            '^NoAutoUpdateSupport$' { return 'no auto-update' }
+            default                 { return [string]$this.Reason }
+        }
+        return [string]$this.Reason
     }
 }

--- a/module/MarkMichaelis.ScoopBucket/MarkMichaelis.ScoopBucket.format.ps1xml
+++ b/module/MarkMichaelis.ScoopBucket/MarkMichaelis.ScoopBucket.format.ps1xml
@@ -69,8 +69,12 @@
       <TableControl>
         <TableHeaders>
           <TableColumnHeader>
-            <Label>Status</Label>
-            <Width>21</Width>
+            <Label> </Label>
+            <Width>2</Width>
+          </TableColumnHeader>
+          <TableColumnHeader>
+            <Label>Name</Label>
+            <Width>26</Width>
           </TableColumnHeader>
           <TableColumnHeader>
             <Label>Installer</Label>
@@ -81,15 +85,7 @@
             <Width>8</Width>
           </TableColumnHeader>
           <TableColumnHeader>
-            <Label>Id</Label>
-            <Width>34</Width>
-          </TableColumnHeader>
-          <TableColumnHeader>
-            <Label>Name</Label>
-            <Width>26</Width>
-          </TableColumnHeader>
-          <TableColumnHeader>
-            <Label>Reason</Label>
+            <Label>Details</Label>
           </TableColumnHeader>
         </TableHeaders>
         <TableRowEntries>
@@ -97,23 +93,22 @@
             <TableColumnItems>
               <TableColumnItem>
                 <ScriptBlock>
-                  # Render Status as a colorblind-safe glyph + label, colored
-                  # via $PSStyle when the host supports it. The underlying
-                  # .Status property stays a plain string for filtering/export.
+                  # Render Status as a colorblind-safe glyph ONLY (no label),
+                  # colored via $PSStyle when the host supports it. The
+                  # underlying .Status string is unchanged for filtering/export.
                   $map = @{
-                    Updated             = @('+', 'Updated')
-                    Installed           = @('+', 'Installed')
-                    Uninstalled         = @('-', 'Uninstalled')
-                    AlreadyLatest       = @('=', 'AlreadyLatest')
-                    AlreadyInstalled    = @('=', 'AlreadyInstalled')
-                    Skipped             = @('>', 'Skipped')
-                    Failed              = @('x', 'Failed')
-                    NotInstalled        = @('!', 'NotInstalled')
-                    SelfManaged         = @('@', 'SelfManaged')
-                    NoAutoUpdateSupport = @('-', 'NoAutoUpdate')
+                    Updated             = '+'
+                    Installed           = '+'
+                    Uninstalled         = '-'
+                    AlreadyLatest       = '='
+                    AlreadyInstalled    = '='
+                    Skipped             = '~'
+                    Failed              = 'x'
+                    NotInstalled        = 'o'
+                    SelfManaged         = '@'
+                    NoAutoUpdateSupport = '-'
                   }
-                  $g, $label = if ($map.ContainsKey($_.Status)) { $map[$_.Status] } else { @('?', $_.Status) }
-                  $text = '{0} {1}' -f $g, $label
+                  $g = if ($map.ContainsKey($_.Status)) { $map[$_.Status] } else { '?' }
                   $style = $null
                   if ($null -ne $PSStyle -and $PSStyle.OutputRendering -ne 'PlainText') {
                     switch ($_.Status) {
@@ -124,13 +119,16 @@
                       'AlreadyInstalled'    { $style = $PSStyle.Foreground.BrightBlack }
                       'Skipped'             { $style = $PSStyle.Foreground.Yellow }
                       'Failed'              { $style = $PSStyle.Foreground.Red }
-                      'NotInstalled'        { $style = $PSStyle.Foreground.Red }
+                      'NotInstalled'        { $style = $PSStyle.Foreground.Yellow }
                       'SelfManaged'         { $style = $PSStyle.Foreground.Cyan }
                       'NoAutoUpdateSupport' { $style = $PSStyle.Foreground.BrightBlack }
                     }
                   }
-                  if ($style) { "$style$text$($PSStyle.Reset)" } else { $text }
+                  if ($style) { "$style$g$($PSStyle.Reset)" } else { $g }
                 </ScriptBlock>
+              </TableColumnItem>
+              <TableColumnItem>
+                <PropertyName>Name</PropertyName>
               </TableColumnItem>
               <TableColumnItem>
                 <PropertyName>Installer</PropertyName>
@@ -139,13 +137,7 @@
                 <PropertyName>Scope</PropertyName>
               </TableColumnItem>
               <TableColumnItem>
-                <PropertyName>Id</PropertyName>
-              </TableColumnItem>
-              <TableColumnItem>
-                <PropertyName>Name</PropertyName>
-              </TableColumnItem>
-              <TableColumnItem>
-                <PropertyName>Reason</PropertyName>
+                <ScriptBlock>$_.Details()</ScriptBlock>
               </TableColumnItem>
             </TableColumnItems>
           </TableRowEntry>

--- a/module/MarkMichaelis.ScoopBucket/Private/Get-PackageUpdateIndex.ps1
+++ b/module/MarkMichaelis.ScoopBucket/Private/Get-PackageUpdateIndex.ps1
@@ -1,0 +1,363 @@
+# Version / available-update probe used to make -WhatIf accurate and to
+# annotate the summary with a `from -> to` version transition (#283).
+#
+# Design: instead of probing each package individually (which would re-run a
+# bulk scan per package), Get-PackageUpdateIndex runs each engine's bulk
+# "what is installed / what is outdated" command ONCE and returns a lookup:
+#
+#   @{ winget = @{ '<id>' = @{ Installed='1.2'; Available='1.3' } }; scoop = ...; ... }
+#
+# Invoke-PackageUpdate / Invoke-PackageInstall then look up each package by
+# Id (case-insensitively) to decide Updated vs AlreadyLatest under -WhatIf and
+# to fill VersionFrom / VersionTo. Every parser is pure (text/JSON -> hashtable)
+# so it can be unit-tested against canned CLI fixtures; the orchestrator only
+# adds the CLI invocation and is defensive (any failure yields an empty/Unknown
+# map rather than throwing, so a flaky probe never aborts a sweep).
+
+function Format-VersionCell {
+    # Normalise a version string sliced out of a fixed-width CLI table. winget
+    # truncates an over-long column with a Unicode ellipsis (U+2026) which the
+    # OEM console codepage renders as mojibake (e.g. "ÔÇª" / "ΓÇª"); strip every
+    # non-printable / non-ASCII byte so a stray truncation marker never leaks
+    # into the rendered `from -> to` transition. Returns the cleaned string.
+    [OutputType([string])]
+    [CmdletBinding()]
+    param([Parameter(Position = 0)][AllowNull()][string]$Value)
+
+    if ([string]::IsNullOrWhiteSpace($Value)) { return '' }
+    return ($Value -replace '[^\x20-\x7E]', '').Trim()
+}
+
+function ConvertFrom-WingetVersionTable {
+    # Parse the fixed-width table emitted by `winget list` (and `winget
+    # upgrade`). Returns @{ '<id>' = @{ Installed; Available } } keyed by the
+    # Id column (lower-cased). The Available column is empty when the package
+    # is already current. winget right-pads columns to header width, so we
+    # slice by the header's column start offsets rather than splitting on
+    # whitespace (Names and versions both contain spaces).
+    [OutputType([hashtable])]
+    [CmdletBinding()]
+    param([Parameter(Position = 0)][string[]]$Lines)
+
+    $map = @{}
+    if (-not $Lines) { return $map }
+
+    # Find the header row: the first line that contains both 'Id' and
+    # 'Version' as column headers, immediately followed (next non-empty line)
+    # by a dashed separator. winget may prefix spinner/progress noise lines.
+    $headerIdx = -1
+    for ($i = 0; $i -lt $Lines.Count; $i++) {
+        $l = $Lines[$i]
+        if ($l -match '(^|\s)Id(\s)' -and $l -match '(^|\s)Version(\s|$)') {
+            $headerIdx = $i
+            break
+        }
+    }
+    if ($headerIdx -lt 0) { return $map }
+
+    $header = $Lines[$headerIdx]
+    $colId        = $header.IndexOf('Id')
+    $colVersion   = $header.IndexOf('Version')
+    $colAvailable = $header.IndexOf('Available')
+    $colSource    = $header.IndexOf('Source')
+    if ($colId -lt 0 -or $colVersion -lt 0) { return $map }
+
+    # Right edge of the Id column = start of Version; of Version = start of
+    # Available (or Source, or end-of-line when neither is present).
+    $idEnd = $colVersion
+    $verEnd = if ($colAvailable -ge 0) { $colAvailable } elseif ($colSource -ge 0) { $colSource } else { [int]::MaxValue }
+    $availEnd = if ($colSource -ge 0) { $colSource } else { [int]::MaxValue }
+
+    for ($i = $headerIdx + 1; $i -lt $Lines.Count; $i++) {
+        $line = $Lines[$i]
+        if ([string]::IsNullOrWhiteSpace($line)) { continue }
+        if ($line -match '^[-\u2500\s]+$') { continue }      # dashed separator
+        if ($line.Length -le $colId) { continue }
+
+        $slice = {
+            param($start, $end)
+            if ($start -lt 0 -or $start -ge $line.Length) { return '' }
+            $stop = [Math]::Min($end, $line.Length)
+            if ($stop -le $start) { return '' }
+            return $line.Substring($start, $stop - $start).Trim()
+        }
+
+        $id = & $slice $colId $idEnd
+        if (-not $id) { continue }
+        $installed = Format-VersionCell (& $slice $colVersion $verEnd)
+        $available = if ($colAvailable -ge 0) { Format-VersionCell (& $slice $colAvailable $availEnd) } else { '' }
+
+        $map[(Format-VersionCell $id).ToLowerInvariant()] = @{ Installed = $installed; Available = $available }
+    }
+    return $map
+}
+
+function ConvertFrom-ChocoOutdated {
+    # Parse `choco outdated -r --no-progress` machine-readable output:
+    #   <id>|<currentVersion>|<availableVersion>|<pinned>
+    # Returns @{ '<id>' = @{ Installed; Available } } for outdated packages.
+    [OutputType([hashtable])]
+    [CmdletBinding()]
+    param([Parameter(Position = 0)][string[]]$Lines)
+
+    $map = @{}
+    if (-not $Lines) { return $map }
+    foreach ($line in $Lines) {
+        if ([string]::IsNullOrWhiteSpace($line)) { continue }
+        $parts = $line.Split('|')
+        if ($parts.Count -lt 3) { continue }
+        $id = $parts[0].Trim()
+        if (-not $id) { continue }
+        $map[$id.ToLowerInvariant()] = @{ Installed = $parts[1].Trim(); Available = $parts[2].Trim() }
+    }
+    return $map
+}
+
+function ConvertFrom-NpmOutdated {
+    # Parse `npm outdated -g --json` output. The JSON is an object keyed by
+    # package name, each with { current, wanted, latest }. Returns
+    # @{ '<name>' = @{ Installed; Available } } for packages with a newer latest.
+    [OutputType([hashtable])]
+    [CmdletBinding()]
+    param([Parameter(Position = 0)][string]$Json)
+
+    $map = @{}
+    if ([string]::IsNullOrWhiteSpace($Json)) { return $map }
+    try { $obj = $Json | ConvertFrom-Json -ErrorAction Stop } catch { return $map }
+    if (-not $obj) { return $map }
+    foreach ($prop in $obj.PSObject.Properties) {
+        $entry = $prop.Value
+        $installed = [string]$entry.current
+        $available = [string]$entry.latest
+        $map[$prop.Name.ToLowerInvariant()] = @{ Installed = $installed; Available = $available }
+    }
+    return $map
+}
+
+function ConvertFrom-ScoopStatus {
+    # Parse `scoop status` fixed-width table. Newer scoop emits columns:
+    #   Name  Installed Version  Latest Version  Missing Dependencies  Info
+    # Only apps with an available update are listed. Returns
+    # @{ '<app>' = @{ Installed; Available } } keyed by bare app name.
+    [OutputType([hashtable])]
+    [CmdletBinding()]
+    param([Parameter(Position = 0)][string[]]$Lines)
+
+    $map = @{}
+    if (-not $Lines) { return $map }
+
+    $headerIdx = -1
+    for ($i = 0; $i -lt $Lines.Count; $i++) {
+        if ($Lines[$i] -match 'Installed Version' -and $Lines[$i] -match 'Latest Version') {
+            $headerIdx = $i; break
+        }
+    }
+    if ($headerIdx -lt 0) { return $map }
+
+    $header = $Lines[$headerIdx]
+    $colName      = $header.IndexOf('Name')
+    $colInstalled = $header.IndexOf('Installed Version')
+    $colLatest    = $header.IndexOf('Latest Version')
+    if ($colName -lt 0 -or $colInstalled -lt 0 -or $colLatest -lt 0) { return $map }
+
+    # Column after Latest Version (Missing Dependencies / Info) bounds the slice.
+    $colAfter = $header.IndexOf('Missing Dependencies')
+    if ($colAfter -lt 0) { $colAfter = $header.IndexOf('Info') }
+
+    for ($i = $headerIdx + 1; $i -lt $Lines.Count; $i++) {
+        $line = $Lines[$i]
+        if ([string]::IsNullOrWhiteSpace($line)) { continue }
+        if ($line -match '^[-\u2500\s]+$') { continue }
+        if ($line.Length -le $colName) { continue }
+
+        $slice = {
+            param($start, $end)
+            if ($start -lt 0 -or $start -ge $line.Length) { return '' }
+            $stop = [Math]::Min($end, $line.Length)
+            if ($stop -le $start) { return '' }
+            return $line.Substring($start, $stop - $start).Trim()
+        }
+
+        $name = & $slice $colName $colInstalled
+        if (-not $name) { continue }
+        $installed = & $slice $colInstalled $colLatest
+        $latestEnd = if ($colAfter -ge 0) { $colAfter } else { [int]::MaxValue }
+        $latest = & $slice $colLatest $latestEnd
+
+        $map[$name.ToLowerInvariant()] = @{ Installed = $installed; Available = $latest }
+    }
+    return $map
+}
+
+function Get-PackageUpdateIndex {
+    <#
+    .SYNOPSIS
+        Build a per-engine map of installed + available versions by running
+        each engine's bulk query ONCE. Used to make -WhatIf accurate and to
+        annotate results with a from -> to version transition (#283).
+
+    .DESCRIPTION
+        Returns a hashtable keyed by installer name. Each value is a hashtable
+        keyed by lower-cased package Id (bare app name for scoop) ->
+        @{ Installed; Available; UpdateAvailable }.
+
+          - winget : `winget list` (Available column populated when outdated)
+          - choco  : `choco list -lo -r` (installed) + `choco outdated -r` (available)
+          - scoop  : `scoop status` (only outdated apps)
+          - npmGlobal : `npm outdated -g --json`
+          - dotnetTool: `dotnet tool list -g` (installed only; Available unknown)
+
+        Only the engines named in -Installers are probed. Any probe failure
+        leaves that engine's map empty (callers treat a missing entry as
+        "unknown" and fall back to optimistic behaviour) -- a flaky probe must
+        never abort the sweep.
+    #>
+    [OutputType([hashtable])]
+    [CmdletBinding()]
+    param([string[]]$Installers)
+
+    $index = @{}
+    $want = [System.Collections.Generic.HashSet[string]]::new(
+        [string[]]@($Installers), [System.StringComparer]::OrdinalIgnoreCase)
+
+    if ($want.Contains('winget') -and (Get-Command winget -ErrorAction SilentlyContinue)) {
+        try {
+            # winget reads the attached console width (even when stdout is
+            # redirected) and truncates over-long Version / Available columns
+            # with an ellipsis. Temporarily widen the buffer so long versions
+            # (e.g. Warp's "v0.2026.05.27.15.44.stable_01") survive intact, then
+            # restore it. Guarded -- a headless / redirected host where the
+            # buffer can't be set just falls back to winget's default width.
+            $prevWidth = $null
+            try { $prevWidth = [Console]::BufferWidth } catch { $prevWidth = $null }
+            try { if ($null -ne $prevWidth -and $prevWidth -lt 512) { [Console]::BufferWidth = 512 } } catch { }
+            try {
+                $out = & winget list --accept-source-agreements 2>$null
+            } finally {
+                try { if ($null -ne $prevWidth -and $prevWidth -lt 512) { [Console]::BufferWidth = $prevWidth } } catch { }
+            }
+            $index['winget'] = ConvertFrom-WingetVersionTable @($out | ForEach-Object { [string]$_ })
+        } catch { Write-Verbose "Get-PackageUpdateIndex/winget: $($_.Exception.Message)"; $index['winget'] = @{} }
+    }
+
+    if ($want.Contains('choco') -and (Get-Command choco -ErrorAction SilentlyContinue)) {
+        try {
+            $installedOut = & choco list --local-only --limit-output --no-progress 2>$null
+            $cmap = @{}
+            foreach ($line in @($installedOut | ForEach-Object { [string]$_ })) {
+                if ([string]::IsNullOrWhiteSpace($line)) { continue }
+                $p = $line.Split('|')
+                if ($p.Count -lt 2) { continue }
+                $cid = $p[0].Trim()
+                if ($cid) { $cmap[$cid.ToLowerInvariant()] = @{ Installed = $p[1].Trim(); Available = '' } }
+            }
+            $outdatedOut = & choco outdated --limit-output --no-progress 2>$null
+            $omap = ConvertFrom-ChocoOutdated @($outdatedOut | ForEach-Object { [string]$_ })
+            foreach ($k in $omap.Keys) {
+                $cmap[$k] = @{ Installed = $omap[$k].Installed; Available = $omap[$k].Available }
+            }
+            $index['choco'] = $cmap
+        } catch { Write-Verbose "Get-PackageUpdateIndex/choco: $($_.Exception.Message)"; $index['choco'] = @{} }
+    }
+
+    if ($want.Contains('scoop') -and (Get-Command scoop -ErrorAction SilentlyContinue)) {
+        try {
+            $out = & scoop status *>&1
+            $index['scoop'] = ConvertFrom-ScoopStatus @($out | ForEach-Object { $_.ToString() })
+        } catch { Write-Verbose "Get-PackageUpdateIndex/scoop: $($_.Exception.Message)"; $index['scoop'] = @{} }
+    }
+
+    if ($want.Contains('npmGlobal') -and (Get-Command npm.cmd -ErrorAction SilentlyContinue)) {
+        try {
+            $out = & npm.cmd outdated -g --json 2>$null
+            $index['npmGlobal'] = ConvertFrom-NpmOutdated ([string]($out -join "`n"))
+        } catch { Write-Verbose "Get-PackageUpdateIndex/npm: $($_.Exception.Message)"; $index['npmGlobal'] = @{} }
+    }
+
+    if ($want.Contains('dotnetTool') -and (Get-Command dotnet -ErrorAction SilentlyContinue)) {
+        try {
+            $out = & dotnet tool list -g 2>$null | ForEach-Object { [string]$_ }
+            $dmap = @{}
+            foreach ($line in $out) {
+                # Rows: "<package id>   <version>   <commands>" after a dashed
+                # separator. Split on 2+ spaces; require a version-looking col 2.
+                if ($line -match '^\s*(\S+)\s{2,}(\S+)\s{2,}\S+') {
+                    $pid = $Matches[1].Trim()
+                    if ($pid -ieq 'Package' -or $pid -match '^-+$') { continue }
+                    $dmap[$pid.ToLowerInvariant()] = @{ Installed = $Matches[2].Trim(); Available = '' }
+                }
+            }
+            $index['dotnetTool'] = $dmap
+        } catch { Write-Verbose "Get-PackageUpdateIndex/dotnet: $($_.Exception.Message)"; $index['dotnetTool'] = @{} }
+    }
+
+    return $index
+}
+
+function Resolve-PackageVersionInfo {
+    <#
+    .SYNOPSIS
+        Look a single package up in the index produced by
+        Get-PackageUpdateIndex and return a uniform version record.
+
+    .DESCRIPTION
+        Returns @{ Present; Installed; Available; UpdateAvailable } where:
+          - Present         : $true if the engine map listed the package,
+                              $false if the map was built but the package was
+                              absent, $null if the engine wasn't probed (unknown).
+          - UpdateAvailable : $true / $false / $null (unknown).
+        Scoop is keyed by bare app name (the '<bucket>/<app>' Id minus the
+        bucket prefix), mirroring Update-ScoopPackage's own parsing.
+    #>
+    [OutputType([hashtable])]
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)][object]$Package,
+        [Parameter(Mandatory)][hashtable]$Index
+    )
+
+    $installer = [string]$Package.Installer
+    $id = [string]$Package.Id
+
+    # No engine map (engine not probed / not installed) => everything unknown.
+    if (-not $Index.ContainsKey($installer)) {
+        return @{ Present = $null; Installed = ''; Available = ''; UpdateAvailable = $null }
+    }
+    $map = $Index[$installer]
+
+    $key = $id.ToLowerInvariant()
+    if ($installer -eq 'scoop') {
+        $bucket, $app = $id -split '/', 2
+        if (-not $app) { $app = $bucket }
+        $key = $app.ToLowerInvariant()
+    }
+
+    if (-not $map.ContainsKey($key)) {
+        # winget/choco/dotnet maps list installed packages, so absence means
+        # not installed. scoop/npm maps list ONLY outdated packages, so
+        # absence means "installed and current" cannot be distinguished from
+        # "not installed" -- treat as present+current (optimistic: a genuine
+        # missing package surfaces as NotInstalled on the real run's probe).
+        if ($installer -in @('scoop', 'npmGlobal')) {
+            return @{ Present = $true; Installed = ''; Available = ''; UpdateAvailable = $false }
+        }
+        return @{ Present = $false; Installed = ''; Available = ''; UpdateAvailable = $null }
+    }
+
+    $entry = $map[$key]
+    $installed = [string]$entry.Installed
+    $available = [string]$entry.Available
+
+    # dotnetTool map carries installed only (Available always '') -> unknown.
+    if ($installer -eq 'dotnetTool') {
+        return @{ Present = $true; Installed = $installed; Available = ''; UpdateAvailable = $null }
+    }
+
+    $updateAvailable = [bool]($available -and $available -ne $installed)
+    return @{
+        Present         = $true
+        Installed       = $installed
+        Available       = $available
+        UpdateAvailable = $updateAvailable
+    }
+}

--- a/module/MarkMichaelis.ScoopBucket/Private/Select-PackageResultSummary.ps1
+++ b/module/MarkMichaelis.ScoopBucket/Private/Select-PackageResultSummary.ps1
@@ -1,0 +1,84 @@
+function Select-PackageResultSummary {
+    <#
+    .SYNOPSIS
+        Apply the default "changed rows only" view to a collected set of
+        PackageResults and print a one-line host summary of the rows that were
+        suppressed (#283).
+
+    .DESCRIPTION
+        Update-Package / Install-Package collect every PackageResult their
+        drivers emit (the full ledger) and pipe them through this helper before
+        returning to the user. By default only rows that represent an actual
+        change -- Updated / Installed / Uninstalled / Failed -- are emitted on
+        the success stream, and a host-only line (Write-Host, never captured)
+        reports the counts of the quiet rows, e.g.
+
+            Hidden: 14 already latest, 2 self-managed, 1 not installed   (-IncludeUnchanged to show all)
+
+        -IncludeUnchanged emits every row and omits the summary line. The line
+        is host-only so piping / Export-Csv still sees a clean object stream,
+        consistent with the #276 "only the table persists" design. PowerShell
+        renders host writes before the auto-formatted object table, so the line
+        appears just above the changed-only table.
+
+    .PARAMETER Result
+        The collected PackageResult objects (may be empty).
+
+    .PARAMETER IncludeUnchanged
+        Emit every row and skip the summary line.
+    #>
+    [OutputType([PackageResult])]
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)][AllowEmptyCollection()][object[]]$Result,
+        [switch]$IncludeUnchanged
+    )
+
+    # Rows that represent a real state change -- always shown.
+    $changed = @('Updated', 'Installed', 'Uninstalled', 'Failed')
+
+    if ($IncludeUnchanged) {
+        foreach ($r in $Result) { $r }
+        return
+    }
+
+    # Friendly label for each suppressed status, used to build the summary.
+    $labels = @{
+        AlreadyLatest       = 'already latest'
+        AlreadyInstalled    = 'already installed'
+        SelfManaged         = 'self-managed'
+        NoAutoUpdateSupport = 'no auto-update'
+        NotInstalled        = 'not installed'
+        Skipped             = 'skipped'
+    }
+
+    $suppressed = @{}
+    $shown = New-Object System.Collections.Generic.List[object]
+    foreach ($r in $Result) {
+        if ($changed -contains $r.Status) {
+            [void]$shown.Add($r)
+            continue
+        }
+        $label = if ($labels.ContainsKey($r.Status)) { $labels[$r.Status] } else { $r.Status.ToLowerInvariant() }
+        if ($suppressed.ContainsKey($label)) { $suppressed[$label]++ } else { $suppressed[$label] = 1 }
+    }
+
+    # Host-only summary of the suppressed rows. PowerShell renders host writes
+    # before the auto-formatted object table, so this reads as a lead-in line
+    # above the changed-only table (consistent with the dispatch messages the
+    # drivers already emit). The object stream below stays clean for piping /
+    # Export-Csv.
+    if ($suppressed.Count -gt 0) {
+        # Stable order: highest count first, then alphabetical, so the line
+        # reads the same way run-to-run.
+        $parts = $suppressed.GetEnumerator() |
+            Sort-Object @{ Expression = 'Value'; Descending = $true }, @{ Expression = 'Key'; Descending = $false } |
+            ForEach-Object { "$($_.Value) $($_.Key)" }
+        Write-Host ("Hidden: {0}   (-IncludeUnchanged to show all)" -f ($parts -join ', ')) -ForegroundColor DarkGray
+        # Blank line so the host summary reads as a distinct lead-in above the
+        # auto-formatted object table rather than colliding with its header.
+        Write-Host ''
+    }
+
+    foreach ($r in $shown) { $r }
+}

--- a/module/MarkMichaelis.ScoopBucket/Public/Install-Package.ps1
+++ b/module/MarkMichaelis.ScoopBucket/Public/Install-Package.ps1
@@ -50,6 +50,11 @@ function Install-Package {
         [Parameter(Mandatory, Position = 0)][string[]]$Name,
         [switch]$DryRun,
         [switch]$SkipCompletion,
+        # Show every package in the result table, including unchanged rows
+        # (AlreadyInstalled / Skipped). By default only changed rows
+        # (Installed / Failed) are shown and the rest are summarized in a
+        # one-line host message. See #283.
+        [switch]$IncludeUnchanged,
         [string]$BucketPath
     )
 
@@ -144,24 +149,30 @@ function Install-Package {
     # resilient sweep Update-Package uses (#272).
     $pkgErrors = [System.Collections.Generic.List[object]]::new()
 
+    # Collect every PackageResult the driver emits so the summary view can
+    # filter to changed rows and render a single table. See #283.
+    $results = New-Object System.Collections.Generic.List[object]
+
     # --- Dispatch (a): Package.Name flow with -Name filter -----------------
     # In-process: reconstruct real [Package] objects from the bundle and call
     # the driver directly (same model Update-Package uses), so results flow
     # back as live PackageResult objects rendered once by the format view.
     foreach ($entry in $byBundle.Values) {
         $pkgObjects = @(Get-BundlePackageObjects -BundlePath $entry.BundlePath)
-        Invoke-PackageInstall -Packages $pkgObjects -Bundle $entry.Bundle `
-            -Name @($entry.Names) -DryRun:$DryRun -SkipCompletion:$SkipCompletion `
-            -ErrorAction Continue -ErrorVariable +pkgErrors
+        $results.AddRange([object[]]@(
+            Invoke-PackageInstall -Packages $pkgObjects -Bundle $entry.Bundle `
+                -Name @($entry.Names) -DryRun:$DryRun -SkipCompletion:$SkipCompletion `
+                -ErrorAction Continue -ErrorVariable +pkgErrors))
     }
 
     # --- Dispatch (b): full-bundle install (no -Name filter) ---------------
     foreach ($b in $fullBundles) {
         Write-UpdateStatus -Activity 'Install-Package' "Install-Package: dispatching bundle '$($b.Bundle)' (all packages)..."
         $pkgObjects = @(Get-BundlePackageObjects -BundlePath $b.BundlePath)
-        Invoke-PackageInstall -Packages $pkgObjects -Bundle $b.Bundle `
-            -DryRun:$DryRun -SkipCompletion:$SkipCompletion `
-            -ErrorAction Continue -ErrorVariable +pkgErrors
+        $results.AddRange([object[]]@(
+            Invoke-PackageInstall -Packages $pkgObjects -Bundle $b.Bundle `
+                -DryRun:$DryRun -SkipCompletion:$SkipCompletion `
+                -ErrorAction Continue -ErrorVariable +pkgErrors))
     }
 
     # --- Dispatch (c): scoop install fallback for bare manifests -----------
@@ -220,4 +231,9 @@ function Install-Package {
             }
         }
     }
+
+    # Emit the collected results through the summary view: changed rows only by
+    # default (with a one-line host summary of the rest), or every row under
+    # -IncludeUnchanged. See #283.
+    Select-PackageResultSummary -Result $results.ToArray() -IncludeUnchanged:$IncludeUnchanged
 }

--- a/module/MarkMichaelis.ScoopBucket/Public/Invoke-PackageUpdate.ps1
+++ b/module/MarkMichaelis.ScoopBucket/Public/Invoke-PackageUpdate.ps1
@@ -68,6 +68,22 @@ function Invoke-PackageUpdate {
 
     Write-UpdateStatus "=== Invoke-PackageUpdate: $Bundle ($($ordered.Count) packages) ==="
 
+    # Build the version/availability index ONCE for every non-custom installer
+    # in scope (#283). It makes -WhatIf accurate (already-latest packages no
+    # longer masquerade as "will update") and supplies the `from -> to` version
+    # transition shown in the Details column. A flaky probe yields an empty map
+    # (Resolve-PackageVersionInfo then falls back to optimistic/unknown), so it
+    # never aborts the sweep.
+    $nonCustomInstallers = @(
+        $ordered |
+            Where-Object { $_.Installer -ne 'custom' -and -not $_.CustomInstallScript } |
+            ForEach-Object { [string]$_.Installer } |
+            Sort-Object -Unique
+    )
+    $updateIndex = if ($nonCustomInstallers.Count -gt 0) {
+        Get-PackageUpdateIndex -Installers $nonCustomInstallers
+    } else { @{} }
+
     $states = New-Object System.Collections.Generic.List[object]
     $total  = $ordered.Count
     $idx    = 0
@@ -79,8 +95,8 @@ function Invoke-PackageUpdate {
     # interleaved with each engine's live progress output. Pipeline
     # consumers are unaffected.
     $addState = {
-        param($p, $st, $rs, $err)
-        $states.Add([pscustomobject]@{ Pkg = $p; State = $st; Reason = $rs; Err = $err })
+        param($p, $st, $rs, $err, $from, $to)
+        $states.Add([pscustomobject]@{ Pkg = $p; State = $st; Reason = $rs; Err = $err; From = $from; To = $to })
     }
 
     # Build + write the standard Failed ErrorRecord, and record the state
@@ -100,6 +116,8 @@ function Invoke-PackageUpdate {
     foreach ($pkg in $ordered) {
         $state  = 'Pending'
         $reason = $null
+        $from   = $null
+        $to     = $null
         $idx++
         $pct = if ($total -gt 0) { [int](($idx - 1) / $total * 100) } else { 0 }
 
@@ -157,7 +175,7 @@ function Invoke-PackageUpdate {
                             # Metadata-only fallback path lost the scriptblock.
                             $result = @{ State = 'NoAutoUpdateSupport'; Reason = 'Reinstall requested but this package was loaded without its CustomInstallScript (metadata-only); Reinstall unavailable.' }
                         } elseif ($isWhatIf) {
-                            $result = @{ State = 'Updated'; Reason = '(WhatIf)' }
+                            $result = @{ State = 'Updated'; Reason = '(Reinstall) (WhatIf)' }
                         } else {
                             [void](& $pkg.CustomInstallScript $pkg)
                             if ($pkg.VerifyScript) {
@@ -180,13 +198,47 @@ function Invoke-PackageUpdate {
                     }
                 }
             } else {
-                $result = switch ($pkg.Installer) {
-                    'winget'      { Update-WingetPackage     -Package $pkg -WhatIf:$isWhatIf -TimeoutMinutes $PackageTimeoutMinutes }
-                    'scoop'       { Update-ScoopPackage      -Package $pkg -WhatIf:$isWhatIf }
-                    'choco'       { Update-ChocoPackage      -Package $pkg -WhatIf:$isWhatIf }
-                    'npmGlobal'   { Update-NpmGlobalPackage  -Package $pkg -WhatIf:$isWhatIf }
-                    'dotnetTool'  { Update-DotnetToolPackage -Package $pkg -WhatIf:$isWhatIf }
-                    default       { throw "Invoke-PackageUpdate: unknown Installer '$($pkg.Installer)' for '$($pkg.Name)'." }
+                # Probe this package's installed/available versions from the
+                # pre-built index (#283). Drives accurate -WhatIf and the
+                # `from -> to` Details annotation.
+                $verInfo = Resolve-PackageVersionInfo -Package $pkg -Index $updateIndex
+                if ($verInfo.Installed) { $from = $verInfo.Installed }
+
+                if ($isWhatIf) {
+                    # Dry run: decide the outcome from the probe instead of
+                    # invoking the engine. Already-latest packages now report
+                    # AlreadyLatest (=) rather than a misleading Updated (+).
+                    if ($verInfo.Present -eq $false) {
+                        $result = @{ State = 'NotInstalled'; Reason = $null }
+                    } elseif ($verInfo.UpdateAvailable -eq $true) {
+                        $to     = $verInfo.Available
+                        $result = @{ State = 'Updated'; Reason = '(WhatIf)' }
+                    } elseif ($verInfo.UpdateAvailable -eq $false) {
+                        $to     = $from
+                        $result = @{ State = 'AlreadyLatest'; Reason = $null }
+                    } else {
+                        # Availability unknown (dotnetTool, or the engine wasn't
+                        # probed): can't promise a no-op, so plan the update but
+                        # say so.
+                        $result = @{ State = 'Updated'; Reason = '(WhatIf, version unknown)' }
+                    }
+                } else {
+                    $result = switch ($pkg.Installer) {
+                        'winget'      { Update-WingetPackage     -Package $pkg -WhatIf:$isWhatIf -TimeoutMinutes $PackageTimeoutMinutes }
+                        'scoop'       { Update-ScoopPackage      -Package $pkg -WhatIf:$isWhatIf }
+                        'choco'       { Update-ChocoPackage      -Package $pkg -WhatIf:$isWhatIf }
+                        'npmGlobal'   { Update-NpmGlobalPackage  -Package $pkg -WhatIf:$isWhatIf }
+                        'dotnetTool'  { Update-DotnetToolPackage -Package $pkg -WhatIf:$isWhatIf }
+                        default       { throw "Invoke-PackageUpdate: unknown Installer '$($pkg.Installer)' for '$($pkg.Name)'." }
+                    }
+                    # Annotate the version transition from the pre-update probe.
+                    # On a real upgrade the index's Available column is the
+                    # version we just moved TO; AlreadyLatest pins to == from.
+                    if ($result.State -eq 'Updated' -and $verInfo.Available) {
+                        $to = $verInfo.Available
+                    } elseif ($result.State -eq 'AlreadyLatest') {
+                        $to = $from
+                    }
                 }
             }
             $state  = $result.State
@@ -208,7 +260,7 @@ function Invoke-PackageUpdate {
         # PostUpdateScript on a no-op upgrade would surprise bundle authors
         # who only intend the hook to fire after a real version bump.
         if ($state -in @('NotInstalled', 'Skipped', 'AlreadyLatest', 'SelfManaged', 'NoAutoUpdateSupport')) {
-            & $addState $pkg $state $reason $null
+            & $addState $pkg $state $reason $null $from $to
             continue
         }
 
@@ -244,7 +296,7 @@ function Invoke-PackageUpdate {
             }
         }
 
-        & $addState $pkg $state $reason $null
+        & $addState $pkg $state $reason $null $from $to
     }
 
     # Tear down the transient progress line before emitting results so the
@@ -257,15 +309,17 @@ function Invoke-PackageUpdate {
     # structured .Error ErrorRecord on failures.
     foreach ($s in $states) {
         [PackageResult]@{
-            Operation = 'Update'
-            Status    = $s.State
-            Name      = $s.Pkg.Name
-            Installer = $s.Pkg.Installer
-            Scope     = $s.Pkg.Scope
-            Id        = $s.Pkg.Id
-            Bundle    = $Bundle
-            Reason    = $s.Reason
-            Error     = $s.Err
+            Operation   = 'Update'
+            Status      = $s.State
+            Name        = $s.Pkg.Name
+            Installer   = $s.Pkg.Installer
+            Scope       = $s.Pkg.Scope
+            Id          = $s.Pkg.Id
+            Bundle      = $Bundle
+            VersionFrom = $s.From
+            VersionTo   = $s.To
+            Reason      = $s.Reason
+            Error       = $s.Err
         }
     }
 }

--- a/module/MarkMichaelis.ScoopBucket/Public/Update-Package.ps1
+++ b/module/MarkMichaelis.ScoopBucket/Public/Update-Package.ps1
@@ -117,6 +117,11 @@ function Update-Package {
         [switch]$MachineWide,
         [switch]$SkipCompletion,
         [switch]$SkipBucketRefresh,
+        # Show every package in the result table, including unchanged rows
+        # (AlreadyLatest / NotInstalled / SelfManaged / NoAutoUpdateSupport /
+        # Skipped). By default only changed rows (Updated / Failed) are shown
+        # and the rest are summarized in a one-line host message. See #283.
+        [switch]$IncludeUnchanged,
         [string]$BucketPath,
         # Hard cap on per-package winget upgrade time (minutes). Default
         # 5 minutes (vast majority of winget upgrades finish in <60s).
@@ -137,7 +142,8 @@ function Update-Package {
     # the end of the run reminds users to run Update-PackageCompletion
     # manually since we can't tell which CLIs (if any) version-bumped.
     if ($MachineWide) {
-        Invoke-AllEnginesUpdate -DryRun:$isWhatIf
+        $mwResults = @(Invoke-AllEnginesUpdate -DryRun:$isWhatIf)
+        Select-PackageResultSummary -Result $mwResults -IncludeUnchanged:$IncludeUnchanged
         return
     }
 
@@ -300,6 +306,11 @@ function Update-Package {
     # WriteError into a terminating error at the call site). See issue #272.
     $pkgErrors = [System.Collections.Generic.List[object]]::new()
 
+    # Collect every PackageResult the drivers emit so the summary view can
+    # filter to changed rows (and render a single table for a '*' sweep rather
+    # than one table per bundle). See #283.
+    $results = New-Object System.Collections.Generic.List[object]
+
     # Dispatch (a): selective per-bundle Name filter.
     foreach ($entry in $byBundle.Values) {
         $pkgObjects = @(Get-BundlePackageObjects -BundlePath $entry.BundlePath)
@@ -308,10 +319,11 @@ function Update-Package {
             $pkgObjects = @($b.Packages | ForEach-Object { ConvertTo-PackageFromMetadata $_ })
         }
         Write-UpdateStatus "Update-Package: dispatching $($entry.Names -join ', ') via $($entry.Bundle)..."
-        Invoke-PackageUpdate -Packages $pkgObjects -Bundle $entry.Bundle `
-            -Name @($entry.Names) -WhatIf:$isWhatIf -SkipCompletion:$SkipCompletion `
-            -PackageTimeoutMinutes $PackageTimeoutMinutes `
-            -ErrorAction Continue -ErrorVariable +pkgErrors
+        $results.AddRange([object[]]@(
+            Invoke-PackageUpdate -Packages $pkgObjects -Bundle $entry.Bundle `
+                -Name @($entry.Names) -WhatIf:$isWhatIf -SkipCompletion:$SkipCompletion `
+                -PackageTimeoutMinutes $PackageTimeoutMinutes `
+                -ErrorAction Continue -ErrorVariable +pkgErrors))
     }
 
     # Dispatch (b): full-bundle update.
@@ -321,10 +333,11 @@ function Update-Package {
             $pkgObjects = @($b.Packages | ForEach-Object { ConvertTo-PackageFromMetadata $_ })
         }
         Write-UpdateStatus "Update-Package: dispatching bundle '$($b.Bundle)' (all packages)..."
-        Invoke-PackageUpdate -Packages $pkgObjects -Bundle $b.Bundle `
-            -WhatIf:$isWhatIf -SkipCompletion:$SkipCompletion `
-            -PackageTimeoutMinutes $PackageTimeoutMinutes `
-            -ErrorAction Continue -ErrorVariable +pkgErrors
+        $results.AddRange([object[]]@(
+            Invoke-PackageUpdate -Packages $pkgObjects -Bundle $b.Bundle `
+                -WhatIf:$isWhatIf -SkipCompletion:$SkipCompletion `
+                -PackageTimeoutMinutes $PackageTimeoutMinutes `
+                -ErrorAction Continue -ErrorVariable +pkgErrors))
     }
 
     # Dispatch (c): bare manifests — no declarative [Package] metadata,
@@ -346,4 +359,9 @@ function Update-Package {
     if ($failed.Count -gt 0) {
         Write-Warning "Update-Package: $($failed.Count) package update(s) failed; the sweep continued past each failure. See errors above for details."
     }
+
+    # Emit the collected results through the summary view: changed rows only by
+    # default (with a one-line host summary of the rest), or every row under
+    # -IncludeUnchanged. See #283.
+    Select-PackageResultSummary -Result $results.ToArray() -IncludeUnchanged:$IncludeUnchanged
 }


### PR DESCRIPTION
## Summary

Makes `Update-Package` / `Install-Package` output truthful and version-aware (#283). Previously `-WhatIf` marked every package "Updated" without checking whether an update actually existed, runs were noisy, and no version transition was shown.

### What changed

- **Accurate WhatIf** -- a new `Get-PackageUpdateIndex` probes each engine's installed/available versions once (`winget list`, `choco outdated`, `scoop status`, `npm outdated`, `dotnet tool list`). `Invoke-PackageUpdate` uses it under `-WhatIf` to report `Updated` only for packages with a real pending update, and `AlreadyLatest` otherwise.
- **Version transitions** -- `PackageResult` gains `VersionFrom` / `VersionTo` and a `Details()` method rendering `from -> to`. The format view is redesigned: glyph-only Status, Name first, no Id column, merged `Details` column.
- **Changed-only output** -- `Select-PackageResultSummary` shows only rows that changed (Updated / Installed / Uninstalled / Failed) plus a host-only `Hidden: N already latest, ...` summary line. `-IncludeUnchanged` shows every row.
- **Robust version parsing** -- winget version cells are sanitized and the probe buffer widened so long versions (e.g. Warp) are not truncated into mojibake.

### Verification

`Update-Package * -WhatIf` real output:

```
Hidden: 32 already latest, 19 not installed, 2 self-managed   (-IncludeUnchanged to show all)
   Name                       Installer   Scope    Details
-  ----                       ---------   -----    -------
+  Node.js                    choco       global   21.2.0 -> 26.2.0 (WhatIf)
+  Claude Desktop             winget      user     1.8555.0.0 -> 1.9659.2 (WhatIf)
+  Aspire CLI                 dotnetTool  global   13.3.2 (WhatIf)
+  Bitwarden                  winget      global   2026.3.1 -> 2026.5.0 (WhatIf)
+  Readwise Reader            custom      global   Reinstalled (WhatIf)
+  7-Zip                      winget      global   23.01 -> 26.01 (WhatIf)
```

Tests: 117 passed / 0 failed across the affected suites (UpdatePackage, InvokePackageInstallSummary, PackageResultDetails, PackageUpdateIndex, InstallPackageFilter).

Closes #283