### PR TITLE
feat: declarative ConfigScript package hook (config always runs, like completions)

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,9 +99,13 @@ The `[Package]` class enforces enums on `Installer` / `Source` / `Scope` /
 `Package.Validate()` for cross-field invariants).
 
 The driver pipeline (validate → topo sort by `DependsOn` → engine
-dispatch → `PostInstallScript` → completion register → completion verify
-via `[CommandCompletion]::CompleteInput`) closes the long-standing gap
-where tab-completion was registered but never end-to-end verified.
+dispatch → `PostInstallScript` → `ConfigScript` → completion register →
+completion verify via `[CommandCompletion]::CompleteInput`) closes the
+long-standing gap where tab-completion was registered but never
+end-to-end verified. `ConfigScript` (see below) is the declarative,
+always-run configuration hook -- it is re-applied on every install and
+every update, surviving the bundle AST harvest the module helper paths
+use.
 
 To use the module locally:
 
@@ -159,10 +163,12 @@ and `PackageManagement\Get-Package`.
 
 **Migration status:** OSBasePackages, DeveloperBasePackages,
 ClientBasePackages, ChatGPT, and Aspire have been migrated to the
-declarative pattern. AIAgents (with its MCP-server matrix logic) and
-the small config-only bundles (`GitConfigVisualStudio`,
-`SetPowerConfiguration`, `McAfeeUninstall`) remain imperative for now;
-the discovery and validation tools handle both forms transparently.
+declarative pattern. AIAgents is migrated, and its MCP-server matrix
+wiring now runs as a declarative `ConfigScript` (see **Refreshing package
+configuration** below) so the module helper paths re-apply it. The small
+config-only bundles (`GitConfigVisualStudio`, `SetPowerConfiguration`,
+`McAfeeUninstall`) remain imperative for now; the discovery and validation
+tools handle both forms transparently.
 
 ### Personal post-install customization (`MarkMichaelis*` bundles)
 
@@ -483,6 +489,46 @@ Behavior:
   blocks were not refreshed.
 - `-WhatIf` / `-Confirm` are honored (the helper opts in to
   `SupportsShouldProcess` with `ConfirmImpact='Medium'`).
+
+### Refreshing package configuration (`ConfigScript` / `Update-PackageConfig`)
+
+Completions are declarative and the framework re-applies them across
+install and update. **Configuration** -- idempotent machine state a
+package owns, such as the AIAgents MCP-server wiring (`mcpServers` JSON /
+Codex TOML entries, the persisted GitHub PAT, the profile self-heal
+block) -- gets the same treatment via the `[Package].ConfigScript` hook.
+
+A `ConfigScript` is:
+
+- **Always run.** Invoked on every install (for both freshly `Installed`
+  and `AlreadyInstalled` packages) and every update (`Updated` *and* the
+  no-op `AlreadyLatest` / `SelfManaged` / `NoAutoUpdateSupport` states) --
+  unlike `PostInstallScript` (install only) and `PostUpdateScript` (update
+  only, skipped on no-op upgrades).
+- **Idempotent.** It receives the `[Package]` as `$args[0]` and re-applies
+  state; re-running just overwrites the package's own entries.
+- **Harvest-surviving.** The scriptblock is preserved by the
+  `Get-BundlePackageObjects` AST harvest, so the module helper paths
+  (`Install-Package` / `Update-Package`) run it -- the gap that previously
+  let `Install-Package AIAgents` install the apps but skip the MCP wiring.
+- **Fail-aware.** A throw marks the package `Failed`, like the other
+  `*Script` hooks. Under `-DryRun` / `-WhatIf` it logs only.
+
+To re-apply configuration on demand -- the clean "refresh the MCP servers"
+entry point -- use `Update-PackageConfig` (the configuration counterpart to
+`Update-PackageCompletion`):
+
+```powershell
+Import-Module MarkMichaelis.ScoopBucket -Force
+Update-PackageConfig AIAgents     # re-wire the MCP servers, no reinstall
+Update-PackageConfig              # re-apply every package's ConfigScript
+Update-PackageConfig -WhatIf      # preview what would run
+```
+
+It accepts a package **or** bundle name (or none / `*` for the whole
+bucket), harvests the real `[Package]` objects so scriptblocks are intact,
+and invokes each `ConfigScript`, returning one row per package
+(`Package`, `Bundle`, `Action`, `Reason`).
 
 ## Testing
 

--- a/bucket/AIAgents.Mcp.Tests.ps1
+++ b/bucket/AIAgents.Mcp.Tests.ps1
@@ -367,4 +367,49 @@ GITHUB_PERSONAL_ACCESS_TOKEN = "leaked"
             $content | Should -Not -Match '\[mcp_servers\.github\.env\]'
         }
     }
+
+    Context 'Install-AIAgentsMcpConfiguration (orchestration)' {
+        BeforeEach {
+            # Force npm/dotnet/gh/playwright "absent" so the real package
+            # installers never run; everything else is mocked at the helper
+            # seam so we assert wiring behavior, not side effects.
+            Mock Get-Command -ParameterFilter { $Name -in @('npm','dotnet','gh','playwright') } { $null }
+            Mock Get-NpmGlobalRoot { 'C:\fake\npm' }
+            Mock Resolve-McpServerCommand { @{ Command = 'npx'; Arguments = @('-y', $PackageName) } }
+            Mock Add-McpServerToJsonConfig { }
+            Mock Add-McpServerToCodex { }
+            Mock Test-IsElevated { $false }
+            Mock Set-PersistedGitHubToken { }
+            Mock Get-McpProfileTargets { @() }
+            Mock Add-McpProfileSentinel { $false }
+        }
+
+        It 'writes every MCP server into every non-skipped JSON agent' {
+            $env:GITHUB_PERSONAL_ACCESS_TOKEN = ''
+            Install-AIAgentsMcpConfiguration 6>$null
+            # 4 servers (no posh -- dotnet absent) x 4 agents = 16, minus the
+            # single github/GitHub Copilot CLI skip = 15.
+            Should -Invoke Add-McpServerToJsonConfig -Times 15 -Exactly
+        }
+
+        It 'does NOT write the github server into GitHub Copilot CLI (built-in)' {
+            $env:GITHUB_PERSONAL_ACCESS_TOKEN = ''
+            Install-AIAgentsMcpConfiguration 6>$null
+            Should -Invoke Add-McpServerToJsonConfig -Times 0 -Exactly -ParameterFilter {
+                $AgentLabel -eq 'GitHub Copilot CLI' -and $Server.Name -eq 'github'
+            }
+        }
+
+        It 'persists the GitHub PAT when one is available' {
+            $env:GITHUB_PERSONAL_ACCESS_TOKEN = 'tok_behaviortest'
+            try {
+                Install-AIAgentsMcpConfiguration 6>$null
+                Should -Invoke Set-PersistedGitHubToken -Times 1 -Exactly -ParameterFilter {
+                    $Token -eq 'tok_behaviortest'
+                }
+            } finally {
+                $env:GITHUB_PERSONAL_ACCESS_TOKEN = ''
+            }
+        }
+    }
 }

--- a/bucket/AIAgents.Mcp.ps1
+++ b/bucket/AIAgents.Mcp.ps1
@@ -446,3 +446,277 @@ function Resolve-McpServerCommand {
     $args = @('-y', $PackageName) + $ExtraArguments
     return @{ Command = 'npx'; Arguments = $args }
 }
+
+# ---------------------------------------------------------------------------
+# Shared declarative data for the MCP wiring. Kept as functions (not top-level
+# variables) so dot-sourcing this file stays side-effect free, and so both the
+# apply (Install-AIAgentsMcpConfiguration) and prune
+# (Reset-AIAgentsMcpConfiguration) paths share one source of truth.
+# ---------------------------------------------------------------------------
+
+function Get-AIAgentsMcpJsonAgent {
+    <#
+    .SYNOPSIS
+        The JSON-config agents AIAgents wires MCP servers into.
+    .OUTPUTS
+        Hashtable[] with Label and Path keys.
+    #>
+    [CmdletBinding()]
+    [OutputType([hashtable[]])]
+    param()
+    @(
+        @{ Label = 'Claude Desktop';     Path = (Join-Path $env:APPDATA     'Claude\claude_desktop_config.json') }
+        @{ Label = 'Claude Code CLI';    Path = (Join-Path $env:USERPROFILE '.claude.json') }
+        @{ Label = 'Gemini CLI';         Path = (Join-Path $env:USERPROFILE '.gemini\settings.json') }
+        @{ Label = 'GitHub Copilot CLI'; Path = (Join-Path $env:USERPROFILE '.copilot\mcp-config.json') }
+    )
+}
+
+function Get-AIAgentsMcpNpmPackage {
+    <#
+    .SYNOPSIS
+        npm package names AIAgents pre-installs globally for its MCP servers.
+    .OUTPUTS
+        String[].
+    #>
+    [CmdletBinding()]
+    [OutputType([string[]])]
+    param()
+    @(
+        '@upstash/context7-mcp',
+        '@playwright/mcp',
+        '@modelcontextprotocol/server-github',
+        '@modelcontextprotocol/server-filesystem'
+    )
+}
+
+function Get-AIAgentsDeprecatedMcpServer {
+    <#
+    .SYNOPSIS
+        MCP server names this bucket has retired and prunes under -Reset.
+    .OUTPUTS
+        String[].
+    #>
+    [CmdletBinding()]
+    [OutputType([string[]])]
+    param()
+    @('shell')
+}
+
+function Install-AIAgentsMcpConfiguration {
+    <#
+    .SYNOPSIS
+        Apply the AIAgents MCP-server configuration idempotently.
+
+    .DESCRIPTION
+        Self-contained machine configuration for the AIAgents bundle: install
+        Playwright browsers, the PoshMcp dotnet tool, and the MCP npm packages;
+        resolve a GitHub PAT; write the mcpServers entries into every supported
+        agent config (JSON + Codex TOML); persist the PAT out-of-band; and
+        install the profile self-heal block. Re-running overwrites only the
+        named entries -- other MCP servers in the same config are preserved.
+
+        This is invoked by the bundle's ConfigScript so it runs on every
+        install, every update, and on demand via Update-PackageConfig.
+    #>
+    [CmdletBinding()]
+    param()
+
+    # Playwright separates its browser binaries from the npm package; install
+    # @playwright/test globally so the `playwright` shim lands on PATH, then
+    # install just chromium.
+    if (Get-Command npm -ErrorAction SilentlyContinue) {
+        if (-not (Get-Command playwright -ErrorAction SilentlyContinue)) {
+            & npm.cmd install --global '@playwright/test'
+            if ($LASTEXITCODE -ne 0) {
+                Write-Warning "npm install --global @playwright/test exited with code $LASTEXITCODE; falling back to npx for browser install."
+            }
+        }
+        if (Get-Command playwright -ErrorAction SilentlyContinue) {
+            & playwright.cmd install chromium
+        }
+        else {
+            & npx.cmd -y '@playwright/test' install chromium
+        }
+        if ($LASTEXITCODE -ne 0) {
+            Write-Warning "playwright install chromium exited with code $LASTEXITCODE; the Playwright MCP server may fail at runtime."
+        }
+    }
+    else {
+        Write-Warning 'npm not found after package pass; skipping Playwright browser install.'
+    }
+
+    # PoshMcp ships as a .NET global tool. Skip silently if dotnet isn't present.
+    $poshMcpAvailable = $false
+    if (Get-Command dotnet -ErrorAction SilentlyContinue) {
+        Write-Host 'Installing PoshMcp dotnet global tool...'
+        & dotnet tool install -g poshmcp 2>&1 | Tee-Object -Variable poshOut
+        if ($LASTEXITCODE -eq 0 -or ($poshOut -join "`n") -match 'already installed') {
+            $poshMcpAvailable = $true
+            $dotnetTools = Join-Path $env:USERPROFILE '.dotnet\tools'
+            if ((Test-Path $dotnetTools) -and ($env:Path -notlike "*$dotnetTools*")) {
+                $env:Path = "$env:Path;$dotnetTools"
+            }
+        }
+        else {
+            Write-Warning 'dotnet tool install -g poshmcp failed; PoshMcp MCP server will not be configured.'
+        }
+    }
+    else {
+        Write-Warning 'dotnet not found; skipping PoshMcp install. Install the .NET 10+ SDK (e.g., DeveloperBasePackages) and re-run AIAgents to enable PoshMcp.'
+    }
+
+    # Auto-detect a GitHub PAT for the GitHub MCP server.
+    $githubToken = $env:GITHUB_PERSONAL_ACCESS_TOKEN
+    if ([string]::IsNullOrWhiteSpace($githubToken) -and (Get-Command gh -ErrorAction SilentlyContinue)) {
+        try {
+            $ghToken = & gh auth token 2>$null
+            if ($LASTEXITCODE -eq 0 -and -not [string]::IsNullOrWhiteSpace($ghToken)) {
+                $githubToken = $ghToken.Trim()
+                Write-Host 'GitHub MCP: using token from `gh auth token`.'
+            }
+        }
+        catch { Write-Verbose "GitHub MCP: gh auth token lookup failed: $($_.Exception.Message)" }
+    }
+    if ([string]::IsNullOrWhiteSpace($githubToken)) {
+        Write-Warning 'GitHub MCP: no token found (set $env:GITHUB_PERSONAL_ACCESS_TOKEN or run `gh auth login`). The MCP entry will be written but will fail at runtime until a token is provided.'
+    }
+
+    # Pre-install MCP server npm packages globally so each agent spawn invokes
+    # the resolved .cmd shim directly instead of paying a fresh npx round-trip.
+    $mcpNpmPackages = Get-AIAgentsMcpNpmPackage
+    if (Get-Command npm -ErrorAction SilentlyContinue) {
+        foreach ($pkg in $mcpNpmPackages) {
+            Write-Host "Installing $pkg globally (latest)..."
+            & npm.cmd install --global "$pkg@latest" 2>&1 | Out-Host
+            if ($LASTEXITCODE -ne 0) {
+                Write-Warning "npm install -g $pkg failed; that MCP entry will fall back to 'npx -y'."
+            }
+        }
+    }
+    else {
+        Write-Warning 'npm not found; all MCP npm entries will fall back to npx (slow first-spawn).'
+    }
+
+    $npmGlobalRoot = Get-NpmGlobalRoot
+
+    $context7Cmd   = Resolve-McpServerCommand -PackageName '@upstash/context7-mcp'                    -NpmGlobalRoot $npmGlobalRoot
+    $playwrightCmd = Resolve-McpServerCommand -PackageName '@playwright/mcp'                          -NpmGlobalRoot $npmGlobalRoot
+    $filesystemCmd = Resolve-McpServerCommand -PackageName '@modelcontextprotocol/server-filesystem' -NpmGlobalRoot $npmGlobalRoot -ExtraArguments @($env:USERPROFILE)
+    $githubCmd     = Resolve-McpServerCommand -PackageName '@modelcontextprotocol/server-github'      -NpmGlobalRoot $npmGlobalRoot
+
+    $mcpServers = @(
+        @{ Name = 'context7';   Command = $context7Cmd.Command;   Arguments = $context7Cmd.Arguments }
+        @{ Name = 'playwright'; Command = $playwrightCmd.Command; Arguments = $playwrightCmd.Arguments }
+        @{ Name = 'filesystem'; Command = $filesystemCmd.Command; Arguments = $filesystemCmd.Arguments }
+        @{
+            Name       = 'github'
+            Command    = $githubCmd.Command
+            Arguments  = $githubCmd.Arguments
+            # GitHub Copilot CLI ships its own remote github-mcp-server; skip
+            # writing this entry there to avoid duplication.
+            SkipAgents = @('GitHub Copilot CLI')
+        }
+    )
+
+    if ($poshMcpAvailable) {
+        $mcpServers += @{
+            Name      = 'posh'
+            Command   = 'poshmcp'
+            Arguments = @('serve', '--transport', 'stdio')
+        }
+    }
+
+    $jsonAgents = Get-AIAgentsMcpJsonAgent
+
+    foreach ($server in $mcpServers) {
+        $skip = @()
+        if ($server.ContainsKey('SkipAgents') -and $server.SkipAgents) { $skip = @($server.SkipAgents) }
+
+        foreach ($agent in $jsonAgents) {
+            if ($skip -contains $agent.Label) {
+                Write-Host "$($agent.Label): skipping $($server.Name) MCP (built-in equivalent)."
+                continue
+            }
+            Add-McpServerToJsonConfig -Path $agent.Path -AgentLabel $agent.Label -Server $server
+        }
+        if ($skip -notcontains 'Codex CLI') {
+            Add-McpServerToCodex -Server $server
+        }
+    }
+
+    # Provision the GitHub PAT out-of-band so it does NOT live in any agent
+    # config file. Profile sentinel acts as a self-heal fallback if HKCU is
+    # ever cleared.
+    $isElevated = Test-IsElevated
+
+    if (-not [string]::IsNullOrWhiteSpace($githubToken)) {
+        Set-PersistedGitHubToken -Token $githubToken -IsElevated:$isElevated
+        $scopeLabel = if ($isElevated) { 'HKLM Machine' } else { 'HKCU User' }
+        Write-Host "GitHub MCP: persisted GITHUB_PERSONAL_ACCESS_TOKEN at $scopeLabel scope."
+    }
+
+    foreach ($profilePath in (Get-McpProfileTargets -IsElevated:$isElevated)) {
+        if (Add-McpProfileSentinel -Path $profilePath) {
+            Write-Host "GitHub MCP: installed self-heal block in $profilePath"
+        }
+    }
+}
+
+function Reset-AIAgentsMcpConfiguration {
+    <#
+    .SYNOPSIS
+        Prune retired / skipped MCP entries and clear the persisted PAT.
+
+    .DESCRIPTION
+        The opt-in counterpart to Install-AIAgentsMcpConfiguration: removes the
+        MCP server names this bucket has retired, prunes entries intentionally
+        skipped (e.g. GitHub Copilot CLI), removes the profile self-heal block,
+        clears the persisted GitHub PAT, and uninstalls the MCP npm packages.
+        Invoked only on explicit `AIAgents.ps1 -Reset`.
+    #>
+    [CmdletBinding()]
+    param()
+
+    $deprecated     = Get-AIAgentsDeprecatedMcpServer
+    $jsonAgents     = Get-AIAgentsMcpJsonAgent
+    $mcpNpmPackages = Get-AIAgentsMcpNpmPackage
+    $isElevated     = Test-IsElevated
+
+    Write-Host "-Reset: pruning deprecated MCP server names ($($deprecated -join ', '))..."
+    foreach ($name in $deprecated) {
+        foreach ($agent in $jsonAgents) {
+            Remove-McpServerFromJsonConfig -Path $agent.Path -AgentLabel $agent.Label -ServerName $name
+        }
+        Remove-McpServerFromCodex -ServerName $name
+    }
+
+    # Prune entries this bucket intentionally skips (server -> skipped agents)
+    # so users upgrading from a pre-skip version get the stale entry cleaned.
+    $skipMap = @{ github = @('GitHub Copilot CLI') }
+    foreach ($serverName in $skipMap.Keys) {
+        foreach ($skipLabel in $skipMap[$serverName]) {
+            $agent = $jsonAgents | Where-Object { $_.Label -eq $skipLabel } | Select-Object -First 1
+            if ($agent) {
+                Remove-McpServerFromJsonConfig -Path $agent.Path -AgentLabel $agent.Label -ServerName $serverName
+            }
+        }
+    }
+
+    Write-Host '-Reset: removing GitHub PAT self-heal block from PowerShell profile(s)...'
+    foreach ($profilePath in (Get-McpProfileTargets -IsElevated:$isElevated)) {
+        if (Remove-McpProfileSentinel -Path $profilePath) {
+            Write-Host "  pruned $profilePath"
+        }
+    }
+
+    Write-Host '-Reset: clearing persisted GITHUB_PERSONAL_ACCESS_TOKEN env var...'
+    Clear-PersistedGitHubToken -IsElevated:$isElevated
+
+    if (Get-Command npm -ErrorAction SilentlyContinue) {
+        Write-Host '-Reset: uninstalling MCP npm packages globally...'
+        foreach ($pkg in $mcpNpmPackages) {
+            & npm.cmd uninstall --global $pkg 2>&1 | Out-Host
+        }
+    }
+}

--- a/bucket/AIAgents.Tests.ps1
+++ b/bucket/AIAgents.Tests.ps1
@@ -40,6 +40,32 @@ Describe 'AIAgents bundle: Warp winget invocation' -Tag 'Light','Bundle' {
     }
 }
 
+Describe 'AIAgents bundle: MCP configuration is declarative' -Tag 'Light','Bundle' {
+    BeforeAll {
+        $bundlePath = Join-Path $PSScriptRoot 'AIAgents.ps1'
+        $script:mcpCfgPkg = & (Get-Module MarkMichaelis.ScoopBucket) {
+            param($p) Get-BundlePackageObjects -BundlePath $p
+        } $bundlePath | Where-Object { $_.Name -eq 'MCP Server Configuration' }
+    }
+
+    It 'declares an MCP Server Configuration package exactly once' {
+        @($script:mcpCfgPkg).Count | Should -Be 1
+    }
+
+    It 'wires the MCP servers through a declarative ConfigScript (not imperative tail code)' {
+        $script:mcpCfgPkg.ConfigScript | Should -Not -BeNullOrEmpty
+        $script:mcpCfgPkg.ConfigScript.GetType().Name | Should -Be 'ScriptBlock'
+        # The script delegates to the self-contained apply function so the
+        # framework re-applies the config on every install/update and via
+        # Update-PackageConfig.
+        "$($script:mcpCfgPkg.ConfigScript)" | Should -Match 'Install-AIAgentsMcpConfiguration'
+    }
+
+    It 'depends on Node.js so npx-based MCP servers resolve at agent start-up' {
+        $script:mcpCfgPkg.DependsOn | Should -Contain 'Node.js'
+    }
+}
+
 Describe 'AIAgents bundle: Gemini desktop -> Gemini CLI Companions' -Tag 'Light','Bundle' {
     BeforeAll {
         $script:aiPkgs = @(Get-Package -BucketPath $PSScriptRoot -Bundle 'AIAgents')

--- a/bucket/AIAgents.ps1
+++ b/bucket/AIAgents.ps1
@@ -341,15 +341,34 @@ Register-ArgumentCompleter -Native -CommandName copilot -ScriptBlock {
 "@
         }
     }
+    # MCP-server wiring as declarative config. Unlike imperative tail code,
+    # a ConfigScript is re-applied by the framework on every install, every
+    # update, and on demand via `Update-PackageConfig AIAgents` -- the same
+    # always-run guarantee completions get. The script is self-contained:
+    # it dot-sources the helper module and resolves its own token / runtime
+    # availability, so it works identically whether invoked by the install
+    # driver, the update driver, or Update-PackageConfig.
+    [Package]@{
+        Name      = 'MCP Server Configuration'
+        Installer = 'custom'
+        DependsOn = @('Node.js')
+        Notes     = 'Idempotent MCP-server wiring for every MCP-capable agent. Re-applied on every install/update and via Update-PackageConfig AIAgents.'
+        # Engine no-op: the configuration IS the work, performed in ConfigScript.
+        CustomInstallScript = { }
+        ConfigScript = {
+            . (Join-Path $PSScriptRoot 'AIAgents.Mcp.ps1')
+            Install-AIAgentsMcpConfiguration
+        }
+    }
 )
 
 Invoke-PackageInstall -Packages $Packages -Bundle 'AIAgents'
 
 # Probe-mode short-circuit: when Get-BundlePackages enumerates the bundle
-# in a child runspace it shims Invoke-PackageInstall and sets this flag,
-# signaling that the trailing imperative work below (npm/dotnet installs,
-# config file writes, HKCU env-var writes, profile-block injection) must
-# be skipped. Production runs leave the flag unset so the work proceeds.
+# in a child runspace it shims Invoke-PackageInstall and sets this flag.
+# The normal MCP wiring now runs as the 'MCP Server Configuration' package's
+# ConfigScript (invoked by the install driver above), so only the opt-in
+# -Reset prune and the best-effort completion sweep remain as tail work.
 if ($global:__SBPKG_IS_PROBE) { return }
 
 # Dot-source MCP-wiring helpers. AIAgents.Mcp.ps1 contains function
@@ -357,239 +376,8 @@ if ($global:__SBPKG_IS_PROBE) { return }
 # from this bundle as well as from bucket/AIAgents.Mcp.Tests.ps1.
 . (Join-Path $PSScriptRoot 'AIAgents.Mcp.ps1')
 
-# ---------------------------------------------------------------------------
-# MCP server prerequisites that are NOT npm-based.
-# ---------------------------------------------------------------------------
-
-# Playwright separates its browser binaries from the npm package; the MCP
-# server starts cleanly without them but fails the first time an agent
-# asks it to open a page. Install `@playwright/test` globally so the
-# `playwright` shim lands on PATH, then install just chromium (~150 MB).
-if (Get-Command npm -ErrorAction SilentlyContinue) {
-    if (-not (Get-Command playwright -ErrorAction SilentlyContinue)) {
-        & npm.cmd install --global '@playwright/test'
-        if ($LASTEXITCODE -ne 0) {
-            Write-Warning "npm install --global @playwright/test exited with code $LASTEXITCODE; falling back to npx for browser install."
-        }
-    }
-    if (Get-Command playwright -ErrorAction SilentlyContinue) {
-        & playwright.cmd install chromium
-    }
-    else {
-        & npx.cmd -y '@playwright/test' install chromium
-    }
-    if ($LASTEXITCODE -ne 0) {
-        Write-Warning "playwright install chromium exited with code $LASTEXITCODE; the Playwright MCP server may fail at runtime."
-    }
-}
-else {
-    Write-Warning 'npm not found after package pass; skipping Playwright browser install.'
-}
-
-# PoshMcp ships as a .NET global tool. Skip silently if dotnet isn't on the
-# machine — installing the .NET 10+ SDK from this script would be too heavy
-# a side effect for a non-developer profile. DeveloperBasePackages already
-# pulls the .NET SDK; users who don't run that simply won't get PoshMcp.
-$PoshMcpAvailable = $false
-if (Get-Command dotnet -ErrorAction SilentlyContinue) {
-    Write-Host 'Installing PoshMcp dotnet global tool...'
-    & dotnet tool install -g poshmcp 2>&1 | Tee-Object -Variable poshOut
-    if ($LASTEXITCODE -eq 0 -or ($poshOut -join "`n") -match 'already installed') {
-        $PoshMcpAvailable = $true
-        $dotnetTools = Join-Path $env:USERPROFILE '.dotnet\tools'
-        if ((Test-Path $dotnetTools) -and ($env:Path -notlike "*$dotnetTools*")) {
-            $env:Path = "$env:Path;$dotnetTools"
-        }
-    }
-    else {
-        Write-Warning "dotnet tool install -g poshmcp failed; PoshMcp MCP server will not be configured."
-    }
-}
-else {
-    Write-Warning 'dotnet not found; skipping PoshMcp install. Install the .NET 10+ SDK (e.g., DeveloperBasePackages) and re-run AIAgents to enable PoshMcp.'
-}
-
-# Auto-detect a GitHub PAT for the GitHub MCP server. Prefer an explicit env
-# var; fall back to the gh CLI's stored token if available.
-$GithubToken = $env:GITHUB_PERSONAL_ACCESS_TOKEN
-if ([string]::IsNullOrWhiteSpace($GithubToken) -and (Get-Command gh -ErrorAction SilentlyContinue)) {
-    try {
-        $ghToken = & gh auth token 2>$null
-        if ($LASTEXITCODE -eq 0 -and -not [string]::IsNullOrWhiteSpace($ghToken)) {
-            $GithubToken = $ghToken.Trim()
-            Write-Host 'GitHub MCP: using token from `gh auth token`.'
-        }
-    }
-    catch { }
-}
-if ([string]::IsNullOrWhiteSpace($GithubToken)) {
-    Write-Warning 'GitHub MCP: no token found (set $env:GITHUB_PERSONAL_ACCESS_TOKEN or run `gh auth login`). The MCP entry will be written but will fail at runtime until a token is provided.'
-}
-
-# ---------------------------------------------------------------------------
-# Configure MCP servers for every MCP-capable agent.
-# Idempotent: re-running just overwrites the named entries; other MCP servers
-# in the same config are preserved.
-# ---------------------------------------------------------------------------
-
-$DeprecatedMcpServers = @('shell')
-
-# ---------------------------------------------------------------------------
-# Pre-install MCP server npm packages globally so each agent spawn invokes
-# the resolved .cmd shim directly instead of paying a fresh npx tarball-
-# fetch round-trip on first use. We deliberately keep `npm install -g
-# <pkg>@latest` (no version pin) so a routine bucket reinstall pulls fixes;
-# `Resolve-McpServerCommand` falls back to `npx -y <pkg>` per-entry when
-# global install or bin resolution fails (graceful degradation).
-# ---------------------------------------------------------------------------
-
-$McpNpmPackages = @(
-    '@upstash/context7-mcp',
-    '@playwright/mcp',
-    '@modelcontextprotocol/server-github',
-    '@modelcontextprotocol/server-filesystem'
-)
-
-if (Get-Command npm -ErrorAction SilentlyContinue) {
-    foreach ($pkg in $McpNpmPackages) {
-        Write-Host "Installing $pkg globally (latest)..."
-        & npm.cmd install --global "$pkg@latest" 2>&1 | Out-Host
-        if ($LASTEXITCODE -ne 0) {
-            Write-Warning "npm install -g $pkg failed; that MCP entry will fall back to 'npx -y'."
-        }
-    }
-}
-else {
-    Write-Warning 'npm not found; all MCP npm entries will fall back to npx (slow first-spawn).'
-}
-
-$NpmGlobalRoot = Get-NpmGlobalRoot
-
-$context7Cmd   = Resolve-McpServerCommand -PackageName '@upstash/context7-mcp'                  -NpmGlobalRoot $NpmGlobalRoot
-$playwrightCmd = Resolve-McpServerCommand -PackageName '@playwright/mcp'                        -NpmGlobalRoot $NpmGlobalRoot
-$filesystemCmd = Resolve-McpServerCommand -PackageName '@modelcontextprotocol/server-filesystem' -NpmGlobalRoot $NpmGlobalRoot -ExtraArguments @($env:USERPROFILE)
-$githubCmd     = Resolve-McpServerCommand -PackageName '@modelcontextprotocol/server-github'    -NpmGlobalRoot $NpmGlobalRoot
-
-$McpServers = @(
-    @{
-        Name      = 'context7'
-        Command   = $context7Cmd.Command
-        Arguments = $context7Cmd.Arguments
-    }
-    @{
-        Name      = 'playwright'
-        Command   = $playwrightCmd.Command
-        Arguments = $playwrightCmd.Arguments
-    }
-    @{
-        Name      = 'filesystem'
-        Command   = $filesystemCmd.Command
-        Arguments = $filesystemCmd.Arguments
-    }
-    @{
-        Name       = 'github'
-        Command    = $githubCmd.Command
-        Arguments  = $githubCmd.Arguments
-        # No `Env` block: the token is provisioned out-of-band via HKCU
-        # (Set-PersistedGitHubToken below) and the profile self-heal
-        # sentinel, so it is no longer scattered across config files.
-        # GitHub Copilot CLI ships its own remote `github-mcp-server`
-        # built in; skip writing this entry there to avoid duplication.
-        SkipAgents = @('GitHub Copilot CLI')
-    }
-)
-
-if ($PoshMcpAvailable) {
-    $McpServers += @{
-        Name      = 'posh'
-        Command   = 'poshmcp'
-        Arguments = @('serve', '--transport', 'stdio')
-    }
-}
-
-$JsonAgents = @(
-    @{ Label = 'Claude Desktop';      Path = (Join-Path $env:APPDATA      'Claude\claude_desktop_config.json') }
-    @{ Label = 'Claude Code CLI';     Path = (Join-Path $env:USERPROFILE  '.claude.json') }
-    @{ Label = 'Gemini CLI';          Path = (Join-Path $env:USERPROFILE  '.gemini\settings.json') }
-    @{ Label = 'GitHub Copilot CLI';  Path = (Join-Path $env:USERPROFILE  '.copilot\mcp-config.json') }
-)
-
-foreach ($server in $McpServers) {
-    $skip = @()
-    if ($server.ContainsKey('SkipAgents') -and $server.SkipAgents) { $skip = @($server.SkipAgents) }
-
-    foreach ($agent in $JsonAgents) {
-        if ($skip -contains $agent.Label) {
-            Write-Host "$($agent.Label): skipping $($server.Name) MCP (built-in equivalent)."
-            continue
-        }
-        Add-McpServerToJsonConfig -Path $agent.Path -AgentLabel $agent.Label -Server $server
-    }
-    if ($skip -notcontains 'Codex CLI') {
-        Add-McpServerToCodex -Server $server
-    }
-}
-
-# ---------------------------------------------------------------------------
-# Provision the GitHub PAT out-of-band so it does NOT live in any agent
-# config file. Claude Desktop launches from the Start menu and will not
-# inherit shell env, so we additionally persist the value at HKCU User
-# (or HKLM Machine when elevated) scope. Profile sentinel acts as a
-# self-heal fallback if HKCU is ever cleared.
-# ---------------------------------------------------------------------------
-
-$IsElevated = Test-IsElevated
-
-if (-not [string]::IsNullOrWhiteSpace($GithubToken)) {
-    Set-PersistedGitHubToken -Token $GithubToken -IsElevated:$IsElevated
-    $scopeLabel = if ($IsElevated) { 'HKLM Machine' } else { 'HKCU User' }
-    Write-Host "GitHub MCP: persisted GITHUB_PERSONAL_ACCESS_TOKEN at $scopeLabel scope."
-}
-
-foreach ($profilePath in (Get-McpProfileTargets -IsElevated:$IsElevated)) {
-    if (Add-McpProfileSentinel -Path $profilePath) {
-        Write-Host "GitHub MCP: installed self-heal block in $profilePath"
-    }
-}
-
 if ($Reset) {
-    Write-Host "-Reset: pruning deprecated MCP server names ($($DeprecatedMcpServers -join ', '))..."
-    foreach ($name in $DeprecatedMcpServers) {
-        foreach ($agent in $JsonAgents) {
-            Remove-McpServerFromJsonConfig -Path $agent.Path -AgentLabel $agent.Label -ServerName $name
-        }
-        Remove-McpServerFromCodex -ServerName $name
-    }
-
-    # Prune entries this run intentionally skipped (e.g., GitHub Copilot
-    # CLI) so users upgrading from a pre-skip version get their stale
-    # `github` entry cleaned out of `~\.copilot\mcp-config.json`.
-    foreach ($server in $McpServers) {
-        if (-not $server.ContainsKey('SkipAgents')) { continue }
-        foreach ($skipLabel in @($server.SkipAgents)) {
-            $agent = $JsonAgents | Where-Object { $_.Label -eq $skipLabel } | Select-Object -First 1
-            if ($agent) {
-                Remove-McpServerFromJsonConfig -Path $agent.Path -AgentLabel $agent.Label -ServerName $server.Name
-            }
-        }
-    }
-
-    Write-Host "-Reset: removing GitHub PAT self-heal block from PowerShell profile(s)..."
-    foreach ($profilePath in (Get-McpProfileTargets -IsElevated:$IsElevated)) {
-        if (Remove-McpProfileSentinel -Path $profilePath) {
-            Write-Host "  pruned $profilePath"
-        }
-    }
-
-    Write-Host "-Reset: clearing persisted GITHUB_PERSONAL_ACCESS_TOKEN env var..."
-    Clear-PersistedGitHubToken -IsElevated:$IsElevated
-
-    if (Get-Command npm -ErrorAction SilentlyContinue) {
-        Write-Host "-Reset: uninstalling MCP npm packages globally..."
-        foreach ($pkg in $McpNpmPackages) {
-            & npm.cmd uninstall --global $pkg 2>&1 | Out-Host
-        }
-    }
+    Reset-AIAgentsMcpConfiguration
 }
 
 # Tab-completion registration: idempotent best-effort. Skipped (with a
@@ -601,3 +389,4 @@ try {
 catch {
     Write-Warning "Skipping CLI tab-completion registration: $($_.Exception.Message)"
 }
+

--- a/bucket/GetBundlePackageObjects.Tests.ps1
+++ b/bucket/GetBundlePackageObjects.Tests.ps1
@@ -99,6 +99,27 @@ Invoke-PackageInstall -Packages $Packages -Bundle 'WithScript'
         $r.Objects[0].CustomInstallScript.GetType().Name | Should -Be 'ScriptBlock'
     }
 
+    It 'preserves scriptblocks (ConfigScript) on reconstructed packages' {
+        $bundle = Join-Path $TestDrive 'WithConfig.ps1'
+        Set-Content -LiteralPath $bundle -Value @'
+$Packages = @(
+    [Package]@{
+        Name         = 'Config'
+        Installer    = 'winget'
+        Id           = 'Foo.Config'
+        ConfigScript = { 'configured' }
+    }
+)
+Invoke-PackageInstall -Packages $Packages -Bundle 'WithConfig'
+'@
+        $r = script:Invoke-GetBundlePackageObjects -Path $bundle
+
+        $r.Warnings.Count | Should -Be 0
+        $r.Objects.Count | Should -Be 1
+        $r.Objects[0].ConfigScript | Should -Not -BeNullOrEmpty
+        $r.Objects[0].ConfigScript.GetType().Name | Should -Be 'ScriptBlock'
+    }
+
     It 'stays quiet (no warning) for a legacy bundle that never assigns $Packages' {
         # Legitimate empty result -- imperative bundle with no $Packages. Must NOT
         # warn (that would be noise on every legacy-bundle dispatch).

--- a/bucket/Package.Tests.ps1
+++ b/bucket/Package.Tests.ps1
@@ -167,6 +167,18 @@ Describe 'Package.Validate() — happy paths' -Tag 'Light', 'Module' {
         $p.Installer | Should -Be 'custom'
     }
 
+    It 'accepts a ConfigScript on a non-custom installer and stores it as a scriptblock' {
+        $p = [Package]@{
+            Name         = 'ripgrep'
+            Installer    = 'scoop'
+            Id           = 'main/ripgrep'
+            ConfigScript = { 'configured' }
+        }
+        { $p.Validate() } | Should -Not -Throw
+        $p.ConfigScript | Should -BeOfType ([scriptblock])
+        (& $p.ConfigScript) | Should -Be 'configured'
+    }
+
     It 'passes a native-completion entry with NativeCommandScript' {
         $p = [Package]@{
             Name                = 'gh'

--- a/bucket/PackageInstall.Tests.ps1
+++ b/bucket/PackageInstall.Tests.ps1
@@ -317,6 +317,65 @@ Describe 'Invoke-PackageInstall pipeline' -Tag 'Light','Module' {
         $r[0].Name | Should -Be 'Readwise'
     }
 
+    It 'runs ConfigScript after a successful install' {
+        $script:configRan = $false
+        $pkgs = [Package[]]@(
+            [Package]@{ Name='A'; Installer='winget'; Id='Foo.A'
+                        ConfigScript = { $script:configRan = $true } }
+        )
+        $null = Invoke-PackageInstall -Packages $pkgs -Bundle 'Test' -SkipCompletion
+        $script:configRan | Should -BeTrue
+    }
+
+    It 'runs ConfigScript even when the package is AlreadyInstalled' {
+        Mock -ModuleName MarkMichaelis.ScoopBucket Install-WingetPackage {
+            return @{ State = 'AlreadyInstalled'; Reason = $null }
+        }
+        $script:configRan = $false
+        $pkgs = [Package[]]@(
+            [Package]@{ Name='A'; Installer='winget'; Id='Foo.A'
+                        ConfigScript = { $script:configRan = $true } }
+        )
+        $r = Invoke-PackageInstall -Packages $pkgs -Bundle 'Test' -SkipCompletion
+        ($r | Where-Object Name -eq 'A').Status | Should -Be 'AlreadyInstalled'
+        $script:configRan | Should -BeTrue
+    }
+
+    It 'passes the [Package] to ConfigScript as $args[0]' {
+        $script:seenName = $null
+        $pkgs = [Package[]]@(
+            [Package]@{ Name='Cfg'; Installer='winget'; Id='Foo.Cfg'
+                        ConfigScript = { param($p) $script:seenName = $p.Name } }
+        )
+        $null = Invoke-PackageInstall -Packages $pkgs -Bundle 'Test' -SkipCompletion
+        $script:seenName | Should -Be 'Cfg'
+    }
+
+    It 'fails the package when ConfigScript throws' {
+        $pkgs = [Package[]]@(
+            [Package]@{ Name='A'; Installer='winget'; Id='Foo.A'
+                        ConfigScript = { throw 'cfgboom' } }
+        )
+        $r = Invoke-PackageInstall -Packages $pkgs -Bundle 'Test' -SkipCompletion `
+            -ErrorAction SilentlyContinue -ErrorVariable errs
+        $r.Count     | Should -Be 1
+        $r[0].Status | Should -Be 'Failed'
+        $r[0].Reason | Should -Match 'ConfigScript threw'
+        $ours = @($errs | Where-Object { $_.FullyQualifiedErrorId -like 'PackageInstallFailed*' })
+        $ours.Count | Should -Be 1
+        $ours[0].Exception.Message | Should -Match 'cfgboom'
+    }
+
+    It 'does not run ConfigScript under -DryRun' {
+        $script:configRan = $false
+        $pkgs = [Package[]]@(
+            [Package]@{ Name='A'; Installer='winget'; Id='Foo.A'
+                        ConfigScript = { $script:configRan = $true } }
+        )
+        $null = Invoke-PackageInstall -Packages $pkgs -Bundle 'Test' -SkipCompletion -DryRun
+        $script:configRan | Should -BeFalse
+    }
+
     It 'skips packages with CISkip set when $env:CI is truthy' {
         $oldCi = $env:CI
         $env:CI = 'true'

--- a/bucket/UpdatePackage.Tests.ps1
+++ b/bucket/UpdatePackage.Tests.ps1
@@ -460,6 +460,70 @@ Describe 'Invoke-PackageUpdate pipeline' -Tag 'Light','Module' {
         Should -Invoke -ModuleName MarkMichaelis.ScoopBucket Update-PathFromRegistry -Times 0 -Exactly
     }
 
+    It 'runs ConfigScript after an Updated package' {
+        $script:configRan = $false
+        $pkgs = [Package[]]@(
+            [Package]@{ Name='A'; Installer='winget'; Id='Foo.A'
+                        ConfigScript = { $script:configRan = $true } }
+        )
+        $null = Invoke-PackageUpdate -Packages $pkgs -Bundle 'Test' -SkipCompletion
+        $script:configRan | Should -BeTrue
+    }
+
+    It 'runs ConfigScript even when the engine reports AlreadyLatest' {
+        Mock -ModuleName MarkMichaelis.ScoopBucket Update-WingetPackage {
+            return @{ State='AlreadyLatest'; Reason='same' }
+        }
+        $script:configRan = $false
+        $pkgs = [Package[]]@(
+            [Package]@{ Name='A'; Installer='winget'; Id='Foo.A'
+                        ConfigScript = { $script:configRan = $true } }
+        )
+        $r = Invoke-PackageUpdate -Packages $pkgs -Bundle 'Test' -SkipCompletion
+        ($r | Where-Object Name -eq 'A').Status | Should -Be 'AlreadyLatest'
+        $script:configRan | Should -BeTrue
+    }
+
+    It 'does NOT run ConfigScript when the package is NotInstalled' {
+        Mock -ModuleName MarkMichaelis.ScoopBucket Update-WingetPackage {
+            return @{ State='NotInstalled'; Reason='probe said no' }
+        }
+        $script:configRan = $false
+        $pkgs = [Package[]]@(
+            [Package]@{ Name='A'; Installer='winget'; Id='Foo.A'
+                        ConfigScript = { $script:configRan = $true } }
+        )
+        $null = Invoke-PackageUpdate -Packages $pkgs -Bundle 'Test' -SkipCompletion
+        $script:configRan | Should -BeFalse
+    }
+
+    It 'fails the package when ConfigScript throws during update' {
+        $pkgs = [Package[]]@(
+            [Package]@{ Name='A'; Installer='winget'; Id='Foo.A'
+                        ConfigScript = { throw 'cfgboom' } }
+        )
+        $r = Invoke-PackageUpdate -Packages $pkgs -Bundle 'Test' -SkipCompletion `
+            -ErrorAction SilentlyContinue -ErrorVariable errs
+        ($r | Where-Object Name -eq 'A').Status | Should -Be 'Failed'
+        ($r | Where-Object Name -eq 'A').Reason | Should -Match 'ConfigScript threw'
+        $ours = @($errs | Where-Object { $_.FullyQualifiedErrorId -like 'PackageUpdateFailed*' })
+        $ours.Count | Should -Be 1
+    }
+
+    It 'does not run ConfigScript under -WhatIf' {
+        Mock -ModuleName MarkMichaelis.ScoopBucket Update-WingetPackage { throw 'engine must not run under -WhatIf' }
+        Mock -ModuleName MarkMichaelis.ScoopBucket Get-PackageUpdateIndex {
+            @{ 'Foo.A' = [pscustomobject]@{ Installed='1.0'; Available='1.0' } }
+        }
+        $script:configRan = $false
+        $pkgs = [Package[]]@(
+            [Package]@{ Name='A'; Installer='winget'; Id='Foo.A'
+                        ConfigScript = { $script:configRan = $true } }
+        )
+        $null = Invoke-PackageUpdate -Packages $pkgs -Bundle 'Test' -SkipCompletion -WhatIf
+        $script:configRan | Should -BeFalse
+    }
+
     It 'DOES re-register completion when engine reports Updated' {
         $pkgs = [Package[]]@(
             [Package]@{

--- a/bucket/UpdatePackageConfig.Tests.ps1
+++ b/bucket/UpdatePackageConfig.Tests.ps1
@@ -1,0 +1,136 @@
+#requires -Version 7.0
+#requires -Modules @{ ModuleName = 'Pester'; ModuleVersion = '5.0.0' }
+
+# Pester coverage for Update-PackageConfig -- the on-demand "re-apply package
+# configuration" command. It walks declarative bundles, reconstructs the real
+# [Package] objects (ConfigScript scriptblocks intact) via the harvest path,
+# and re-runs each ConfigScript idempotently. This is the clean entry point for
+# the user's original "refresh the MCP servers" request:
+#   Update-PackageConfig AIAgents
+
+BeforeAll {
+    $script:repoRoot = Split-Path -Parent $PSScriptRoot
+    $script:psd1     = Join-Path $script:repoRoot 'module\MarkMichaelis.ScoopBucket\MarkMichaelis.ScoopBucket.psd1'
+    Import-Module $script:psd1 -Force
+
+    function script:New-ConfigBucket {
+        # Build a throwaway bucket with two bundles:
+        #   Alpha  -- one package with a ConfigScript that appends to a sentinel.
+        #   Bravo  -- one package with a ConfigScript that appends to a sentinel,
+        #             plus one package with NO ConfigScript.
+        $bucket = Join-Path ([System.IO.Path]::GetTempPath()) ("ScoopBucket-cfg-$([guid]::NewGuid().ToString('N'))")
+        New-Item -ItemType Directory -Path $bucket | Out-Null
+        $sentinel = Join-Path $bucket 'config-ran.log'
+
+        $psd1Lit = $script:psd1 -replace "'", "''"
+        $senLit  = $sentinel -replace "'", "''"
+
+        $alpha = @"
+`$scoopBucketPsd1 = '$psd1Lit'
+if (Test-Path `$scoopBucketPsd1) { Import-Module `$scoopBucketPsd1 -Force } else { Import-Module MarkMichaelis.ScoopBucket -Force }
+
+`$Packages = [Package[]]@(
+    [Package]@{
+        Name = 'alpha'; Installer = 'winget'; Id = 'Test.Alpha'
+        ConfigScript = { Add-Content -LiteralPath '$senLit' -Value "alpha:`$(`$args[0].Name)" }
+    }
+)
+
+Invoke-PackageInstall -Packages `$Packages -Bundle 'Alpha'
+"@
+        Set-Content -LiteralPath (Join-Path $bucket 'Alpha.ps1') -Value $alpha -Encoding UTF8
+
+        $bravo = @"
+`$scoopBucketPsd1 = '$psd1Lit'
+if (Test-Path `$scoopBucketPsd1) { Import-Module `$scoopBucketPsd1 -Force } else { Import-Module MarkMichaelis.ScoopBucket -Force }
+
+`$Packages = [Package[]]@(
+    [Package]@{
+        Name = 'bravo'; Installer = 'winget'; Id = 'Test.Bravo'
+        ConfigScript = { Add-Content -LiteralPath '$senLit' -Value 'bravo' }
+    }
+    [Package]@{ Name = 'charlie'; Installer = 'winget'; Id = 'Test.Charlie' }
+)
+
+Invoke-PackageInstall -Packages `$Packages -Bundle 'Bravo'
+"@
+        Set-Content -LiteralPath (Join-Path $bucket 'Bravo.ps1') -Value $bravo -Encoding UTF8
+
+        foreach ($name in 'Alpha', 'Bravo') {
+            $manifest = @{
+                '$schema' = 'https://raw.githubusercontent.com/lukesampson/scoop/master/schema.json'
+                version   = '1.00.000'
+                url       = @('https://example.invalid/test')
+                installer = @{ script = @("& `"`$dir\$name.ps1`"") }
+            }
+            Set-Content -LiteralPath (Join-Path $bucket "$name.json") `
+                -Value ($manifest | ConvertTo-Json -Depth 4) -Encoding UTF8
+        }
+
+        [pscustomobject]@{ Bucket = $bucket; Sentinel = $sentinel }
+    }
+}
+
+Describe 'Update-PackageConfig' -Tag 'Light', 'Module' {
+
+    It 'is exported by the module' {
+        Get-Command Update-PackageConfig -Module MarkMichaelis.ScoopBucket | Should -Not -BeNullOrEmpty
+    }
+
+    It 'runs the ConfigScript for a named bundle and passes the [Package]' {
+        $env = script:New-ConfigBucket
+        try {
+            $null = Update-PackageConfig -Name 'Alpha' -BucketPath $env.Bucket
+            Test-Path -LiteralPath $env.Sentinel | Should -BeTrue
+            (Get-Content -LiteralPath $env.Sentinel -Raw) | Should -Match 'alpha:alpha'
+        } finally {
+            Remove-Item -LiteralPath $env.Bucket -Recurse -Force -ErrorAction Ignore
+        }
+    }
+
+    It 'runs every ConfigScript across all bundles when no name is given' {
+        $env = script:New-ConfigBucket
+        try {
+            $null = Update-PackageConfig -BucketPath $env.Bucket
+            $content = Get-Content -LiteralPath $env.Sentinel -Raw
+            $content | Should -Match 'alpha:alpha'
+            $content | Should -Match 'bravo'
+        } finally {
+            Remove-Item -LiteralPath $env.Bucket -Recurse -Force -ErrorAction Ignore
+        }
+    }
+
+    It 'does not run other bundles ConfigScripts when a single bundle is named' {
+        $env = script:New-ConfigBucket
+        try {
+            $null = Update-PackageConfig -Name 'Bravo' -BucketPath $env.Bucket
+            $content = Get-Content -LiteralPath $env.Sentinel -Raw
+            $content | Should -Match 'bravo'
+            $content | Should -Not -Match 'alpha'
+        } finally {
+            Remove-Item -LiteralPath $env.Bucket -Recurse -Force -ErrorAction Ignore
+        }
+    }
+
+    It 'under -WhatIf does not invoke any ConfigScript' {
+        $env = script:New-ConfigBucket
+        try {
+            $null = Update-PackageConfig -BucketPath $env.Bucket -WhatIf
+            Test-Path -LiteralPath $env.Sentinel | Should -BeFalse
+        } finally {
+            Remove-Item -LiteralPath $env.Bucket -Recurse -Force -ErrorAction Ignore
+        }
+    }
+
+    It 'emits a result row only for packages that declare a ConfigScript' {
+        $env = script:New-ConfigBucket
+        try {
+            $rows = @(Update-PackageConfig -BucketPath $env.Bucket)
+            $rows.Package | Should -Contain 'alpha'
+            $rows.Package | Should -Contain 'bravo'
+            $rows.Package | Should -Not -Contain 'charlie'
+        } finally {
+            Remove-Item -LiteralPath $env.Bucket -Recurse -Force -ErrorAction Ignore
+        }
+    }
+}

--- a/module/MarkMichaelis.ScoopBucket/Classes/Package.ps1
+++ b/module/MarkMichaelis.ScoopBucket/Classes/Package.ps1
@@ -71,6 +71,17 @@ class Package {
     [scriptblock] $PostUpdateScript
     [scriptblock] $VerifyScript
 
+    # Idempotent machine configuration for this package (e.g. writing tool
+    # config files, persisting env vars, editing profiles). Unlike
+    # PostInstallScript (install-only) and PostUpdateScript (update-only and
+    # skipped on no-op upgrades), ConfigScript is re-applied on EVERY install
+    # and EVERY update -- and on demand via Update-PackageConfig -- mirroring
+    # the way declarative Completion is always (re)registered. It must be
+    # idempotent because it runs repeatedly. Receives the [Package] as
+    # $args[0], like the other *Script hooks. A throw marks the package
+    # Failed, consistent with PostInstallScript / PostUpdateScript.
+    [scriptblock] $ConfigScript
+
     # Engine-specific extra arguments appended to the install command.
     # Currently only consumed by Install-WingetPackage. Use for cases
     # where winget needs a flag beyond the standard ones (e.g.

--- a/module/MarkMichaelis.ScoopBucket/MarkMichaelis.ScoopBucket.psd1
+++ b/module/MarkMichaelis.ScoopBucket/MarkMichaelis.ScoopBucket.psd1
@@ -30,6 +30,7 @@
         'Invoke-PackageUninstall',
         'Invoke-PackageUpdate',
         'Update-PackageCompletion',
+        'Update-PackageConfig',
         'Import-PackageCompletion',
         'Remove-StorePwsh',
         'Add-MachinePath',

--- a/module/MarkMichaelis.ScoopBucket/Public/Invoke-PackageInstall.ps1
+++ b/module/MarkMichaelis.ScoopBucket/Public/Invoke-PackageInstall.ps1
@@ -217,6 +217,24 @@ function Invoke-PackageInstall {
             }
         }
 
+        # ConfigScript: idempotent machine configuration re-applied on every
+        # install (Installed OR AlreadyInstalled), mirroring the always-run
+        # nature of completion registration. A throw fails the package, like
+        # PostInstallScript. See [Package].ConfigScript.
+        if ($pkg.ConfigScript) {
+            if ($DryRun) {
+                Write-UpdateStatus -Activity 'Install-Package' "  [DryRun] ConfigScript ($($pkg.Name))"
+            } else {
+                try {
+                    [void](& $pkg.ConfigScript $pkg 2>$null)
+                } catch {
+                    $reason = "ConfigScript threw: $($_.Exception.Message)"
+                    & $failPackage $pkg $reason
+                    continue
+                }
+            }
+        }
+
         if (-not $SkipCompletion -and -not $DryRun -and
             $pkg.Completion -ne 'none' -and $pkg.CliCommands.Count -gt 0) {
             foreach ($cli in $pkg.CliCommands) {

--- a/module/MarkMichaelis.ScoopBucket/Public/Invoke-PackageUpdate.ps1
+++ b/module/MarkMichaelis.ScoopBucket/Public/Invoke-PackageUpdate.ps1
@@ -113,6 +113,27 @@ function Invoke-PackageUpdate {
         $PSCmdlet.WriteError($errRec)
     }
 
+    # ConfigScript runner: idempotent machine configuration re-applied on
+    # every update for an installed package (Updated OR a no-op state like
+    # AlreadyLatest), mirroring the always-run nature of the install-path
+    # ConfigScript hook. Returns $true on success, $false when the script
+    # threw (in which case the package has already been recorded Failed).
+    $runConfigScript = {
+        param($p)
+        if (-not $p.ConfigScript) { return $true }
+        if ($isWhatIf) {
+            Write-UpdateStatus "  [WhatIf] ConfigScript ($($p.Name))"
+            return $true
+        }
+        try {
+            [void](& $p.ConfigScript $p 2>$null)
+            return $true
+        } catch {
+            & $failPackage $p "ConfigScript threw: $($_.Exception.Message)"
+            return $false
+        }
+    }
+
     foreach ($pkg in $ordered) {
         $state  = 'Pending'
         $reason = $null
@@ -253,13 +274,20 @@ function Invoke-PackageUpdate {
             continue
         }
 
-        # NotInstalled / Skipped / AlreadyLatest / SelfManaged /
-        # NoAutoUpdateSupport short-circuit: no PATH refresh, no PostUpdate
-        # hook, no completion re-register. The registered completer is by
-        # definition still current for AlreadyLatest, and running
-        # PostUpdateScript on a no-op upgrade would surprise bundle authors
-        # who only intend the hook to fire after a real version bump.
-        if ($state -in @('NotInstalled', 'Skipped', 'AlreadyLatest', 'SelfManaged', 'NoAutoUpdateSupport')) {
+        # NotInstalled / Skipped: the package is not present / not processed,
+        # so there is nothing to configure -- no ConfigScript, no hooks.
+        if ($state -in @('NotInstalled', 'Skipped')) {
+            & $addState $pkg $state $reason $null $from $to
+            continue
+        }
+
+        # AlreadyLatest / SelfManaged / NoAutoUpdateSupport: the package IS
+        # installed but there was no version bump, so PATH refresh,
+        # PostUpdateScript, and completion re-register are intentionally
+        # skipped. ConfigScript STILL runs -- idempotent config is re-applied
+        # on every update regardless of whether a new version was fetched.
+        if ($state -in @('AlreadyLatest', 'SelfManaged', 'NoAutoUpdateSupport')) {
+            if (-not (& $runConfigScript $pkg)) { continue }
             & $addState $pkg $state $reason $null $from $to
             continue
         }
@@ -279,6 +307,9 @@ function Invoke-PackageUpdate {
                 }
             }
         }
+
+        # Idempotent config after a real upgrade, before completion re-register.
+        if (-not (& $runConfigScript $pkg)) { continue }
 
         # Re-register completion only when we actually upgraded — note
         # the AlreadyLatest / NotInstalled paths already short-circuited

--- a/module/MarkMichaelis.ScoopBucket/Public/Update-PackageConfig.ps1
+++ b/module/MarkMichaelis.ScoopBucket/Public/Update-PackageConfig.ps1
@@ -1,0 +1,136 @@
+function Update-PackageConfig {
+    <#
+    .SYNOPSIS
+        Re-apply the declarative ConfigScript for packages in this bucket
+        without reinstalling or updating them.
+
+    .DESCRIPTION
+        Configuration declared on a Package via its ConfigScript is
+        idempotent machine configuration (for example the MCP-server wiring
+        in the AIAgents bundle). The install / update drivers already run it
+        automatically on every install and every update, but there are times
+        you want to re-apply it on demand -- after restoring a dev machine,
+        after editing a config bundle, or simply to "refresh the MCP servers"
+        without touching the installed apps.
+
+        Update-PackageConfig walks every declarative bundle via
+        Get-BundlePackages, reconstructs the real [Package] objects
+        (ConfigScript scriptblocks intact) for each matching bundle through
+        Get-BundlePackageObjects, and invokes each package's ConfigScript.
+        Packages with no ConfigScript are ignored.
+
+        This is the on-demand counterpart to Update-PackageCompletion: where
+        that command refreshes tab-completion blocks, this one refreshes
+        package configuration.
+
+    .PARAMETER Name
+        One or more package OR bundle names to refresh (matched
+        case-insensitively against Package.Name and the bundle name). Omit
+        the parameter (or pass '*') to refresh every package that declares a
+        ConfigScript across the whole bucket.
+
+    .PARAMETER BucketPath
+        Override the auto-detected bucket directory (forwarded to
+        Get-BundlePackages / Get-BundlePackageObjects).
+
+    .OUTPUTS
+        PSCustomObject[] -- one row per package that declares a ConfigScript,
+        with Package, Bundle, Action (Applied | WhatIf | Failed) and Reason.
+
+    .EXAMPLE
+        Update-PackageConfig AIAgents
+
+        Re-apply the AIAgents configuration (re-wires the MCP servers).
+
+    .EXAMPLE
+        Update-PackageConfig
+
+        Re-apply every package's ConfigScript across the bucket.
+    #>
+    [CmdletBinding(SupportsShouldProcess, ConfirmImpact = 'Medium')]
+    [OutputType([pscustomobject[]])]
+    param(
+        [Parameter(Position = 0)][string[]]$Name,
+        [string]$BucketPath
+    )
+
+    $bundleArgs = @{}
+    if ($BucketPath) { $bundleArgs['BucketPath'] = $BucketPath }
+    $bundles = Get-BundlePackages @bundleArgs
+
+    # A null / empty / '*' filter means "every package in every bundle".
+    $matchAll = (-not $Name) -or ($Name -contains '*')
+
+    $results = New-Object System.Collections.Generic.List[object]
+
+    foreach ($b in $bundles) {
+        if (-not $b.Packages -or $b.Packages.Count -eq 0) { continue }
+
+        # Does this bundle have anything in scope? When a filter is supplied,
+        # the bundle is in scope if its name matches OR any of its package
+        # names match -- so a bundle-name request harvests the whole bundle
+        # and a package-name request harvests just the named package(s).
+        $bundleNameMatches = $false
+        if (-not $matchAll) {
+            foreach ($n in $Name) {
+                if ($b.Bundle -ieq $n) { $bundleNameMatches = $true; break }
+            }
+        }
+
+        $wantNames = $null
+        if (-not $matchAll -and -not $bundleNameMatches) {
+            $wantNames = @($b.Packages | Where-Object { $Name -contains $_.Name } | ForEach-Object Name)
+            if (-not $wantNames -or $wantNames.Count -eq 0) { continue }
+        }
+
+        # Reconstruct the real [Package] objects (scriptblocks intact). Only
+        # this harvest path preserves ConfigScript; the metadata-only
+        # Get-BundlePackages round-trip strips scriptblocks.
+        $pkgObjects = @(Get-BundlePackageObjects -BundlePath $b.BundlePath)
+
+        foreach ($p in $pkgObjects) {
+            if (-not $p.ConfigScript) { continue }
+            if ($wantNames -and ($wantNames -notcontains $p.Name)) { continue }
+
+            if ($WhatIfPreference) {
+                $results.Add([pscustomobject]@{
+                    Package = $p.Name; Bundle = $b.Bundle
+                    Action  = 'WhatIf'; Reason = ''
+                })
+                continue
+            }
+
+            if (-not $PSCmdlet.ShouldProcess("$($b.Bundle)/$($p.Name)", 'Re-apply ConfigScript')) {
+                $results.Add([pscustomobject]@{
+                    Package = $p.Name; Bundle = $b.Bundle
+                    Action  = 'Skipped'; Reason = 'Declined at the confirmation prompt.'
+                })
+                continue
+            }
+
+            try {
+                [void](& $p.ConfigScript $p 2>$null)
+                $results.Add([pscustomobject]@{
+                    Package = $p.Name; Bundle = $b.Bundle
+                    Action  = 'Applied'; Reason = ''
+                })
+            } catch {
+                $results.Add([pscustomobject]@{
+                    Package = $p.Name; Bundle = $b.Bundle
+                    Action  = 'Failed'; Reason = "ConfigScript threw: $($_.Exception.Message)"
+                })
+                Write-Error "Update-PackageConfig: $($b.Bundle)/$($p.Name) ConfigScript threw: $($_.Exception.Message)"
+            }
+        }
+    }
+
+    $arr = $results.ToArray()
+    $byAction = $arr | Group-Object Action | ForEach-Object { "$($_.Name)=$($_.Count)" }
+    if ($byAction) {
+        Write-Verbose "Update-PackageConfig: $($byAction -join ', ')"
+    } else {
+        Write-Verbose 'Update-PackageConfig: no packages declare a ConfigScript.'
+    }
+
+    return , $arr
+}


### PR DESCRIPTION
## Summary

Adds a declarative ConfigScript hook to the [Package] class so package
configuration is treated like completions -- re-applied idempotently on
**every install and every update**, and on demand -- surviving the bundle AST
harvest so it runs uniformly through `Install-Package` / `Update-Package`.
Migrates the AIAgents MCP-server wiring onto the hook as the first consumer.

### What changed

- `[Package].ConfigScript` field (idempotent config; receives the `[Package]` as `\[0]`; throw -> Failed; DryRun/WhatIf log only).
- **Install driver**: runs `ConfigScript` for every non-failed package (Installed + AlreadyInstalled).
- **Update driver**: runs `ConfigScript` for installed packages regardless of version bump (Updated **and** AlreadyLatest / SelfManaged / NoAutoUpdateSupport); NotInstalled / Skipped do not run it.
- **New `Update-PackageConfig` command** (exported): the on-demand "refresh the MCP servers" entry point. Accepts a package or bundle name (or none / `*` = all), harvests real `[Package]` objects (scriptblocks intact), and re-applies each `ConfigScript`.
- **AIAgents migration**: MCP wiring moved out of imperative tail code into `Install-AIAgentsMcpConfiguration` / `Reset-AIAgentsMcpConfiguration` in `AIAgents.Mcp.ps1` and declared via `ConfigScript` on a new `MCP Server Configuration` package. `-Reset` remains an opt-in direct-invocation path.
- README: new "Refreshing package configuration" section + pipeline / migration-status updates.

### Tests

Behavior-first Pester throughout. Full Light suite: **1452 passed, 0 failed, 3 skipped**.

- `Package.Tests.ps1` -- ConfigScript field.
- `PackageInstall.Tests.ps1` -- install-path hook (Installed, AlreadyInstalled, `\[0]`, throw->Failed, DryRun no-run).
- `UpdatePackage.Tests.ps1` -- update-path hook (Updated, AlreadyLatest still runs, NotInstalled no-run, throw->Failed, WhatIf no-run).
- `GetBundlePackageObjects.Tests.ps1` -- ConfigScript survives the AST harvest.
- `UpdatePackageConfig.Tests.ps1` -- the new command end-to-end.
- `AIAgents.Mcp.Tests.ps1` / `AIAgents.Tests.ps1` -- orchestration wiring + declarative ConfigScript on the bundle.

### Test locally

```powershell
Invoke-Pester -Path .\bucket\PackageInstall.Tests.ps1,.\bucket\UpdatePackage.Tests.ps1,.\bucket\UpdatePackageConfig.Tests.ps1,.\bucket\AIAgents.Mcp.Tests.ps1,.\bucket\AIAgents.Tests.ps1,.\bucket\GetBundlePackageObjects.Tests.ps1 -Output Minimal
```

Closes #297