### PR TITLE
feat(install): register declared completions when installing by manifest name (#291)

### DIFF
--- a/bucket/InstallPackageManifestCompletion.Tests.ps1
+++ b/bucket/InstallPackageManifestCompletion.Tests.ps1
@@ -1,0 +1,125 @@
+#requires -Version 7.0
+#requires -Modules @{ ModuleName = 'Pester'; ModuleVersion = '5.0.0' }
+
+# Pester regression test for #291: Install-Package dispatched through the
+# bare-manifest fallback (path c) must register the tab-completions that a
+# declarative [Package] declares for that same manifest. The mapping key is
+# [Package].Id with the owner prefix stripped (e.g. 'Owner/VsTest' -> 'VsTest'),
+# matched case-insensitively against the requested manifest base name.
+#
+# Before the fix, `Install-Package -Name 'VsTest'` resolved a bare
+# '<name>.json' manifest, ran `scoop install`, and registered NOTHING -- even
+# though a bundle declared the same manifest with CliCommands/Completion. After
+# the fix it registers the declared completers the same way the Package.Name
+# path already does.
+
+BeforeAll {
+    $script:repoRoot   = Split-Path -Parent $PSScriptRoot
+    $script:moduleRoot = Join-Path $script:repoRoot 'module\MarkMichaelis.ScoopBucket'
+    $script:psd1       = Join-Path $script:moduleRoot 'MarkMichaelis.ScoopBucket.psd1'
+
+    Import-Module $script:psd1 -Force
+
+    # Throwaway bucket: one declarative bundle that declares a package whose
+    # Id ('Owner/VsTest') maps to a sibling 'VsTest.json' manifest, plus a
+    # truly metadata-less 'LonePkg.json' manifest with no declaring [Package].
+    $script:tmpBucket = Join-Path ([System.IO.Path]::GetTempPath()) ("ScoopBucket-manifest-comp-$([guid]::NewGuid().ToString('N'))")
+    New-Item -ItemType Directory -Path $script:tmpBucket | Out-Null
+
+    $bundleText = @"
+`$scoopBucketPsd1 = '$($script:psd1 -replace "'","''")'
+if (Test-Path `$scoopBucketPsd1) { Import-Module `$scoopBucketPsd1 -Force } else { Import-Module MarkMichaelis.ScoopBucket -Force }
+
+`$Packages = [Package[]]@(
+    [Package]@{
+        Name        = 'Visual Studio Test'
+        Installer   = 'scoop'
+        Id          = 'Owner/VsTest'
+        CliCommands = @('devenv')
+        Completion  = 'auto'
+        ExpectedCompletions = @{ devenv = @('/Build','/Run') }
+        NativeCommandScript = { 'Register-ArgumentCompleter -Native -CommandName devenv -ScriptBlock { }' }
+    }
+)
+
+Invoke-PackageInstall -Packages `$Packages -Bundle 'VsTestBundle'
+"@
+    Set-Content -Path (Join-Path $script:tmpBucket 'VsTestBundle.ps1') -Value $bundleText -Encoding UTF8
+
+    # Sibling scoop manifest the bundle's package declares via Id. Its base
+    # name 'VsTest' != the Package.Name 'Visual Studio Test', so Install-Package
+    # routes it through path (c), not path (a).
+    $vsManifest = @{
+        '$schema'  = 'https://raw.githubusercontent.com/lukesampson/scoop/master/schema.json'
+        version   = '1.00.000'
+        url       = @('https://example.invalid/vstest')
+        installer = @{ script = @('Write-Host vstest install') }
+    }
+    Set-Content -LiteralPath (Join-Path $script:tmpBucket 'VsTest.json') `
+        -Value ($vsManifest | ConvertTo-Json -Depth 4) -Encoding UTF8
+
+    # A truly metadata-less manifest: no [Package] declares it.
+    $loneManifest = @{
+        '$schema'  = 'https://raw.githubusercontent.com/lukesampson/scoop/master/schema.json'
+        version   = '1.00.000'
+        url       = @('https://example.invalid/lone')
+        installer = @{ script = @('Write-Host lone install') }
+    }
+    Set-Content -LiteralPath (Join-Path $script:tmpBucket 'LonePkg.json') `
+        -Value ($loneManifest | ConvertTo-Json -Depth 4) -Encoding UTF8
+}
+
+AfterAll {
+    if ($script:tmpBucket -and (Test-Path $script:tmpBucket)) {
+        Remove-Item -LiteralPath $script:tmpBucket -Recurse -Force -ErrorAction Ignore
+    }
+}
+
+Describe 'Install-Package bare-manifest completion (#291)' -Tag 'Light', 'Module' {
+
+    BeforeEach {
+        # Never actually shell out to scoop; the dispatch path runs
+        # `& scoop install <name>` from module scope.
+        Mock -ModuleName MarkMichaelis.ScoopBucket scoop { }
+        # Capture (and suppress) the in-session + persistent registration so
+        # the test asserts INVOCATION rather than depending on the CLI being
+        # present or on $PROFILE.AllUsersAllHosts being writable.
+        Mock -ModuleName MarkMichaelis.ScoopBucket Import-PackageCompletion { @() }
+        Mock -ModuleName MarkMichaelis.ScoopBucket Register-PackageCompletion { @{ Source = 'Native'; Action = 'Registered'; Reason = $null } }
+    }
+
+    It 'registers the declared devenv completer when installing by the manifest name' {
+        Install-Package -Name 'VsTest' -BucketPath $script:tmpBucket | Out-Null
+
+        # In-session import is invoked with the declaring package (devenv CLI).
+        Should -Invoke -ModuleName MarkMichaelis.ScoopBucket Import-PackageCompletion -Times 1 -Exactly -ParameterFilter {
+            $Package -and (@($Package).CliCommands -contains 'devenv')
+        }
+        # Persistent sentinel-block registration is invoked for devenv too,
+        # consistent with how the Package.Name path (a) registers completers.
+        Should -Invoke -ModuleName MarkMichaelis.ScoopBucket Register-PackageCompletion -Times 1 -Exactly -ParameterFilter {
+            $Cli -eq 'devenv'
+        }
+        # The manifest still got installed via scoop.
+        Should -Invoke -ModuleName MarkMichaelis.ScoopBucket scoop -ParameterFilter {
+            ($args -contains 'install') -and ($args -contains 'VsTest')
+        }
+    }
+
+    It 'does NOT register completion for a metadata-less manifest, but still installs it' {
+        Install-Package -Name 'LonePkg' -BucketPath $script:tmpBucket | Out-Null
+
+        Should -Invoke -ModuleName MarkMichaelis.ScoopBucket Import-PackageCompletion -Times 0 -Exactly
+        Should -Invoke -ModuleName MarkMichaelis.ScoopBucket Register-PackageCompletion -Times 0 -Exactly
+        Should -Invoke -ModuleName MarkMichaelis.ScoopBucket scoop -ParameterFilter {
+            ($args -contains 'install') -and ($args -contains 'LonePkg')
+        }
+    }
+
+    It 'skips completion registration entirely under -SkipCompletion' {
+        Install-Package -Name 'VsTest' -SkipCompletion -BucketPath $script:tmpBucket | Out-Null
+
+        Should -Invoke -ModuleName MarkMichaelis.ScoopBucket Import-PackageCompletion -Times 0 -Exactly
+        Should -Invoke -ModuleName MarkMichaelis.ScoopBucket Register-PackageCompletion -Times 0 -Exactly
+    }
+}

--- a/bucket/InstallPackageManifestCompletion.Tests.ps1
+++ b/bucket/InstallPackageManifestCompletion.Tests.ps1
@@ -79,8 +79,9 @@ Describe 'Install-Package bare-manifest completion (#291)' -Tag 'Light', 'Module
 
     BeforeEach {
         # Never actually shell out to scoop; the dispatch path runs
-        # `& scoop install <name>` from module scope.
-        Mock -ModuleName MarkMichaelis.ScoopBucket scoop { }
+        # `& scoop install <name>` from module scope. Report success so the
+        # post-install completion registration runs.
+        Mock -ModuleName MarkMichaelis.ScoopBucket scoop { $global:LASTEXITCODE = 0 }
         # Capture (and suppress) the in-session + persistent registration so
         # the test asserts INVOCATION rather than depending on the CLI being
         # present or on $PROFILE.AllUsersAllHosts being writable.
@@ -121,5 +122,20 @@ Describe 'Install-Package bare-manifest completion (#291)' -Tag 'Light', 'Module
 
         Should -Invoke -ModuleName MarkMichaelis.ScoopBucket Import-PackageCompletion -Times 0 -Exactly
         Should -Invoke -ModuleName MarkMichaelis.ScoopBucket Register-PackageCompletion -Times 0 -Exactly
+    }
+
+    It 'does NOT register completion when scoop install fails (non-zero exit)' {
+        # A failed install must not leave behind completers for a CLI that was
+        # never actually installed.
+        Mock -ModuleName MarkMichaelis.ScoopBucket scoop { $global:LASTEXITCODE = 1 }
+
+        Install-Package -Name 'VsTest' -BucketPath $script:tmpBucket | Out-Null
+
+        Should -Invoke -ModuleName MarkMichaelis.ScoopBucket Import-PackageCompletion -Times 0 -Exactly
+        Should -Invoke -ModuleName MarkMichaelis.ScoopBucket Register-PackageCompletion -Times 0 -Exactly
+        # The install was still attempted.
+        Should -Invoke -ModuleName MarkMichaelis.ScoopBucket scoop -ParameterFilter {
+            ($args -contains 'install') -and ($args -contains 'VsTest')
+        }
     }
 }

--- a/bucket/InstallPackageManifestCompletion.Tests.ps1
+++ b/bucket/InstallPackageManifestCompletion.Tests.ps1
@@ -171,8 +171,8 @@ Describe 'Install-Package bare-manifest completion (#291)' -Tag 'Light', 'Module
         }
     }
 
-    It 'honors -WhatIf: neither installs the manifest nor registers completion' {
-        Install-Package -Name 'VsTest' -WhatIf -BucketPath $script:tmpBucket | Out-Null
+    It 'honors -DryRun uniformly: neither installs the manifest nor registers completion' {
+        Install-Package -Name 'VsTest' -DryRun -BucketPath $script:tmpBucket | Out-Null
 
         Should -Invoke -ModuleName MarkMichaelis.ScoopBucket scoop -Times 0 -Exactly
         Should -Invoke -ModuleName MarkMichaelis.ScoopBucket Import-PackageCompletion -Times 0 -Exactly

--- a/bucket/InstallPackageManifestCompletion.Tests.ps1
+++ b/bucket/InstallPackageManifestCompletion.Tests.ps1
@@ -138,4 +138,12 @@ Describe 'Install-Package bare-manifest completion (#291)' -Tag 'Light', 'Module
             ($args -contains 'install') -and ($args -contains 'VsTest')
         }
     }
+
+    It 'honors -WhatIf: neither installs the manifest nor registers completion' {
+        Install-Package -Name 'VsTest' -WhatIf -BucketPath $script:tmpBucket | Out-Null
+
+        Should -Invoke -ModuleName MarkMichaelis.ScoopBucket scoop -Times 0 -Exactly
+        Should -Invoke -ModuleName MarkMichaelis.ScoopBucket Import-PackageCompletion -Times 0 -Exactly
+        Should -Invoke -ModuleName MarkMichaelis.ScoopBucket Register-PackageCompletion -Times 0 -Exactly
+    }
 }

--- a/bucket/InstallPackageManifestCompletion.Tests.ps1
+++ b/bucket/InstallPackageManifestCompletion.Tests.ps1
@@ -40,6 +40,15 @@ if (Test-Path `$scoopBucketPsd1) { Import-Module `$scoopBucketPsd1 -Force } else
         ExpectedCompletions = @{ devenv = @('/Build','/Run') }
         NativeCommandScript = { 'Register-ArgumentCompleter -Native -CommandName devenv -ScriptBlock { }' }
     }
+    [Package]@{
+        Name        = 'Winget Declared'
+        Installer   = 'winget'
+        Id          = 'Vendor/WingetOnly'
+        CliCommands = @('wgtool')
+        Completion  = 'auto'
+        ExpectedCompletions = @{ wgtool = @('--x') }
+        NativeCommandScript = { 'Register-ArgumentCompleter -Native -CommandName wgtool -ScriptBlock { }' }
+    }
 )
 
 Invoke-PackageInstall -Packages `$Packages -Bundle 'VsTestBundle'
@@ -67,6 +76,19 @@ Invoke-PackageInstall -Packages `$Packages -Bundle 'VsTestBundle'
     }
     Set-Content -LiteralPath (Join-Path $script:tmpBucket 'LonePkg.json') `
         -Value ($loneManifest | ConvertTo-Json -Depth 4) -Encoding UTF8
+
+    # A manifest whose Id base name matches a declarative [Package] that is
+    # NOT a scoop package (Installer='winget'). The scoop-manifest dispatch
+    # must not borrow that package's completion -- the Id match would be
+    # coincidental.
+    $wingetManifest = @{
+        '$schema'  = 'https://raw.githubusercontent.com/lukesampson/scoop/master/schema.json'
+        version   = '1.00.000'
+        url       = @('https://example.invalid/wingetonly')
+        installer = @{ script = @('Write-Host wingetonly install') }
+    }
+    Set-Content -LiteralPath (Join-Path $script:tmpBucket 'WingetOnly.json') `
+        -Value ($wingetManifest | ConvertTo-Json -Depth 4) -Encoding UTF8
 }
 
 AfterAll {
@@ -136,6 +158,16 @@ Describe 'Install-Package bare-manifest completion (#291)' -Tag 'Light', 'Module
         # The install was still attempted.
         Should -Invoke -ModuleName MarkMichaelis.ScoopBucket scoop -ParameterFilter {
             ($args -contains 'install') -and ($args -contains 'VsTest')
+        }
+    }
+
+    It 'does NOT borrow completion from a non-scoop ([winget]) package whose Id base coincidentally matches' {
+        Install-Package -Name 'WingetOnly' -BucketPath $script:tmpBucket | Out-Null
+
+        Should -Invoke -ModuleName MarkMichaelis.ScoopBucket Import-PackageCompletion -Times 0 -Exactly
+        Should -Invoke -ModuleName MarkMichaelis.ScoopBucket Register-PackageCompletion -Times 0 -Exactly
+        Should -Invoke -ModuleName MarkMichaelis.ScoopBucket scoop -ParameterFilter {
+            ($args -contains 'install') -and ($args -contains 'WingetOnly')
         }
     }
 

--- a/module/MarkMichaelis.ScoopBucket/Public/Install-Package.ps1
+++ b/module/MarkMichaelis.ScoopBucket/Public/Install-Package.ps1
@@ -193,10 +193,11 @@ function Install-Package {
             Write-UpdateStatus -Activity 'Install-Package' "  [DryRun] scoop install $n"
             continue
         }
-        # Honor -WhatIf / -Confirm for the bare-manifest path too, so it is
-        # consistent with paths (a)/(b) which gate every engine call through
-        # Invoke-PackageInstall. Under -WhatIf this prints the standard
-        # "What if" line and skips both the install and the completion work.
+        # Honor -WhatIf / -Confirm for the bare-manifest path. Install-Package
+        # advertises SupportsShouldProcess, so gating the scoop install here
+        # makes -WhatIf/-Confirm skip the real install (and its completion
+        # work) instead of running it unconditionally. Under -WhatIf this
+        # prints the standard "What if" line and continues to the next name.
         if (-not $PSCmdlet.ShouldProcess($n, 'scoop install')) { continue }
         # Clear any stale $LASTEXITCODE first. If `scoop` resolves to a
         # PowerShell function/wrapper that runs no native command, it leaves

--- a/module/MarkMichaelis.ScoopBucket/Public/Install-Package.ps1
+++ b/module/MarkMichaelis.ScoopBucket/Public/Install-Package.ps1
@@ -198,6 +198,12 @@ function Install-Package {
         # Invoke-PackageInstall. Under -WhatIf this prints the standard
         # "What if" line and skips both the install and the completion work.
         if (-not $PSCmdlet.ShouldProcess($n, 'scoop install')) { continue }
+        # Clear any stale $LASTEXITCODE first. If `scoop` resolves to a
+        # PowerShell function/wrapper that runs no native command, it leaves
+        # $LASTEXITCODE untouched; a leftover non-zero value from an earlier
+        # command would otherwise be misread as a failed install and wrongly
+        # suppress completion. A null exit code is treated as success below.
+        $global:LASTEXITCODE = $null
         # Delegate to scoop. We pass the bare name (assumes the
         # MarkMichaelis bucket has been added — see
         # `Install-Package AddMarkMichaelisScoopBucket`); scoop will

--- a/module/MarkMichaelis.ScoopBucket/Public/Install-Package.ps1
+++ b/module/MarkMichaelis.ScoopBucket/Public/Install-Package.ps1
@@ -189,16 +189,15 @@ function Install-Package {
     $manifestPackagesToImport = New-Object System.Collections.Generic.List[object]
     foreach ($n in $manifestNames) {
         Write-UpdateStatus -Activity 'Install-Package' "Install-Package: dispatching manifest '$n' via scoop install (no declarative [Package] match)..."
+        # Preview mode is uniform across all dispatch paths: -DryRun is the
+        # module's single preview switch (paths (a)/(b) forward it to
+        # Invoke-PackageInstall; here we short-circuit). We deliberately do
+        # NOT add a path-specific -WhatIf gate, which would make preview
+        # behave differently here than for the Package.Name / bundle paths.
         if ($DryRun) {
             Write-UpdateStatus -Activity 'Install-Package' "  [DryRun] scoop install $n"
             continue
         }
-        # Honor -WhatIf / -Confirm for the bare-manifest path. Install-Package
-        # advertises SupportsShouldProcess, so gating the scoop install here
-        # makes -WhatIf/-Confirm skip the real install (and its completion
-        # work) instead of running it unconditionally. Under -WhatIf this
-        # prints the standard "What if" line and continues to the next name.
-        if (-not $PSCmdlet.ShouldProcess($n, 'scoop install')) { continue }
         # Clear any stale $LASTEXITCODE first. If `scoop` resolves to a
         # PowerShell function/wrapper that runs no native command, it leaves
         # $LASTEXITCODE untouched; a leftover non-zero value from an earlier

--- a/module/MarkMichaelis.ScoopBucket/Public/Install-Package.ps1
+++ b/module/MarkMichaelis.ScoopBucket/Public/Install-Package.ps1
@@ -208,7 +208,7 @@ function Install-Package {
         # CLI that was never actually installed. Treat a null exit code (no
         # native command ran, e.g. a stubbed scoop) as success so the
         # best-effort registration still fires in that case.
-        $installExit = $global:LASTEXITCODE
+        $installExit = $LASTEXITCODE
 
         if (-not $SkipCompletion -and ($null -eq $installExit -or $installExit -eq 0)) {
             # Find the declarative [Package] (if any) whose Id base name
@@ -219,6 +219,11 @@ function Install-Package {
             foreach ($b in $bundles) {
                 foreach ($p in $b.Packages) {
                     if (-not $p.Id) { continue }
+                    # Only scoop-installed packages can declare a scoop
+                    # manifest; an Id-base collision with a winget/choco/etc.
+                    # package is coincidental and must not borrow its
+                    # completion metadata.
+                    if ($p.Installer -ine 'scoop') { continue }
                     $manifestBase = ($p.Id -split '/')[-1]
                     if ($manifestBase -ieq $n -and $p.Completion -ne 'none') {
                         $declaring = $p

--- a/module/MarkMichaelis.ScoopBucket/Public/Install-Package.ps1
+++ b/module/MarkMichaelis.ScoopBucket/Public/Install-Package.ps1
@@ -193,6 +193,11 @@ function Install-Package {
             Write-UpdateStatus -Activity 'Install-Package' "  [DryRun] scoop install $n"
             continue
         }
+        # Honor -WhatIf / -Confirm for the bare-manifest path too, so it is
+        # consistent with paths (a)/(b) which gate every engine call through
+        # Invoke-PackageInstall. Under -WhatIf this prints the standard
+        # "What if" line and skips both the install and the completion work.
+        if (-not $PSCmdlet.ShouldProcess($n, 'scoop install')) { continue }
         # Delegate to scoop. We pass the bare name (assumes the
         # MarkMichaelis bucket has been added — see
         # `Install-Package AddMarkMichaelisScoopBucket`); scoop will

--- a/module/MarkMichaelis.ScoopBucket/Public/Install-Package.ps1
+++ b/module/MarkMichaelis.ScoopBucket/Public/Install-Package.ps1
@@ -198,8 +198,14 @@ function Install-Package {
         # `Install-Package AddMarkMichaelisScoopBucket`); scoop will
         # resolve and run the manifest's installer.script.
         & scoop install $n
+        # Capture scoop's exit status BEFORE any other command can clobber
+        # $LASTEXITCODE. A failed install must not register completers for a
+        # CLI that was never actually installed. Treat a null exit code (no
+        # native command ran, e.g. a stubbed scoop) as success so the
+        # best-effort registration still fires in that case.
+        $installExit = $global:LASTEXITCODE
 
-        if (-not $SkipCompletion) {
+        if (-not $SkipCompletion -and ($null -eq $installExit -or $installExit -eq 0)) {
             # Find the declarative [Package] (if any) whose Id base name
             # matches this manifest. The Id may carry an owner/bucket prefix
             # ('<owner>/<manifest>'); the manifest base name is the segment

--- a/module/MarkMichaelis.ScoopBucket/Public/Install-Package.ps1
+++ b/module/MarkMichaelis.ScoopBucket/Public/Install-Package.ps1
@@ -176,6 +176,17 @@ function Install-Package {
     }
 
     # --- Dispatch (c): scoop install fallback for bare manifests -----------
+    # Some bare `<name>.json` manifests are ALSO declared by a [Package] in a
+    # bundle via its Id (with the owner prefix stripped -- e.g. the package
+    # whose Id is 'MarkMichaelis/VisualStudio2026Enterprise' declares the
+    # 'VisualStudio2026Enterprise.json' manifest). Those packages carry the
+    # completion metadata (CliCommands / Completion / NativeCommandScript) that
+    # path (a) would register when installed by Package.Name. Resolve that
+    # declaring [Package] after the install so reaching a manifest by its
+    # *manifest* name registers the same completers path (a) does. Manifests
+    # with no declaring [Package] are genuinely metadata-less and dispatch as a
+    # plain `scoop install` with no completion (#291).
+    $manifestPackagesToImport = New-Object System.Collections.Generic.List[object]
     foreach ($n in $manifestNames) {
         Write-UpdateStatus -Activity 'Install-Package' "Install-Package: dispatching manifest '$n' via scoop install (no declarative [Package] match)..."
         if ($DryRun) {
@@ -187,6 +198,58 @@ function Install-Package {
         # `Install-Package AddMarkMichaelisScoopBucket`); scoop will
         # resolve and run the manifest's installer.script.
         & scoop install $n
+
+        if (-not $SkipCompletion) {
+            # Find the declarative [Package] (if any) whose Id base name
+            # matches this manifest. The Id may carry an owner/bucket prefix
+            # ('<owner>/<manifest>'); the manifest base name is the segment
+            # after the last '/'.
+            $declaring = $null
+            foreach ($b in $bundles) {
+                foreach ($p in $b.Packages) {
+                    if (-not $p.Id) { continue }
+                    $manifestBase = ($p.Id -split '/')[-1]
+                    if ($manifestBase -ieq $n -and $p.Completion -ne 'none') {
+                        $declaring = $p
+                        break
+                    }
+                }
+                if ($declaring) { break }
+            }
+
+            if ($declaring -and $declaring.CliCommands -and $declaring.CliCommands.Count -gt 0) {
+                # Persistent sentinel-block registration -- mirrors the path (a)
+                # flow in Invoke-PackageInstall so a fresh pwsh inherits the
+                # completers on next startup.
+                foreach ($cli in $declaring.CliCommands) {
+                    $registerArgs = @{ Cli = $cli; Mode = $declaring.Completion }
+                    if ($declaring.NativeCommandScript) { $registerArgs['NativeCommand'] = $declaring.NativeCommandScript }
+                    # Prefer the loader's pre-captured native completer text
+                    # (NativeCommandOutputs[$cli]) when present -- the live
+                    # NativeCommandScript scriptblock is stripped by the
+                    # Get-BundlePackages JSON round-trip.
+                    if ($declaring.PSObject.Properties.Name -contains 'NativeCommandOutputs' -and $declaring.NativeCommandOutputs) {
+                        $no = $declaring.NativeCommandOutputs
+                        $preCaptured = $null
+                        if ($no -is [hashtable] -and $no.ContainsKey($cli)) {
+                            $preCaptured = [string]$no[$cli]
+                        } elseif ($no.PSObject -and ($no.PSObject.Properties.Name -contains $cli)) {
+                            $preCaptured = [string]$no.$cli
+                        }
+                        if ($preCaptured -and $preCaptured.Trim()) {
+                            $registerArgs['PreCapturedNative'] = $preCaptured
+                        }
+                    }
+                    try {
+                        $null = Register-PackageCompletion @registerArgs
+                    } catch {
+                        Write-Warning "  $n/$cli completion registration failed: $($_.Exception.Message)"
+                    }
+                }
+                # Queue the declaring package for in-session import below.
+                [void]$manifestPackagesToImport.Add($declaring)
+            }
+        }
     }
 
     # --- Post-install: register completers in the caller's session ---------
@@ -221,6 +284,12 @@ function Install-Package {
             foreach ($p in $b.Packages) {
                 if ($p.Completion -ne 'none') { [void]$packagesToImport.Add($p) }
             }
+        }
+        # Path (c): packages whose manifest was installed via `scoop install`
+        # but that a bundle declares via Id (#291). Already filtered to
+        # Completion != 'none' and CliCommands present in the dispatch loop.
+        foreach ($p in $manifestPackagesToImport) {
+            [void]$packagesToImport.Add($p)
         }
         if ($packagesToImport.Count -gt 0) {
             $imported = Import-PackageCompletion -Package $packagesToImport


### PR DESCRIPTION
## Summary

Installing a package by its scoop manifest name (the bare-manifest fallback,
"path c") now registers that package's declared tab-completions, the same way
installing by its declarative `[Package].Name` (path a) already does.

Closes #291

## Problem

`Install-Package` classifies each requested name into three dispatch paths:

- (a) ByName - matches a `[Package].Name`; `Invoke-PackageInstall` registers completions.
- (b) FullBundle - bundle-name match; completions registered.
- (c) Bare-manifest fallback - a `<name>.json` manifest with no `[Package].Name` match. It ran `scoop install <name>` and registered NOTHING.

Concrete gap: `bucket/DeveloperBasePackages.ps1` declares a package with
`Name='Visual Studio'`, `Id='MarkMichaelis/VisualStudio2026Enterprise'`,
`CliCommands=@('devenv')`, `Completion='auto'`, and a curated
`NativeCommandScript`. The manifest is `bucket/VisualStudio2026Enterprise.json`.

- `Install-Package -Name 'Visual Studio'` -> path (a) -> devenv completion registered.
- `Install-Package -Name 'VisualStudio2026Enterprise'` -> path (c) -> scoop install runs but NO completion registered.

## Fix

In path (c), after `scoop install` succeeds, look for a declarative `[Package]`
whose `Id` base name (the segment after the last `/`, so any `<owner>/` prefix
is stripped) equals the requested manifest name (case-insensitive). When found
and its `Completion -ne 'none'` with CLI commands present:

- invoke the persistent sentinel-block registration (`Register-PackageCompletion`
  per CLI), mirroring how path (a) does it in `Invoke-PackageInstall`; and
- queue the declaring package for in-session import via `Import-PackageCompletion`.

Manifests with no declaring `[Package]` keep today's behavior exactly: a plain
`scoop install` with no completion.

## Tests

New `bucket/InstallPackageManifestCompletion.Tests.ps1` (Light, Module):

- installing by the manifest name registers the declared `devenv` completer
  (mocked `scoop install`; asserts `Import-PackageCompletion` and
  `Register-PackageCompletion` are invoked for `devenv`);
- a metadata-less manifest still dispatches `scoop install` with NO completion;
- `-SkipCompletion` suppresses all registration.

The primary test fails behaviorally (assertion, not parse error) when the
production change is reverted. All related Light suites pass (158).

Local command:

    Invoke-Pester -Path bucket/InstallPackageManifestCompletion.Tests.ps1 -Output Detailed

## Scope notes

- Secondary item (Update-Package bare-manifest completion) was intentionally
  left as-is: `Update-Package` still skips bare manifests with a warning. The
  same Id->manifest resolution could be applied there, but it adds branching to
  the update sweep for marginal benefit; tracked as a possible follow-up.
- Out of scope / known limitation: a RAW `scoop install <name>` invoked outside
  this module (bypassing `Install-Package`) still will not register completions.
  That would require per-manifest `post_install` hooks.
- Minor refactor note: the per-CLI registration block is duplicated inline with
  `Invoke-PackageInstall` (and `Update-PackageCompletion`), matching the
  existing codebase pattern; a shared helper is a possible future cleanup.