### PR TITLE
feat(completion): native (tool-sourced) vs curated Mode column (#289)

### DIFF
--- a/bucket/AIAgents.ps1
+++ b/bucket/AIAgents.ps1
@@ -151,6 +151,7 @@ Register-ArgumentCompleter -Native -CommandName npx -ScriptBlock {
         #              below mirrors that headlessly.
         CliCommands = @('warp','oz')
         Completion  = 'auto'
+        NativeCompletionKind = 'native'
         Notes       = 'Agentic AI terminal (warp.dev). One binary, two exposed entry points: `warp` (UI + CLI passthrough) and `oz` (the canonical "Oz CLI" used in Warp''s docs for agent / MCP / run management). The winget installer drops warp.exe at %LOCALAPPDATA%\Programs\Warp\ but does NOT add it to PATH; PostInstallScript copies warp.exe -> oz.exe in-place (warp uses argv[0] to brand its --help text and Register-ArgumentCompleter target, so a rename is required — a launcher shim would leave argv[0] as warp.exe) and registers both as scoop shims, mirroring the bcomp.com pattern in DeveloperBasePackages. Tab completion is sourced from the binary itself via `warp completions powershell` / `oz completions powershell` so it tracks whatever subcommands Warp ships. MCP wiring below intentionally skips Warp: Warp manages MCP servers via its in-app Settings > Agents > MCP servers UI (its own store); use `oz mcp` from CLI if parity with the JSON/TOML-wired agents is needed.'
         ExpectedCompletions = @{
             warp = @('--help','--version','agent','mcp','run','completions')

--- a/bucket/ClientBasePackages.ps1
+++ b/bucket/ClientBasePackages.ps1
@@ -173,6 +173,7 @@ Register-ArgumentCompleter -Native -CommandName sox -ScriptBlock {
         Scope       = 'user'
         CliCommands = @('todoist')
         Completion  = 'native'
+        NativeCompletionKind = 'native'
         NativeCommandScript = { todoist completion powershell }
         WingetExtraArgs = @('--silent', '--disable-interactivity')
         DependsOn   = @('Todoist')

--- a/bucket/DeveloperBasePackages.ps1
+++ b/bucket/DeveloperBasePackages.ps1
@@ -12,6 +12,7 @@ $Packages = [Package[]]@(
         Id          = 'main/dotnet'
         CliCommands = @('dotnet')
         Completion  = 'auto'
+        NativeCompletionKind = 'native'
         Notes       = 'Sources tab completion from the official `dotnet complete` API (https://learn.microsoft.com/en-us/dotnet/core/tools/enable-tab-autocomplete) instead of the third-party PSCompletions catalog so completions track whatever subcommands the installed SDK ships. Hand-curated ExpectedCompletions covers the canonical top-level verbs the test harness validates.'
         ExpectedCompletions = @{ dotnet = @('add','build','clean','pack','publish','restore','run','test') }
         NativeCommandScript = {

--- a/bucket/OSBasePackages.ps1
+++ b/bucket/OSBasePackages.ps1
@@ -218,6 +218,7 @@ Register-ArgumentCompleter -Native -CommandName ffmpeg -ScriptBlock {
         Id          = 'main/ripgrep'
         CliCommands = @('rg')
         Completion  = 'native'
+        NativeCompletionKind = 'native'
         NativeCommandScript = { rg --generate complete-powershell }
         Notes       = 'scoop main/ripgrep gives v14+, required for --generate complete-powershell. See #73.'
         ExpectedCompletions = @{ rg = @('--help','--version','--color') }

--- a/bucket/Package.Tests.ps1
+++ b/bucket/Package.Tests.ps1
@@ -257,6 +257,30 @@ Describe 'Package.Validate() — invariants' -Tag 'Light', 'Module' {
         { $p.Validate() } | Should -Throw -ExpectedMessage '*NativeCommandScript is required*'
     }
 
+    It 'rejects NativeCompletionKind when no NativeCommandScript is present' {
+        $p = [Package]@{
+            Name        = 'x'
+            Installer   = 'scoop'
+            Id          = 'main/x'
+            NativeCompletionKind = 'native'
+        }
+        { $p.Validate() } | Should -Throw -ExpectedMessage '*NativeCompletionKind*only valid alongside a NativeCommandScript*'
+    }
+
+    It 'accepts NativeCompletionKind alongside a NativeCommandScript' {
+        $p = [Package]@{
+            Name        = 'x'
+            Installer   = 'scoop'
+            Id          = 'main/x'
+            CliCommands = @('x')
+            Completion  = 'native'
+            NativeCompletionKind = 'native'
+            NativeCommandScript  = { 'x completion powershell' }
+            ExpectedCompletions  = @{ x = @('--help') }
+        }
+        $p.GetValidationError() | Should -BeNullOrEmpty
+    }
+
     It 'rejects self-referential DependsOn' {
         $p = [Package]@{
             Name      = 'x'

--- a/bucket/UpdatePackageCompletion.Tests.ps1
+++ b/bucket/UpdatePackageCompletion.Tests.ps1
@@ -19,7 +19,8 @@ BeforeAll {
     #   pscompletions-bw       — pscompletions mode (eligible)
     #   pscompletions-other    — pscompletions mode but CLI NOT on PATH (skipped)
     #   auto-no-native         — auto mode, no NativeCommandScript (eligible)
-    #   auto-with-native       — auto mode, with NativeCommandScript  (skipped — repair can't rebuild native)
+    #   auto-with-native       — auto mode, NativeCommandScript + NativeCompletionKind='native' (Mode=native)
+    #   native-only            — native mode, NativeCommandScript, kind unset (Mode=curated default)
     #   none-mode              — Completion='none' (ignored entirely)
     #   no-clicommands         — Completion='auto' but CliCommands=@() (ignored)
     $script:tmpBucket = Join-Path ([System.IO.Path]::GetTempPath()) ("ScoopBucket-update-completion-$([guid]::NewGuid().ToString('N'))")
@@ -63,6 +64,7 @@ if (Test-Path `$scoopBucketPsd1) { Import-Module `$scoopBucketPsd1 -Force } else
         Id                  = 'Test.AutoWithNative'
         CliCommands         = @('$($script:onPathCli)-native')
         Completion          = 'auto'
+        NativeCompletionKind = 'native'
         NativeCommandScript = { 'auto-native-completion-source' }
     }
     [Package]@{
@@ -160,7 +162,9 @@ Describe 'Update-PackageCompletion eligibility classification' -Tag 'Light' {
         $nativeOnly | Should -Not -BeNullOrEmpty
         $nativeOnly.Action | Should -Be 'Registered'
         $nativeOnly.Source | Should -Be 'Native'
-        $nativeOnly.Mode   | Should -Be 'native'
+        # NativeOnly declares no NativeCompletionKind, so the hand-maintained
+        # default surfaces as 'curated' (#289).
+        $nativeOnly.Mode   | Should -Be 'curated'
 
         # v3 (#216): payload lives in the sidecar, not the profile.
         $sidecar = Join-Path (Split-Path -Parent $script:profilePath) "completions\$($script:onPathCli)-nativeonly.ps1"
@@ -190,7 +194,9 @@ Describe 'Update-PackageCompletion eligibility classification' -Tag 'Light' {
         # because that's the only registration path we can safely repair.
         $twin.Mode | Should -Be 'pscompletions'
 
-        # auto-mode WITH a NativeCommandScript now repairs via native too.
+        # auto-mode WITH a NativeCommandScript now repairs via native too;
+        # AutoWithNative declares NativeCompletionKind='native' so it shows
+        # the tool-sourced label (#289).
         $autoNative = $results | Where-Object Cli -EQ "$($script:onPathCli)-native"
         $autoNative | Should -Not -BeNullOrEmpty
         $autoNative.Action | Should -Be 'WhatIf'
@@ -199,7 +205,7 @@ Describe 'Update-PackageCompletion eligibility classification' -Tag 'Light' {
         $nativeOnly = $results | Where-Object Cli -EQ "$($script:onPathCli)-nativeonly"
         $nativeOnly | Should -Not -BeNullOrEmpty
         $nativeOnly.Action | Should -Be 'WhatIf'
-        $nativeOnly.Mode   | Should -Be 'native'
+        $nativeOnly.Mode   | Should -Be 'curated'
     }
 
     It "preserves existing sentinel blocks unless -Force is passed" {
@@ -316,5 +322,48 @@ Describe 'Update-PackageCompletion quiet -WhatIf output (#287)' -Tag 'Light' {
         foreach ($row in $whatIf) {
             $row.Source | Should -Be 'WhatIf'
         }
+    }
+}
+
+Describe 'Update-PackageCompletion native vs curated Mode (#289)' -Tag 'Light' {
+    BeforeEach {
+        if (Test-Path $script:profilePath) { Remove-Item -LiteralPath $script:profilePath -Force }
+    }
+
+    It "reports Mode='native' for packages whose completion is sourced from the tool (NativeCompletionKind='native')" {
+        # AutoWithNative declares NativeCompletionKind='native', modelling a
+        # tool-sourced completer (dotnet/rg/warp/todoist). The Mode column must
+        # say 'native' -- NOT the generic registration label.
+        $results = Update-PackageCompletion -BucketPath $script:tmpBucket `
+            -ProfilePath $script:profilePath -WhatIf -IncludeUnchanged
+
+        $row = $results | Where-Object Cli -EQ "$($script:onPathCli)-native"
+        $row | Should -Not -BeNullOrEmpty
+        $row.Mode | Should -Be 'native'
+    }
+
+    It "reports Mode='curated' for a NativeCommandScript package that leaves NativeCompletionKind unset" {
+        # NativeOnly ships a hand-maintained list with no NativeCompletionKind,
+        # so it must surface as 'curated' rather than the meaningless blanket
+        # 'native' the column produced before #289.
+        $results = Update-PackageCompletion -BucketPath $script:tmpBucket `
+            -ProfilePath $script:profilePath -WhatIf -IncludeUnchanged
+
+        $row = $results | Where-Object Cli -EQ "$($script:onPathCli)-nativeonly"
+        $row | Should -Not -BeNullOrEmpty
+        $row.Mode | Should -Be 'curated'
+    }
+
+    It 'never reports a blanket native Mode for every completion-bearing row' {
+        # Anti-regression for the original complaint: at least one native
+        # registration must be 'curated' so the column carries signal.
+        $results = Update-PackageCompletion -BucketPath $script:tmpBucket `
+            -ProfilePath $script:profilePath -WhatIf -IncludeUnchanged
+
+        $modes = $results |
+            Where-Object { $_.Source -eq 'Native' -or $_.Action -eq 'WhatIf' } |
+            ForEach-Object Mode | Sort-Object -Unique
+        $modes | Should -Contain 'curated'
+        $modes | Should -Contain 'native'
     }
 }

--- a/module/MarkMichaelis.ScoopBucket/Classes/Package.ps1
+++ b/module/MarkMichaelis.ScoopBucket/Classes/Package.ps1
@@ -47,6 +47,23 @@ class Package {
     # CompletionContract.Tests.ps1. Required whenever Completion != 'none'.
     [hashtable] $ExpectedCompletions = @{}
 
+    # Reporting-only classification of WHERE a native-completion block's
+    # contents come from. Surfaced as the 'Mode' column of
+    # Update-PackageCompletion so the output distinguishes:
+    #   'native'  - sourced live from the tool's own completion engine
+    #               (e.g. `dotnet complete`, `rg --generate
+    #               complete-powershell`, `warp completions powershell`,
+    #               `todoist completion powershell`); the registered block
+    #               tracks whatever subcommands the installed build ships.
+    #   'curated' - a hand-maintained subcommand/flag list shipped by this
+    #               bucket because the tool has no PowerShell-native
+    #               completion (e.g. bw, devenv, node, claude, 7z).
+    # Only meaningful alongside a NativeCommandScript. Defaults to '' which
+    # Update-PackageCompletion renders as 'curated' (the conservative,
+    # under-claiming label) so authors only opt INTO 'native'.
+    [ValidateSet('', 'native', 'curated')]
+    [string]   $NativeCompletionKind = ''
+
     [scriptblock] $NativeCommandScript
     [scriptblock] $CustomInstallScript
     [scriptblock] $CustomUninstallScript
@@ -149,6 +166,10 @@ class Package {
 
         if ($this.Completion -in @('native', 'auto') -and -not $this.NativeCommandScript) {
             return "Package '$($this.Name)': NativeCommandScript is required when Completion='$($this.Completion)'."
+        }
+
+        if ($this.NativeCompletionKind -and -not $this.NativeCommandScript) {
+            return "Package '$($this.Name)': NativeCompletionKind='$($this.NativeCompletionKind)' is only valid alongside a NativeCommandScript."
         }
 
         # Inverse direction: if a Package exposes CLIs on PATH, it MUST register

--- a/module/MarkMichaelis.ScoopBucket/Private/Get-BundlePackages.ps1
+++ b/module/MarkMichaelis.ScoopBucket/Private/Get-BundlePackages.ps1
@@ -104,6 +104,7 @@ function global:Invoke-PackageInstall {
             Scope       = `$p.Scope
             CliCommands = @(`$p.CliCommands)
             Completion  = `$p.Completion
+            NativeCompletionKind = `$p.NativeCompletionKind
             ExpectedCompletions = `$p.ExpectedCompletions
             NativeCommandOutputs = `$nativeOutputs
             DependsOn   = @(`$p.DependsOn)

--- a/module/MarkMichaelis.ScoopBucket/Public/Get-Package.ps1
+++ b/module/MarkMichaelis.ScoopBucket/Public/Get-Package.ps1
@@ -98,6 +98,7 @@ function Get-Package {
                 Scope       = $p.Scope
                 CliCommands = @($p.CliCommands)
                 Completion  = $p.Completion
+                NativeCompletionKind = $p.NativeCompletionKind
                 ExpectedCompletions = $expected
                 NativeCommandOutputs = $nativeOutputs
                 DependsOn   = @($p.DependsOn)

--- a/module/MarkMichaelis.ScoopBucket/Public/Update-PackageCompletion.ps1
+++ b/module/MarkMichaelis.ScoopBucket/Public/Update-PackageCompletion.ps1
@@ -60,6 +60,18 @@ function Update-PackageCompletion {
         Reason — the Action column already says 'WhatIf' — and do NOT
         emit the built-in "What if:" host line (the returned summary
         table is the single source of truth).
+
+        The Mode column reports how the completion block is sourced (#289):
+          native  — the block is produced live from the tool's own
+                    completion engine (dotnet/rg/warp/todoist), declared
+                    via the package's NativeCompletionKind='native'.
+          curated — a hand-maintained subcommand/flag list shipped by this
+                    bucket (the default for native registrations whose
+                    NativeCompletionKind is unset).
+          pscompletions — legacy class retained for schema compatibility;
+                    no packages resolve to it after #241.
+        Both native and curated use the same Register-ArgumentCompleter
+        -Native wiring; Mode describes the SOURCE, not the mechanism.
     #>
     [CmdletBinding(SupportsShouldProcess, ConfirmImpact = 'Medium')]
     [OutputType([pscustomobject[]])]
@@ -109,11 +121,26 @@ function Update-PackageCompletion {
                 $effectiveMode = if ($hasNative) { 'native' } else { 'pscompletions' }
             }
 
+            # Reporting label for the Mode column. A native registration is
+            # either 'native' (the block is sourced live from the tool's own
+            # completion engine -- dotnet/rg/warp/todoist) or 'curated' (a
+            # hand-maintained list this bucket ships because the tool has no
+            # PowerShell-native completion). The package declares which via
+            # NativeCompletionKind; an unset kind under-claims as 'curated'.
+            # The registration mechanism is identical for both
+            # (Register-ArgumentCompleter -Native), so $effectiveMode -- the
+            # value handed to Register-PackageCompletion below -- stays
+            # 'native'; only the displayed Mode differs.
+            $displayMode = $effectiveMode
+            if ($effectiveMode -eq 'native') {
+                $displayMode = if ("$($p.NativeCompletionKind)" -eq 'native') { 'native' } else { 'curated' }
+            }
+
             foreach ($cli in $p.CliCommands) {
                 if (-not (Get-Command $cli -ErrorAction SilentlyContinue)) {
                     $results.Add([pscustomobject]@{
                         Cli = $cli; Package = $p.Name; Bundle = $b.Bundle
-                        Mode = $effectiveMode; Action = 'Skipped'; Source = 'Skipped'
+                        Mode = $displayMode; Action = 'Skipped'; Source = 'Skipped'
                         Reason = "CLI '$cli' not on PATH."
                     })
                     continue
@@ -124,7 +151,7 @@ function Update-PackageCompletion {
                 if ($alreadyHas -and -not $Force) {
                     $results.Add([pscustomobject]@{
                         Cli = $cli; Package = $p.Name; Bundle = $b.Bundle
-                        Mode = $effectiveMode; Action = 'Preserved'; Source = 'Existing'
+                        Mode = $displayMode; Action = 'Preserved'; Source = 'Existing'
                         Reason = 'Sentinel block already in profile; pass -Force to refresh.'
                     })
                     continue
@@ -160,7 +187,7 @@ function Update-PackageCompletion {
                     if (-not $nativeArg) {
                         $results.Add([pscustomobject]@{
                             Cli = $cli; Package = $p.Name; Bundle = $b.Bundle
-                            Mode = $effectiveMode; Action = 'Skipped'; Source = 'Skipped'
+                            Mode = $displayMode; Action = 'Skipped'; Source = 'Skipped'
                             Reason = "No pre-captured native completion source for '$cli' (NativeCommandOutputs empty); re-run Install-Package to refresh."
                         })
                         continue
@@ -180,7 +207,7 @@ function Update-PackageCompletion {
                 if ($WhatIfPreference) {
                     $results.Add([pscustomobject]@{
                         Cli = $cli; Package = $p.Name; Bundle = $b.Bundle
-                        Mode = $effectiveMode; Action = 'WhatIf'; Source = 'WhatIf'
+                        Mode = $displayMode; Action = 'WhatIf'; Source = 'WhatIf'
                         Reason = ''
                     })
                     continue
@@ -192,7 +219,7 @@ function Update-PackageCompletion {
                 if (-not $PSCmdlet.ShouldProcess($profileTarget, $action)) {
                     $results.Add([pscustomobject]@{
                         Cli = $cli; Package = $p.Name; Bundle = $b.Bundle
-                        Mode = $effectiveMode; Action = 'Skipped'; Source = 'Skipped'
+                        Mode = $displayMode; Action = 'Skipped'; Source = 'Skipped'
                         Reason = 'Declined at the confirmation prompt.'
                     })
                     continue
@@ -209,7 +236,7 @@ function Update-PackageCompletion {
                     $r = Register-PackageCompletion @registerArgs
                     $results.Add([pscustomobject]@{
                         Cli = $cli; Package = $p.Name; Bundle = $b.Bundle
-                        Mode = $effectiveMode
+                        Mode = $displayMode
                         Action = $(if ($r.Source -eq 'Skipped') { 'Skipped' } else { 'Registered' })
                         Source = $r.Source
                         Reason = $r.Reason
@@ -217,7 +244,7 @@ function Update-PackageCompletion {
                 } catch {
                     $results.Add([pscustomobject]@{
                         Cli = $cli; Package = $p.Name; Bundle = $b.Bundle
-                        Mode = $effectiveMode; Action = 'Skipped'; Source = 'Skipped'
+                        Mode = $displayMode; Action = 'Skipped'; Source = 'Skipped'
                         Reason = "Register-PackageCompletion threw: $($_.Exception.Message)"
                     })
                 }


### PR DESCRIPTION
## Summary

`Update-PackageCompletion` reported `Mode = native` for every
completion-bearing package, so the column carried no signal. Since #241
removed the PSCompletions path and `Package` validation requires a
`NativeCommandScript` for `Completion='native'|'auto'`, `auto` always
collapsed to `native`. The word "native" also misleadingly named the
wiring mechanism (`Register-ArgumentCompleter -Native`), not whether the
tool actually ships native completion.

This makes the `Mode` column meaningful by reporting where the completer's
contents come from:

- `native`  -> sourced live from the tool's own completion engine
  (`dotnet`, `rg`, `warp`/`oz`, `todoist`).
- `curated` -> a hand-maintained subcommand/flag list this bucket ships
  because the tool has no PowerShell-native completion (`bw`, `devenv`,
  `node`, `claude`, `7z`, ...).

## Changes

- Add a validated `NativeCompletionKind` (`'' | 'native' | 'curated'`)
  field to the `Package` class. Author intent -- not a fragile text
  heuristic. Validation rejects the field when no `NativeCommandScript` is
  present.
- Thread `NativeCompletionKind` through the bundle loader probe
  (`Get-BundlePackages`) and the `Get-Package` flattener so it survives the
  round-trip.
- Render the value in `Update-PackageCompletion`'s `Mode` column. An unset
  kind under-claims as `curated`, so authors only opt INTO `native`. The
  registration mechanism is unchanged; only the displayed label differs.
- Mark the four tool-sourced packages (`dotnet`, `ripgrep`, `Warp`,
  `Todoist CLI`) as `NativeCompletionKind='native'`.

## Sample output

```
Cli       Package            Mode
---       -------            ----
bw        Bitwarden CLI      curated
node      Node.js            curated
procexp   Sysinternals Suite curated
dotnet    dotnet             native
warp      Warp               native
oz        Warp               native
```

## Tests

- New `Describe 'Update-PackageCompletion native vs curated Mode (#289)'`
  block (native row, curated row, anti-blanket regression).
- New `Package` validation tests for `NativeCompletionKind`.
- Updated existing `Mode` assertions to the new labels.
- Full safe bucket sweep (excluding Heavy/CliAvailability/Integration):
  1327 passed, 0 failed.

Closes #289
