### PR TITLE
Unify install/update preview on ShouldProcess/-WhatIf with -DryRun alias

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,7 +123,18 @@ Get-Package -Installer scoop      # filter by engine
 Get-Package -Name 'rip*','Bit*'   # wildcard
 Install-Package -Name 'BitwardenCli'   # auto-pulls Bitwarden via DependsOn
 Install-Package -Name beyon<Tab>       # Tab-completes to 'Beyond Compare'
+Install-Package -Name 'ripgrep' -DryRun   # preview, no real install
+Update-Package  -Name 'ripgrep' -DryRun   # preview, no real update
 ```
+
+**Preview is one opt-in mechanism.** `Install-Package` and
+`Update-Package` build on PowerShell's standard
+`SupportsShouldProcess`, so `-WhatIf` and `-Confirm` work for free.
+`-DryRun` is the preferred alias for the same preview: it simply sets
+`$WhatIfPreference = $true` for the call, so `-DryRun` and `-WhatIf`
+drive identical behavior (plan every action, emit the planned result
+rows, invoke no engines). Preview is **opt-in** -- the default actually
+installs/updates, and `-WhatIf:$false` forces execution.
 
 `-Name` on both `Install-Package` and `Get-Package` registers a Tab
 completer that suggests every package declared in any bundle (prefix

--- a/bucket/DryRunWhatIfParity.Tests.ps1
+++ b/bucket/DryRunWhatIfParity.Tests.ps1
@@ -1,0 +1,142 @@
+#requires -Version 7.0
+#requires -Modules @{ ModuleName = 'Pester'; ModuleVersion = '5.0.0' }
+
+# Behavior-first regression: -DryRun and -WhatIf must drive ONE preview
+# mechanism (ShouldProcess / $WhatIfPreference). -DryRun is retained as a
+# first-class alias that routes through the SAME code path as -WhatIf.
+# Preview is opt-in: the default (no switch) performs the real install/update.
+# See #299.
+
+BeforeAll {
+    $script:repoRoot   = Split-Path -Parent $PSScriptRoot
+    $script:moduleRoot = Join-Path $script:repoRoot 'module\MarkMichaelis.ScoopBucket'
+    $script:psd1       = Join-Path $script:moduleRoot 'MarkMichaelis.ScoopBucket.psd1'
+
+    Import-Module $script:psd1 -Force
+
+    # Throwaway bucket with a single winget package so Install-Package /
+    # Update-Package have a declarative [Package] to dispatch.
+    $script:tmpBucket = Join-Path ([System.IO.Path]::GetTempPath()) ("ScoopBucket-preview-$([guid]::NewGuid().ToString('N'))")
+    New-Item -ItemType Directory -Path $script:tmpBucket | Out-Null
+
+    $bundleText = @"
+`$scoopBucketPsd1 = '$($script:psd1 -replace "'","''")'
+if (Test-Path `$scoopBucketPsd1) { Import-Module `$scoopBucketPsd1 -Force } else { Import-Module MarkMichaelis.ScoopBucket -Force }
+
+`$Packages = [Package[]]@(
+    [Package]@{ Name = 'solo'; Installer = 'winget'; Id = 'Test.Solo' }
+)
+
+Invoke-PackageInstall -Packages `$Packages -Bundle 'PreviewBundle'
+"@
+    Set-Content -Path (Join-Path $script:tmpBucket 'PreviewBundle.ps1') -Value $bundleText -Encoding UTF8
+
+    $bundleManifest = @{
+        '$schema'  = 'https://raw.githubusercontent.com/lukesampson/scoop/master/schema.json'
+        version   = '1.00.000'
+        url       = @('https://example.invalid/preview-bundle')
+        installer = @{ script = @('& "$dir\\PreviewBundle.ps1"') }
+    }
+    Set-Content -LiteralPath (Join-Path $script:tmpBucket 'PreviewBundle.json') `
+        -Value ($bundleManifest | ConvertTo-Json -Depth 4) -Encoding UTF8
+}
+
+AfterAll {
+    if ($script:tmpBucket -and (Test-Path $script:tmpBucket)) {
+        Remove-Item -LiteralPath $script:tmpBucket -Recurse -Force -ErrorAction Ignore
+    }
+}
+
+Describe 'Install-Package preview: -WhatIf / -DryRun parity' -Tag 'Light', 'Module' {
+    BeforeEach {
+        # The engine branches on its own -WhatIf switch: a preview run must
+        # reach it with $WhatIf = $true (no real install); a real run reaches
+        # it with $WhatIf = $false. Encode that in the returned Reason so a
+        # parity test can assert the mechanism, not just the wording.
+        Mock -ModuleName MarkMichaelis.ScoopBucket Install-WingetPackage {
+            if ($WhatIf) { return @{ State = 'Installed'; Reason = '(WhatIf)' } }
+            return @{ State = 'Installed'; Reason = 'REAL-INSTALL' }
+        }
+    }
+
+    It '-WhatIf performs no real install but emits a planned PackageResult row' {
+        $r = @(Install-Package -Name 'solo' -WhatIf -SkipCompletion -BucketPath $script:tmpBucket)
+
+        $r.Count     | Should -Be 1
+        $r.Name      | Should -Be 'solo'
+        $r.Installer | Should -Be 'winget'
+        $r.Id        | Should -Be 'Test.Solo'
+        $r.Status    | Should -Be 'Installed'
+        $r.Reason    | Should -Be '(WhatIf)'
+        Should -Invoke -ModuleName MarkMichaelis.ScoopBucket Install-WingetPackage `
+            -Times 1 -Exactly -ParameterFilter { $WhatIf -eq $true }
+        Should -Not -Invoke -ModuleName MarkMichaelis.ScoopBucket Install-WingetPackage `
+            -ParameterFilter { $WhatIf -ne $true }
+    }
+
+    It '-DryRun behaves identically to -WhatIf (same no-op, same planned row)' {
+        $r = @(Install-Package -Name 'solo' -DryRun -SkipCompletion -BucketPath $script:tmpBucket)
+
+        $r.Count  | Should -Be 1
+        $r.Name   | Should -Be 'solo'
+        $r.Status | Should -Be 'Installed'
+        $r.Reason | Should -Be '(WhatIf)'
+        Should -Invoke -ModuleName MarkMichaelis.ScoopBucket Install-WingetPackage `
+            -Times 1 -Exactly -ParameterFilter { $WhatIf -eq $true }
+        Should -Not -Invoke -ModuleName MarkMichaelis.ScoopBucket Install-WingetPackage `
+            -ParameterFilter { $WhatIf -ne $true }
+    }
+
+    It 'default (no switch) performs the real install (preview is opt-in)' {
+        $r = @(Install-Package -Name 'solo' -SkipCompletion -BucketPath $script:tmpBucket)
+
+        $r.Status | Should -Be 'Installed'
+        $r.Reason | Should -Be 'REAL-INSTALL'
+        Should -Invoke -ModuleName MarkMichaelis.ScoopBucket Install-WingetPackage `
+            -Times 1 -Exactly -ParameterFilter { -not $WhatIf }
+    }
+
+    It '-WhatIf:$false forces the real install' {
+        $r = @(Install-Package -Name 'solo' -WhatIf:$false -SkipCompletion -BucketPath $script:tmpBucket)
+
+        $r.Reason | Should -Be 'REAL-INSTALL'
+        Should -Invoke -ModuleName MarkMichaelis.ScoopBucket Install-WingetPackage `
+            -Times 1 -Exactly -ParameterFilter { -not $WhatIf }
+    }
+}
+
+Describe 'Update-Package preview: -WhatIf / -DryRun parity' -Tag 'Light', 'Module' {
+    BeforeEach {
+        # Empty index => the WhatIf path plans an update without probing real
+        # engines; a real run reaches Update-WingetPackage.
+        Mock -ModuleName MarkMichaelis.ScoopBucket Get-PackageUpdateIndex { @{} }
+        Mock -ModuleName MarkMichaelis.ScoopBucket Update-WingetPackage {
+            return @{ State = 'Updated'; Reason = 'REAL-UPDATE' }
+        }
+    }
+
+    It '-WhatIf plans the update without invoking the engine' {
+        $r = @(Update-Package -Name 'solo' -WhatIf -SkipCompletion -BucketPath $script:tmpBucket)
+
+        $r.Name   | Should -Be 'solo'
+        $r.Status | Should -Be 'Updated'
+        $r.Reason | Should -Match 'WhatIf'
+        Should -Not -Invoke -ModuleName MarkMichaelis.ScoopBucket Update-WingetPackage
+    }
+
+    It '-DryRun behaves identically to -WhatIf' {
+        $r = @(Update-Package -Name 'solo' -DryRun -SkipCompletion -BucketPath $script:tmpBucket)
+
+        $r.Name   | Should -Be 'solo'
+        $r.Status | Should -Be 'Updated'
+        $r.Reason | Should -Match 'WhatIf'
+        Should -Not -Invoke -ModuleName MarkMichaelis.ScoopBucket Update-WingetPackage
+    }
+
+    It 'default (no switch) invokes the real update engine (preview is opt-in)' {
+        $r = @(Update-Package -Name 'solo' -SkipCompletion -SkipBucketRefresh -BucketPath $script:tmpBucket)
+
+        $r.Reason | Should -Be 'REAL-UPDATE'
+        Should -Invoke -ModuleName MarkMichaelis.ScoopBucket Update-WingetPackage -Times 1 -Exactly
+    }
+}

--- a/docs/designs/2026-06-03-dryrun-whatif-unification-plan.md
+++ b/docs/designs/2026-06-03-dryrun-whatif-unification-plan.md
@@ -1,0 +1,39 @@
+# Plan: Unify install/update preview on ShouldProcess/-WhatIf with -DryRun alias
+
+Issue: #299
+Branch: refactor/299-dryrun-whatif
+
+## Design
+
+Single preview mechanism = `$WhatIfPreference` / ShouldProcess. `-DryRun` becomes a
+first-class alias: each public/driver function sets `$WhatIfPreference = $true` for the
+call scope when `-DryRun` is supplied, then derives a local `$isWhatIf = [bool]$WhatIfPreference`
+and keys every preview branch off that single boolean. `-WhatIf` / `-Confirm` continue to
+work for free via `SupportsShouldProcess`. Preview stays opt-in; default executes;
+`-WhatIf:$false` forces execution.
+
+The private engine helpers (`Install-WingetPackage`, etc.) already take the standard
+`[switch]$WhatIf` and return the `{ State; Reason }` contract -- they are NOT the custom
+plumbing being removed (they never had `-DryRun`). They stay as-is; the drivers forward
+`-WhatIf:$isWhatIf` to them.
+
+## Tasks
+
+1. TDD: add `bucket/DryRunWhatIfParity.Tests.ps1` proving the install + update trios
+   (-WhatIf no-op + planned rows; -DryRun identical; default executes; -WhatIf:$false executes).
+2. `Invoke-PackageInstall.ps1`: bridge `-DryRun` -> `$WhatIfPreference`; derive `$isWhatIf`;
+   replace every `if ($DryRun)` / `-not $DryRun` with `$isWhatIf`; forward `-WhatIf:$isWhatIf`
+   to engines; update `.PARAMETER DryRun` doc.
+3. `Install-Package.ps1`: bridge `-DryRun` -> `$WhatIfPreference`; derive `$isWhatIf`; gate
+   the bare-manifest path (c) with `$PSCmdlet.ShouldProcess`; forward `-DryRun:$isWhatIf`;
+   replace `-not $DryRun` with `-not $isWhatIf`; rewrite the ~192-200 comment + `.PARAMETER`.
+4. `Update-Package.ps1`: add `[switch]$DryRun` alias param; bridge before the existing
+   `$isWhatIf = [bool]$WhatIfPreference`; add `.PARAMETER DryRun` + example.
+5. `Invoke-PackageUpdate.ps1`: add `[switch]$DryRun` alias param; bridge to `$WhatIfPreference`.
+6. README: add a short preview note describing -DryRun/-WhatIf as one opt-in mechanism.
+7. Run focused tests + full safe sweep; PR; Copilot review; rebase-merge; cleanup.
+
+## Verification
+
+`Invoke-Pester` safe sweep (ExcludeTag Heavy,CliAvailability,Integration,Slow,Install) on
+`bucket` green; CI green.

--- a/module/MarkMichaelis.ScoopBucket/Public/Install-Package.ps1
+++ b/module/MarkMichaelis.ScoopBucket/Public/Install-Package.ps1
@@ -30,7 +30,13 @@ function Install-Package {
         Package.Name).
 
     .PARAMETER DryRun
-        Plan only — log every action without invoking engines.
+        Preview only — plan every action without invoking engines.
+        `-DryRun` is the preferred ALIAS for the idiomatic `-WhatIf`
+        preview: supplying it sets `$WhatIfPreference = $true` for the
+        whole call so it and `-WhatIf` (and `-Confirm`) drive the SAME
+        ShouldProcess machinery across every dispatch path. Preview is
+        opt-in; the default performs real installs, and `-WhatIf:$false`
+        forces execution.
 
     .PARAMETER SkipCompletion
         Don't attempt completion registration.
@@ -57,6 +63,14 @@ function Install-Package {
         [switch]$IncludeUnchanged,
         [string]$BucketPath
     )
+
+    # Bridge the preferred `-DryRun` alias into the single preview mechanism:
+    # set $WhatIfPreference for this scope so `-DryRun`, `-WhatIf`, and
+    # `-Confirm` all flow through the same ShouldProcess checks (the engine
+    # `-WhatIf` gates on paths (a)/(b) and the $PSCmdlet.ShouldProcess gate on
+    # the bare-manifest path (c) below). Derive one boolean to thread through.
+    if ($DryRun) { $WhatIfPreference = $true }
+    $isWhatIf = [bool]$WhatIfPreference
 
     $bundleArgs = @{}
     if ($BucketPath) { $bundleArgs['BucketPath'] = $BucketPath }
@@ -161,7 +175,7 @@ function Install-Package {
         $pkgObjects = @(Get-BundlePackageObjects -BundlePath $entry.BundlePath)
         $results.AddRange([object[]]@(
             Invoke-PackageInstall -Packages $pkgObjects -Bundle $entry.Bundle `
-                -Name @($entry.Names) -DryRun:$DryRun -SkipCompletion:$SkipCompletion `
+                -Name @($entry.Names) -DryRun:$isWhatIf -SkipCompletion:$SkipCompletion `
                 -ErrorAction Continue -ErrorVariable +pkgErrors))
     }
 
@@ -171,7 +185,7 @@ function Install-Package {
         $pkgObjects = @(Get-BundlePackageObjects -BundlePath $b.BundlePath)
         $results.AddRange([object[]]@(
             Invoke-PackageInstall -Packages $pkgObjects -Bundle $b.Bundle `
-                -DryRun:$DryRun -SkipCompletion:$SkipCompletion `
+                -DryRun:$isWhatIf -SkipCompletion:$SkipCompletion `
                 -ErrorAction Continue -ErrorVariable +pkgErrors))
     }
 
@@ -189,12 +203,12 @@ function Install-Package {
     $manifestPackagesToImport = New-Object System.Collections.Generic.List[object]
     foreach ($n in $manifestNames) {
         Write-UpdateStatus -Activity 'Install-Package' "Install-Package: dispatching manifest '$n' via scoop install (no declarative [Package] match)..."
-        # Preview mode is uniform across all dispatch paths: -DryRun is the
-        # module's single preview switch (paths (a)/(b) forward it to
-        # Invoke-PackageInstall; here we short-circuit). We deliberately do
-        # NOT add a path-specific -WhatIf gate, which would make preview
-        # behave differently here than for the Package.Name / bundle paths.
-        if ($DryRun) {
+        # Preview mode is uniform across all dispatch paths via the single
+        # ShouldProcess mechanism. Paths (a)/(b) forward the preview flag to
+        # Invoke-PackageInstall; here we gate the real `scoop install` with
+        # $PSCmdlet.ShouldProcess so `-DryRun`/`-WhatIf`/`-Confirm` all skip
+        # the engine call identically while still logging the planned action.
+        if (-not $PSCmdlet.ShouldProcess($n, 'scoop install')) {
             Write-UpdateStatus -Activity 'Install-Package' "  [DryRun] scoop install $n"
             continue
         }
@@ -283,7 +297,7 @@ function Install-Package {
     # invoke Register-ArgumentCompleter directly in the current session.
     # Register-ArgumentCompleter -Native is process-global so this works
     # regardless of module scope.
-    if (-not $SkipCompletion -and -not $DryRun) {
+    if (-not $SkipCompletion -and -not $isWhatIf) {
         # NOTE: List[object] (not List[Package]) because $b.Packages items
         # are JSON-deserialized PSCustomObjects from Get-BundlePackages'
         # child runspace, not real [Package] instances. PowerShell can't

--- a/module/MarkMichaelis.ScoopBucket/Public/Invoke-PackageInstall.ps1
+++ b/module/MarkMichaelis.ScoopBucket/Public/Invoke-PackageInstall.ps1
@@ -66,9 +66,12 @@ function Invoke-PackageInstall {
         Drop these packages. Packages that DependsOn-ed them log a warning.
 
     .PARAMETER DryRun
-        Plan only — log every action without invoking engines. Named
-        DryRun instead of WhatIf because SupportsShouldProcess already
-        steals -WhatIf for ShouldProcess prompts.
+        Preview only — plan every action without invoking engines.
+        `-DryRun` is a first-class ALIAS for the standard `-WhatIf`
+        preview: it simply sets `$WhatIfPreference = $true` for the call
+        scope, so it and `-WhatIf` drive the SAME ShouldProcess machinery
+        (the per-engine `-WhatIf` checks, the per-hook guards below).
+        Preview is opt-in; the default performs the real install.
 
     .PARAMETER SkipCompletion
         Don't attempt completion registration (used by tests / CI when
@@ -84,6 +87,14 @@ function Invoke-PackageInstall {
         [switch]$DryRun,
         [switch]$SkipCompletion
     )
+
+    # Bridge the `-DryRun` alias into the single preview mechanism: flipping
+    # $WhatIfPreference for this scope makes every nested `$PSCmdlet.ShouldProcess`
+    # / `-WhatIf` check (here and in the engines) treat the run as a preview, so
+    # `-DryRun` and `-WhatIf` are indistinguishable downstream. Derive one
+    # boolean and key every preview branch off it.
+    if ($DryRun) { $WhatIfPreference = $true }
+    $isWhatIf = [bool]$WhatIfPreference
 
     # Cross-field validation is intentionally NOT done in a pre-loop. A
     # single malformed declaration must fail only THAT package (as a Failed
@@ -152,7 +163,7 @@ function Invoke-PackageInstall {
 
         try {
             if ($pkg.CustomInstallScript) {
-                if ($DryRun) {
+                if ($isWhatIf) {
                     Write-UpdateStatus -Activity 'Install-Package' "  [DryRun] CustomInstallScript"
                     $result = @{ State = 'Installed'; Reason = '(DryRun)' }
                 } else {
@@ -167,11 +178,11 @@ function Invoke-PackageInstall {
                 }
             } else {
                 $result = switch ($pkg.Installer) {
-                    'winget'      { Install-WingetPackage     -Package $pkg -WhatIf:$DryRun }
-                    'scoop'       { Install-ScoopPackage      -Package $pkg -WhatIf:$DryRun }
-                    'choco'       { Install-ChocoPackage      -Package $pkg -WhatIf:$DryRun }
-                    'npmGlobal'   { Install-NpmGlobalPackage  -Package $pkg -WhatIf:$DryRun }
-                    'dotnetTool'  { Install-DotnetToolPackage -Package $pkg -WhatIf:$DryRun }
+                    'winget'      { Install-WingetPackage     -Package $pkg -WhatIf:$isWhatIf }
+                    'scoop'       { Install-ScoopPackage      -Package $pkg -WhatIf:$isWhatIf }
+                    'choco'       { Install-ChocoPackage      -Package $pkg -WhatIf:$isWhatIf }
+                    'npmGlobal'   { Install-NpmGlobalPackage  -Package $pkg -WhatIf:$isWhatIf }
+                    'dotnetTool'  { Install-DotnetToolPackage -Package $pkg -WhatIf:$isWhatIf }
                     default       { throw "Invoke-PackageInstall: unknown Installer '$($pkg.Installer)' for '$($pkg.Name)'." }
                 }
             }
@@ -190,10 +201,10 @@ function Invoke-PackageInstall {
             continue
         }
 
-        if (-not $DryRun) { Update-PathFromRegistry }
+        if (-not $isWhatIf) { Update-PathFromRegistry }
 
         if ($pkg.PostInstallScript) {
-            if ($DryRun) {
+            if ($isWhatIf) {
                 Write-UpdateStatus -Activity 'Install-Package' "  [DryRun] PostInstallScript"
             } else {
                 try {
@@ -210,7 +221,7 @@ function Invoke-PackageInstall {
             }
         }
 
-        if (-not $DryRun) {
+        if (-not $isWhatIf) {
             $verified = Test-PackageInstalled -Package $pkg
             if (-not $verified -and ($pkg.CliCommands.Count -gt 0 -or $pkg.VerifyScript)) {
                 Write-Warning "  $($pkg.Name): verification failed (CliCommands not on PATH and/or VerifyScript=false)."
@@ -222,7 +233,7 @@ function Invoke-PackageInstall {
         # nature of completion registration. A throw fails the package, like
         # PostInstallScript. See [Package].ConfigScript.
         if ($pkg.ConfigScript) {
-            if ($DryRun) {
+            if ($isWhatIf) {
                 Write-UpdateStatus -Activity 'Install-Package' "  [DryRun] ConfigScript ($($pkg.Name))"
             } else {
                 try {
@@ -235,7 +246,7 @@ function Invoke-PackageInstall {
             }
         }
 
-        if (-not $SkipCompletion -and -not $DryRun -and
+        if (-not $SkipCompletion -and -not $isWhatIf -and
             $pkg.Completion -ne 'none' -and $pkg.CliCommands.Count -gt 0) {
             foreach ($cli in $pkg.CliCommands) {
                 $registerArgs = @{ Cli = $cli; Mode = $pkg.Completion }

--- a/module/MarkMichaelis.ScoopBucket/Public/Invoke-PackageUpdate.ps1
+++ b/module/MarkMichaelis.ScoopBucket/Public/Invoke-PackageUpdate.ps1
@@ -40,6 +40,9 @@ function Invoke-PackageUpdate {
         [string[]]$Name,
         [string[]]$Skip,
         [switch]$SkipCompletion,
+        # Preferred alias for the standard -WhatIf preview. Bridged into
+        # $WhatIfPreference below so -DryRun and -WhatIf drive one mechanism.
+        [switch]$DryRun,
         # Per-package winget timeout in minutes (0 disables). Forwarded
         # to Update-WingetPackage only; other engines are unaffected.
         # Default 5 minutes; bundles can override per-package via
@@ -49,7 +52,9 @@ function Invoke-PackageUpdate {
 
     # The driver advertises SupportsShouldProcess, so -WhatIf flips
     # $WhatIfPreference in this scope (and is inherited by callees). Engines
-    # key off -WhatIf, so thread this boolean through dispatch.
+    # key off -WhatIf, so thread this boolean through dispatch. The preferred
+    # `-DryRun` alias bridges into the same flag for one preview mechanism.
+    if ($DryRun) { $WhatIfPreference = $true }
     $isWhatIf = [bool]$WhatIfPreference
 
     # NOTE: cross-field validation is deliberately NOT done in a pre-loop

--- a/module/MarkMichaelis.ScoopBucket/Public/Update-Package.ps1
+++ b/module/MarkMichaelis.ScoopBucket/Public/Update-Package.ps1
@@ -88,6 +88,13 @@ function Update-Package {
         few-seconds refresh cost, or when running offline. Has no
         effect under -WhatIf or -MachineWide (which bypass it already).
 
+    .PARAMETER DryRun
+        Preview only — plan the update without invoking engines. `-DryRun`
+        is the preferred ALIAS for the idiomatic `-WhatIf` preview:
+        supplying it sets `$WhatIfPreference = $true` for the whole call so
+        it and `-WhatIf` (and `-Confirm`) drive the SAME ShouldProcess
+        machinery. Preview is opt-in; the default performs real updates.
+
     .PARAMETER BucketPath
         Override the auto-detected bucket directory.
 
@@ -96,6 +103,10 @@ function Update-Package {
 
     .EXAMPLE
         Update-Package -Name '*' -WhatIf
+
+    .EXAMPLE
+        Update-Package -Name 'ripgrep' -DryRun
+        # -DryRun is an alias for -WhatIf: previews without updating.
 
     .EXAMPLE
         Update-Package -Name 'OSBasePackages'
@@ -117,6 +128,10 @@ function Update-Package {
         [switch]$MachineWide,
         [switch]$SkipCompletion,
         [switch]$SkipBucketRefresh,
+        # Preferred alias for the standard -WhatIf preview (see .PARAMETER
+        # DryRun). Bridged into $WhatIfPreference below so both spellings
+        # drive one ShouldProcess mechanism.
+        [switch]$DryRun,
         # Show every package in the result table, including unchanged rows
         # (AlreadyLatest / NotInstalled / SelfManaged / NoAutoUpdateSupport /
         # Skipped). By default only changed rows (Updated / Failed) are shown
@@ -134,7 +149,9 @@ function Update-Package {
 
     # Update-Package advertises SupportsShouldProcess, so -WhatIf flips
     # $WhatIfPreference in this scope (and is inherited by Invoke-PackageUpdate
-    # and the engines, which key off -WhatIf). Thread this boolean through.
+    # and the engines, which key off -WhatIf). The preferred `-DryRun` alias
+    # bridges into the same flag so both spellings preview identically.
+    if ($DryRun) { $WhatIfPreference = $true }
     $isWhatIf = [bool]$WhatIfPreference
 
     # Machine-wide sweep: bypass bundle resolution entirely and dispatch


### PR DESCRIPTION
## Summary

Unifies the install/update preview on PowerShell's idiomatic
`SupportsShouldProcess` / `-WhatIf` / `$WhatIfPreference` mechanism and keeps
`-DryRun` as a first-class alias that routes through the SAME code path.

Before this change the two switches diverged: `Install-Package -WhatIf` did NOT
suppress the real install on the primary (Package.Name) path -- only `-DryRun`
did -- and `Update-Package` exposed no `-DryRun` at all.

## What changed

- `Install-Package` / `Invoke-PackageInstall`: `-DryRun` now bridges into
  `$WhatIfPreference` at the top of the function (`if ($DryRun) { $WhatIfPreference = $true }`),
  and every preview branch keys off one derived `$isWhatIf` boolean instead of a
  separate `$DryRun` flag. The bare-manifest dispatch path now gates the real
  `scoop install` through `$PSCmdlet.ShouldProcess`.
- `Update-Package` / `Invoke-PackageUpdate`: gain a `[switch]$DryRun` alias that
  bridges into the existing `$WhatIfPreference`-driven path.
- Private engine helpers are unchanged: they already take the standard
  `[switch]$WhatIf` and return the `{ State; Reason }` contract, and the drivers
  forward `-WhatIf:$isWhatIf` to them.
- README + `.PARAMETER` docs describe the single opt-in model.

## Behavior

- `Install-Package -Name <x> -WhatIf` performs NO real install but emits planned
  `PackageResult` rows.
- `Install-Package -Name <x> -DryRun` behaves identically to `-WhatIf`.
- `Update-Package` gets the same `-WhatIf` / `-DryRun` / default trio.
- Default (no switch) still performs real installs/updates (preview is opt-in).
- `-WhatIf:$false` forces execution.

## Tests

New behavior-first regression `bucket/DryRunWhatIfParity.Tests.ps1` (7 cases)
proves the install + update parity trios. Each new assertion fails for a
behavioral reason on the pre-change code (the `-WhatIf` install ran for real;
`Update-Package -DryRun` did not exist).

Safe sweep (ExcludeTag Heavy, CliAvailability, Integration, Slow, Install) on
`bucket`: 1479 passed, 0 failed, 2 skipped. PSScriptAnalyzer: no new findings
vs main (the change adds a real `ShouldProcess` call to `Install-Package`).

Closes #299
