### PR TITLE
feat: add Android platform-tools (adb/fastboot) to DeveloperBasePackages

### DIFF
--- a/bucket/DeveloperBasePackages.ps1
+++ b/bucket/DeveloperBasePackages.ps1
@@ -169,6 +169,45 @@ Register-ArgumentCompleter -Native -CommandName python -ScriptBlock {
     }
 
     [Package]@{
+        Name        = 'Android Platform Tools'
+        Installer   = 'scoop'
+        Id          = 'main/adb'
+        CliCommands = @('adb','fastboot')
+        Completion  = 'auto'
+        Notes       = 'Android SDK platform-tools (adb/fastboot). scoop main/adb shims adb.exe and fastboot.exe automatically. Neither adb nor fastboot ships a `completions powershell` subcommand or a PSCompletions entry, so the completer is hand-curated (curated, not native -- #289/#293). Subcommand lists drawn from `adb --help` and `fastboot --help`.'
+        ExpectedCompletions = @{
+            adb      = @('devices','install','shell','logcat')
+            fastboot = @('devices','flash','reboot')
+        }
+        NativeCommandScript = {
+            @"
+Register-ArgumentCompleter -Native -CommandName adb -ScriptBlock {
+    param(`$wordToComplete, `$commandAst, `$cursorPosition)
+    @(
+        'devices','help','version','connect','disconnect','pair','push','pull','sync',
+        'shell','install','install-multiple','uninstall','logcat','forward','reverse',
+        'reboot','sideload','root','unroot','remount','bugreport','backup','restore',
+        'kill-server','start-server','get-state','get-serialno','wait-for-device','tcpip','emu',
+        '-s','-d','-e','-H','-P','-a'
+    ) | Where-Object { `$_ -like "`$wordToComplete*" } | ForEach-Object {
+        [System.Management.Automation.CompletionResult]::new(`$_, `$_, 'ParameterValue', `$_)
+    }
+}
+Register-ArgumentCompleter -Native -CommandName fastboot -ScriptBlock {
+    param(`$wordToComplete, `$commandAst, `$cursorPosition)
+    @(
+        'devices','flash','flashall','erase','format','getvar','boot','reboot',
+        'reboot-bootloader','continue','update','set_active','oem','flashing',
+        '--help','--version','-w','-s'
+    ) | Where-Object { `$_ -like "`$wordToComplete*" } | ForEach-Object {
+        [System.Management.Automation.CompletionResult]::new(`$_, `$_, 'ParameterValue', `$_)
+    }
+}
+"@
+        }
+    }
+
+    [Package]@{
         Name        = 'Aspire'
         Installer   = 'scoop'
         Id          = 'MarkMichaelis/Aspire'

--- a/bucket/DeveloperBasePackagesAdb.Tests.ps1
+++ b/bucket/DeveloperBasePackagesAdb.Tests.ps1
@@ -1,0 +1,85 @@
+#requires -Version 7.0
+#requires -Modules @{ ModuleName = 'Pester'; ModuleVersion = '5.0.0' }
+
+<#
+.SYNOPSIS
+    Behavior-first tests for the Android platform-tools (adb/fastboot) entry
+    in DeveloperBasePackages (issue #293).
+
+.DESCRIPTION
+    Locks in the contract that the bucket ships Android platform-tools via
+    scoop (main/adb) with curated PowerShell argument completers for both
+    `adb` and `fastboot`. Mirrors the pattern already in place for `python`,
+    `devenv`, `code`, `copilot`, and `aspire` in the same bundle.
+
+    These tests fail if the entry is removed or reverted to a non-scoop /
+    no-completion shape -- providing the regression guard.
+#>
+
+BeforeAll {
+    $scoopBucketPsd1 = Join-Path $PSScriptRoot '..\module\MarkMichaelis.ScoopBucket\MarkMichaelis.ScoopBucket.psd1'
+    if (Test-Path $scoopBucketPsd1) { Import-Module $scoopBucketPsd1 -Force } else { Import-Module MarkMichaelis.ScoopBucket -Force }
+    $script:pkgs = @(Get-Package -BucketPath $PSScriptRoot)
+    $script:adb = @($script:pkgs | Where-Object { $_.CliCommands -contains 'adb' })
+}
+
+Describe 'DeveloperBasePackages: Android platform-tools (issue #293)' -Tag 'Light','Bundle','Completion' {
+
+    It 'declares exactly one Android platform-tools entry in DeveloperBasePackages' {
+        $script:adb.Count | Should -Be 1
+        $script:adb[0].Bundle | Should -Be 'DeveloperBasePackages'
+    }
+
+    It 'installs via scoop from main/adb' {
+        $script:adb[0].Installer | Should -Be 'scoop'
+        $script:adb[0].Id | Should -Be 'main/adb'
+    }
+
+    It 'declares CliCommands adb and fastboot' {
+        @($script:adb[0].CliCommands) | Should -Contain 'adb'
+        @($script:adb[0].CliCommands) | Should -Contain 'fastboot'
+    }
+
+    It "uses Completion='auto'" {
+        $script:adb[0].Completion | Should -Be 'auto'
+    }
+
+    It 'is curated (no NativeCompletionKind -- adb has no native PS completion engine)' {
+        # adb/fastboot ship no `completions powershell` subcommand, so the
+        # completer is hand-curated, not sourced live from the tool (#289).
+        "$($script:adb[0].NativeCompletionKind)" | Should -Be ''
+    }
+
+    It 'ships a NativeCommandScript' {
+        $script:adb[0].HasNativeCommandScript | Should -BeTrue
+    }
+
+    It 'declares non-empty ExpectedCompletions for adb and fastboot' {
+        $script:adb[0].ExpectedCompletions.ContainsKey('adb') | Should -BeTrue
+        $script:adb[0].ExpectedCompletions.ContainsKey('fastboot') | Should -BeTrue
+        @($script:adb[0].ExpectedCompletions['adb']).Count | Should -BeGreaterThan 0
+        @($script:adb[0].ExpectedCompletions['fastboot']).Count | Should -BeGreaterThan 0
+        foreach ($expected in 'devices','install','shell') {
+            $script:adb[0].ExpectedCompletions['adb'] | Should -Contain $expected
+        }
+        foreach ($expected in 'devices','flash','reboot') {
+            $script:adb[0].ExpectedCompletions['fastboot'] | Should -Contain $expected
+        }
+    }
+
+    It 'NativeCommandScript renders Register-ArgumentCompleter -Native for adb and fastboot' {
+        foreach ($cli in 'adb','fastboot') {
+            $rendered = $script:adb[0].NativeCommandOutputs[$cli]
+            $rendered | Should -Not -BeNullOrEmpty
+            $rendered | Should -Match 'Register-ArgumentCompleter\s+-Native'
+            $rendered | Should -Match "-CommandName\s+$cli"
+        }
+    }
+
+    It 'NativeCommandScript exposes canonical adb subcommands' {
+        $rendered = $script:adb[0].NativeCommandOutputs['adb']
+        foreach ($sub in "'devices'","'install'","'shell'","'logcat'") {
+            $rendered | Should -BeLike "*$sub*"
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Adds Android SDK platform-tools (`adb` / `fastboot`) to the bucket as a scoop-installed `[Package]` in `DeveloperBasePackages`.

Scoop's `main` bucket already ships `adb` (currently 37.0.0), shimming `adb.exe` and `fastboot.exe`. By declaring it as a managed `[Package]`, `Invoke-PackageInstall` now:

- installs it via scoop (`adb` / `fastboot` shims created automatically), and
- registers curated tab-completion automatically -- no manual `Update-PackageCompletion` needed.

`adb` and `fastboot` ship no `completions powershell` subcommand and have no PSCompletions entry, so the completer is hand-curated (`curated`, not `native` -- per #289). Subcommand lists are drawn from `adb --help` / `fastboot --help`.

## Changes

- `bucket/DeveloperBasePackages.ps1` -- new `Android Platform Tools` entry (`scoop` / `main/adb`; `CliCommands = adb, fastboot`; `Completion = auto` with a `NativeCommandScript` registering `-Native` completers for both; `ExpectedCompletions` for both).
- `bucket/DeveloperBasePackagesAdb.Tests.ps1` -- behavior-first regression tests mirroring `DeveloperBasePackagesPython.Tests.ps1` (9 tests).

## Test

```
$cfg = New-PesterConfiguration
$cfg.Run.Path = 'bucket\DeveloperBasePackagesAdb.Tests.ps1'
$cfg.Run.PassThru = $true
$cfg.Filter.ExcludeTag = @('Heavy','CliAvailability','Integration','Slow','Install')
Invoke-Pester -Configuration $cfg
```

Local results: adb suite 9/9 passed; full safe sweep 1354 passed, 0 failed, 2 skipped.

Closes #293