### PR TITLE
fix(completion): quiet -WhatIf output (suppress built-in What-if lines, blank Reason)

### DIFF
--- a/bucket/UpdatePackageCompletion.Tests.ps1
+++ b/bucket/UpdatePackageCompletion.Tests.ps1
@@ -285,3 +285,36 @@ Describe 'Update-PackageCompletion changed-only output (#285)' -Tag 'Light' {
         }
     }
 }
+
+Describe 'Update-PackageCompletion quiet -WhatIf output (#287)' -Tag 'Light' {
+    BeforeEach {
+        if (Test-Path $script:profilePath) { Remove-Item -LiteralPath $script:profilePath -Force }
+    }
+
+    It 'leaves the Reason empty on WhatIf preview rows (the Action column already says WhatIf)' {
+        $results = Update-PackageCompletion -BucketPath $script:tmpBucket `
+            -ProfilePath $script:profilePath -WhatIf -IncludeUnchanged
+
+        $whatIf = $results | Where-Object Action -EQ 'WhatIf'
+        $whatIf | Should -Not -BeNullOrEmpty
+        foreach ($row in $whatIf) {
+            $row.Reason | Should -BeNullOrEmpty
+        }
+    }
+
+    It 'tags WhatIf preview rows with Source=WhatIf (not Skipped)' {
+        # Distinguishes a -WhatIf preview (would register) from a genuine
+        # Skipped row, and guards the same branch that bypasses
+        # ShouldProcess (and therefore its built-in "What if:" host line).
+        # If the ShouldProcess-gated preview path is reinstated, these rows
+        # revert to Source='Skipped' and this fails.
+        $results = Update-PackageCompletion -BucketPath $script:tmpBucket `
+            -ProfilePath $script:profilePath -WhatIf -IncludeUnchanged
+
+        $whatIf = $results | Where-Object Action -EQ 'WhatIf'
+        $whatIf | Should -Not -BeNullOrEmpty
+        foreach ($row in $whatIf) {
+            $row.Source | Should -Be 'WhatIf'
+        }
+    }
+}

--- a/module/MarkMichaelis.ScoopBucket/Public/Update-PackageCompletion.ps1
+++ b/module/MarkMichaelis.ScoopBucket/Public/Update-PackageCompletion.ps1
@@ -53,9 +53,13 @@ function Update-PackageCompletion {
     .OUTPUTS
         PSCustomObject[] — one record per (Cli, Package) candidate,
         with Cli, Package, Bundle, Mode, Action (Registered | Preserved
-        | Skipped | WhatIf), Source (Native | Existing | Skipped —
-        'Existing' accompanies Action='Preserved'; PSCompletions was
-        removed in #241), and Reason fields.
+        | Skipped | WhatIf), Source (Native | Existing | Skipped |
+        WhatIf — 'Existing' accompanies Action='Preserved', 'WhatIf'
+        accompanies a -WhatIf preview row; PSCompletions was removed in
+        #241), and Reason fields. WhatIf preview rows carry an empty
+        Reason — the Action column already says 'WhatIf' — and do NOT
+        emit the built-in "What if:" host line (the returned summary
+        table is the single source of truth).
     #>
     [CmdletBinding(SupportsShouldProcess, ConfirmImpact = 'Medium')]
     [OutputType([pscustomobject[]])]
@@ -164,11 +168,32 @@ function Update-PackageCompletion {
                 }
 
                 $action = "Register $effectiveMode completion block for '$cli'"
+
+                # -WhatIf preview: record the would-be row WITHOUT calling
+                # $PSCmdlet.ShouldProcess. ShouldProcess's built-in
+                # "What if: Performing the operation ..." line is written
+                # straight to the host (it bypasses every output stream, so
+                # it can't be redirected) and merely duplicates this row in
+                # the summary table -- which is the single source of truth.
+                # The Action column already says 'WhatIf', so the Reason is
+                # left empty rather than a redundant '(would register)'.
+                if ($WhatIfPreference) {
+                    $results.Add([pscustomobject]@{
+                        Cli = $cli; Package = $p.Name; Bundle = $b.Bundle
+                        Mode = $effectiveMode; Action = 'WhatIf'; Source = 'WhatIf'
+                        Reason = ''
+                    })
+                    continue
+                }
+
+                # Real run (or -Confirm). ShouldProcess still gates the write
+                # and drives the -Confirm prompt; a declined prompt is a
+                # Skipped row, not a registration.
                 if (-not $PSCmdlet.ShouldProcess($profileTarget, $action)) {
                     $results.Add([pscustomobject]@{
                         Cli = $cli; Package = $p.Name; Bundle = $b.Bundle
-                        Mode = $effectiveMode; Action = 'WhatIf'; Source = 'Skipped'
-                        Reason = '(would register)'
+                        Mode = $effectiveMode; Action = 'Skipped'; Source = 'Skipped'
+                        Reason = 'Declined at the confirmation prompt.'
                     })
                     continue
                 }


### PR DESCRIPTION
## Summary

Fixes the noisy `Update-PackageCompletion -WhatIf` output. Closes #287.

### Before

One `What if: Performing the operation "Register native completion block for
'<cli>'" ...` host line per eligible CLI (27+ lines), **then** the summary
table -- which already lists every row as `Action = WhatIf`. The Reason column
also repeated `(would register)` on every WhatIf row.

### After

Only the summary table renders; the Reason is blank for WhatIf rows:

```
Hidden: 15 skipped, 9 preserved   (-IncludeUnchanged to show all)

Action      Cli       Package              Mode     Reason
------      ---       -------              ----     ------
WhatIf      node      Node.js              native
WhatIf      dotnet    dotnet               native
WhatIf      handle    Sysinternals Suite   native
...
```

### How

The built-in `What if:` line is emitted by `\.ShouldProcess` and
written straight to the host -- it bypasses every output stream, so it cannot be
redirected. The only way to suppress it is to not call ShouldProcess for the
preview. Under `\False` the function now records the would-be row
(`Source = WhatIf`, empty Reason) and continues. ShouldProcess is retained for
real writes and `-Confirm` (a declined prompt becomes a `Skipped` row).

### Not a bug (clarified in the issue)

- **Every Mode is `native`**: by design -- `Package` validation requires a
  `NativeCommandScript` for `Completion='auto'|'native'`, and `auto`
  always resolves to `native` now that PSCompletions was removed (#241).
- **Many `WhatIf` rows**: truthful -- the AllUsers profile holds only 11
  blocks and some CLI names drifted (`handle64` -> `handle`), so those CLIs
  have no matching block.

## Tests

`Invoke-Pester -Path .\bucket\UpdatePackageCompletion.Tests.ps1` -> 13 passed
(2 new: empty-Reason and Source=WhatIf, both fail on revert). Shared format
re-verified via `PackageResultDetails.Tests.ps1` -> 10 passed.