### PR TITLE
feat(completion): changed-only output + Action column + -IncludeUnchanged

### DIFF
--- a/bucket/UpdatePackageCompletion.Tests.ps1
+++ b/bucket/UpdatePackageCompletion.Tests.ps1
@@ -120,7 +120,7 @@ Describe 'Update-PackageCompletion eligibility classification' -Tag 'Light' {
 
     It 'skips pscompletions packages whose CLI is not on PATH' {
         $results = Update-PackageCompletion -BucketPath $script:tmpBucket `
-            -ProfilePath $script:profilePath -WhatIf
+            -ProfilePath $script:profilePath -WhatIf -IncludeUnchanged
         $offPath = $results | Where-Object Cli -EQ $script:offPathCli
         $offPath | Should -Not -BeNullOrEmpty
         $offPath.Action | Should -Be 'Skipped'
@@ -170,7 +170,7 @@ Describe 'Update-PackageCompletion eligibility classification' -Tag 'Light' {
 
     It "ignores Completion='none' and packages without CliCommands" {
         $results = Update-PackageCompletion -BucketPath $script:tmpBucket `
-            -ProfilePath $script:profilePath -WhatIf
+            -ProfilePath $script:profilePath -WhatIf -IncludeUnchanged
         ($results | Where-Object Cli -EQ "$($script:onPathCli)-none") | Should -BeNullOrEmpty
         ($results | Where-Object Package -EQ 'NoCliCommands')          | Should -BeNullOrEmpty
     }
@@ -208,22 +208,80 @@ Describe 'Update-PackageCompletion eligibility classification' -Tag 'Light' {
         Set-Content -Path $script:profilePath -Value $existing -Encoding UTF8
 
         $results = Update-PackageCompletion -BucketPath $script:tmpBucket `
-            -ProfilePath $script:profilePath -WhatIf
+            -ProfilePath $script:profilePath -WhatIf -IncludeUnchanged
         $bw = $results | Where-Object Cli -EQ $script:onPathCli
         $bw.Action | Should -Be 'Preserved'
         $bw.Reason | Should -Match 'pass -Force'
     }
 
-    It 'returns row objects without writing a Write-Host summary (#276 quiet output)' {
+    It 'does not write a per-row Write-Host tally with -IncludeUnchanged (#276 quiet output)' {
         # The returned rows ARE the output; the old one-line Write-Host tally
-        # duplicated them (the anti-pattern removed from the package tables).
-        # It is now a transient Write-Verbose, so Write-Host must never fire.
+        # duplicated them. With -IncludeUnchanged there are no suppressed rows
+        # to summarize, so Write-Host must never fire.
         Mock -ModuleName MarkMichaelis.ScoopBucket Write-Host { }
 
         $results = Update-PackageCompletion -BucketPath $script:tmpBucket `
-            -ProfilePath $script:profilePath -WhatIf
+            -ProfilePath $script:profilePath -WhatIf -IncludeUnchanged
 
         $results | Should -Not -BeNullOrEmpty
         Should -Invoke -ModuleName MarkMichaelis.ScoopBucket Write-Host -Times 0 -Exactly
+    }
+}
+
+Describe 'Update-PackageCompletion changed-only output (#285)' -Tag 'Light' {
+    BeforeEach {
+        if (Test-Path $script:profilePath) { Remove-Item -LiteralPath $script:profilePath -Force }
+    }
+
+    It 'returns only changed rows (Registered / WhatIf) and suppresses Skipped by default' {
+        # Fresh profile + -WhatIf: every eligible on-PATH CLI is a WhatIf row
+        # (shown); the off-PATH CLI is Skipped (suppressed by default).
+        $results = Update-PackageCompletion -BucketPath $script:tmpBucket `
+            -ProfilePath $script:profilePath -WhatIf
+
+        ($results | Where-Object Action -EQ 'Skipped')  | Should -BeNullOrEmpty
+        ($results | Where-Object Cli -EQ $script:offPathCli) | Should -BeNullOrEmpty
+        ($results | Where-Object Action -EQ 'WhatIf')   | Should -Not -BeNullOrEmpty
+        ($results | ForEach-Object Action | Sort-Object -Unique) |
+            ForEach-Object { $_ | Should -BeIn @('Registered', 'WhatIf') }
+    }
+
+    It 'prints a host-only Hidden summary line for the suppressed rows' {
+        # Record every Write-Host line via a global list. ParameterFilter on
+        # the positional $Object is brittle across hosts, so we capture the
+        # rendered text directly and assert on the joined output.
+        $global:scoopBucketHostLines = New-Object System.Collections.Generic.List[string]
+        Mock -ModuleName MarkMichaelis.ScoopBucket Write-Host {
+            $global:scoopBucketHostLines.Add([string]$Object)
+        }
+
+        $null = Update-PackageCompletion -BucketPath $script:tmpBucket `
+            -ProfilePath $script:profilePath -WhatIf
+
+        try {
+            ($global:scoopBucketHostLines -join "`n") |
+                Should -Match 'Hidden: .*skipped.*-IncludeUnchanged'
+        } finally {
+            Remove-Variable -Name scoopBucketHostLines -Scope Global -ErrorAction Ignore
+        }
+    }
+
+    It '-IncludeUnchanged returns every row (including Skipped) and prints no Hidden line' {
+        Mock -ModuleName MarkMichaelis.ScoopBucket Write-Host { }
+
+        $all = Update-PackageCompletion -BucketPath $script:tmpBucket `
+            -ProfilePath $script:profilePath -WhatIf -IncludeUnchanged
+
+        ($all | Where-Object Action -EQ 'Skipped') | Should -Not -BeNullOrEmpty
+        Should -Invoke -ModuleName MarkMichaelis.ScoopBucket Write-Host -Times 0 -Exactly
+    }
+
+    It 'tags every returned row with the CompletionResult type name for the format view' {
+        $results = Update-PackageCompletion -BucketPath $script:tmpBucket `
+            -ProfilePath $script:profilePath -WhatIf
+        $results | Should -Not -BeNullOrEmpty
+        foreach ($r in $results) {
+            $r.PSObject.TypeNames | Should -Contain 'MarkMichaelis.ScoopBucket.CompletionResult'
+        }
     }
 }

--- a/module/MarkMichaelis.ScoopBucket/MarkMichaelis.ScoopBucket.format.ps1xml
+++ b/module/MarkMichaelis.ScoopBucket/MarkMichaelis.ScoopBucket.format.ps1xml
@@ -144,5 +144,55 @@
         </TableRowEntries>
       </TableControl>
     </View>
+    <View>
+      <Name>CompletionResult</Name>
+      <ViewSelectedBy>
+        <TypeName>MarkMichaelis.ScoopBucket.CompletionResult</TypeName>
+      </ViewSelectedBy>
+      <TableControl>
+        <TableHeaders>
+          <TableColumnHeader>
+            <Label>Action</Label>
+            <Width>11</Width>
+          </TableColumnHeader>
+          <TableColumnHeader>
+            <Label>Cli</Label>
+            <Width>20</Width>
+          </TableColumnHeader>
+          <TableColumnHeader>
+            <Label>Package</Label>
+            <Width>24</Width>
+          </TableColumnHeader>
+          <TableColumnHeader>
+            <Label>Mode</Label>
+            <Width>14</Width>
+          </TableColumnHeader>
+          <TableColumnHeader>
+            <Label>Reason</Label>
+          </TableColumnHeader>
+        </TableHeaders>
+        <TableRowEntries>
+          <TableRowEntry>
+            <TableColumnItems>
+              <TableColumnItem>
+                <PropertyName>Action</PropertyName>
+              </TableColumnItem>
+              <TableColumnItem>
+                <PropertyName>Cli</PropertyName>
+              </TableColumnItem>
+              <TableColumnItem>
+                <PropertyName>Package</PropertyName>
+              </TableColumnItem>
+              <TableColumnItem>
+                <PropertyName>Mode</PropertyName>
+              </TableColumnItem>
+              <TableColumnItem>
+                <PropertyName>Reason</PropertyName>
+              </TableColumnItem>
+            </TableColumnItems>
+          </TableRowEntry>
+        </TableRowEntries>
+      </TableControl>
+    </View>
   </ViewDefinitions>
 </Configuration>

--- a/module/MarkMichaelis.ScoopBucket/Public/Update-PackageCompletion.ps1
+++ b/module/MarkMichaelis.ScoopBucket/Public/Update-PackageCompletion.ps1
@@ -62,7 +62,8 @@ function Update-PackageCompletion {
     param(
         [string]$BucketPath,
         [switch]$Force,
-        [string]$ProfilePath
+        [string]$ProfilePath,
+        [switch]$IncludeUnchanged
     )
 
     $bundleArgs = @{}
@@ -167,7 +168,7 @@ function Update-PackageCompletion {
                     $results.Add([pscustomobject]@{
                         Cli = $cli; Package = $p.Name; Bundle = $b.Bundle
                         Mode = $effectiveMode; Action = 'WhatIf'; Source = 'Skipped'
-                        Reason = '-WhatIf or -Confirm declined.'
+                        Reason = '(would register)'
                     })
                     continue
                 }
@@ -200,9 +201,19 @@ function Update-PackageCompletion {
     }
 
     $arr = $results.ToArray()
-    # The returned row objects ARE the output -- a Write-Host summary here would
-    # duplicate them (the same anti-pattern removed from the package result
-    # tables). Mirror a one-line tally to the transient verbose stream only.
+
+    # Tag every row with a type name so the format view can render a tidy,
+    # consistent column set (mirrors the #283 PackageResult table).
+    foreach ($row in $arr) {
+        if ($row -and -not ($row.PSObject.TypeNames -contains 'MarkMichaelis.ScoopBucket.CompletionResult')) {
+            $row.PSObject.TypeNames.Insert(0, 'MarkMichaelis.ScoopBucket.CompletionResult')
+        }
+    }
+
+    # The returned row objects ARE the output -- a Write-Host tally of the
+    # VISIBLE rows would duplicate them (the anti-pattern removed from the
+    # package tables in #276). Mirror a one-line tally to the transient verbose
+    # stream only.
     $byAction = $arr | Group-Object Action | ForEach-Object { "$($_.Name)=$($_.Count)" }
     if ($byAction) {
         Write-Verbose "Update-PackageCompletion: $($byAction -join ', ')"
@@ -210,5 +221,34 @@ function Update-PackageCompletion {
         Write-Verbose 'Update-PackageCompletion: no eligible CLIs found.'
     }
 
-    return ,$arr
+    if ($IncludeUnchanged) {
+        return , $arr
+    }
+
+    # Changed-only view (#285): show only rows that represent an action --
+    # Registered (we wrote a block) or WhatIf (we would). Preserved (already in
+    # the profile) and Skipped (CLI absent / no native source) are the quiet
+    # majority; summarize their counts on a host-only line that, unlike the
+    # removed #276 tally, never duplicates a visible row.
+    $changed = @('Registered', 'WhatIf')
+    $shown = New-Object System.Collections.Generic.List[object]
+    $suppressed = @{}
+    foreach ($row in $arr) {
+        if ($changed -contains $row.Action) {
+            [void]$shown.Add($row)
+            continue
+        }
+        $label = "$($row.Action)".ToLowerInvariant()
+        if ($suppressed.ContainsKey($label)) { $suppressed[$label]++ } else { $suppressed[$label] = 1 }
+    }
+
+    if ($suppressed.Count -gt 0) {
+        $parts = $suppressed.GetEnumerator() |
+            Sort-Object @{ Expression = 'Value'; Descending = $true }, @{ Expression = 'Key'; Descending = $false } |
+            ForEach-Object { "$($_.Value) $($_.Key)" }
+        Write-Host ("Hidden: {0}   (-IncludeUnchanged to show all)" -f ($parts -join ', ')) -ForegroundColor DarkGray
+        Write-Host ''
+    }
+
+    return , $shown.ToArray()
 }


### PR DESCRIPTION
## Summary

Applies the #283 truthful-output style to `Update-PackageCompletion`.

- **Changed-only by default.** Returns only rows representing an action
  (`Registered` / `WhatIf`). The quiet majority (`Preserved` / `Skipped`)
  is summarized on a single host-only line:
  `Hidden: N skipped, M preserved   (-IncludeUnchanged to show all)`.
- **`-IncludeUnchanged`** restores every row (Registered / WhatIf / Preserved / Skipped).
- **Readable Action column.** Rows are tagged
  `MarkMichaelis.ScoopBucket.CompletionResult` and rendered through a new format
  view: `Action` / `Cli` / `Package` / `Mode` / `Reason`. The earlier
  glyph idea was dropped -- under `-WhatIf` every shown row is a preview so the
  glyph was always `?` (no signal); a plain word column is clearer, especially
  under `-IncludeUnchanged` where Registered/Preserved/Skipped mix.
- **`-WhatIf` reason** now reads `(would register)`.

## Sample (`-WhatIf -IncludeUnchanged`)

```
Action      Cli       Package              Mode     Reason
------      ---       -------              ----     ------
WhatIf      node      Node.js              native   (would register)
Skipped     gemini    Gemini CLI           native   CLI 'gemini' not on PATH.
WhatIf      dotnet    dotnet               native   (would register)
```

Default (no `-IncludeUnchanged`) hides the Skipped/Preserved rows and prints
the Hidden summary line instead.

## Tests

`Invoke-Pester -Path .\bucket\UpdatePackageCompletion.Tests.ps1` -> 11 passed.
Shared format file re-verified against `PackageResultDetails.Tests.ps1` -> 10 passed.

Closes #285