### PR TITLE
Bucket reorg Phase 1: recursion + loader enablers (no moves)

### DIFF
--- a/.github/scripts/Get-PackageCommands.ps1
+++ b/.github/scripts/Get-PackageCommands.ps1
@@ -355,7 +355,7 @@ try {
 # Bundles already covered by the declarative source above are skipped.
 # ---------------------------------------------------------------------------
 
-$bundleScripts = Get-ChildItem -Path $BucketPath -Filter *.ps1 |
+$bundleScripts = Get-ChildItem -Path $BucketPath -Filter *.ps1 -Recurse |
     Where-Object { $_.Name -notlike '*.Tests.ps1' } |
     Where-Object {
         $stem = [System.IO.Path]::GetFileNameWithoutExtension($_.Name)

--- a/bucket/BucketManifestVersion.Tests.ps1
+++ b/bucket/BucketManifestVersion.Tests.ps1
@@ -22,7 +22,7 @@
 BeforeDiscovery {
     $script:BucketRoot = $PSScriptRoot
     $script:ManifestCases = @(
-        Get-ChildItem -Path $script:BucketRoot -Filter '*.json' -File | ForEach-Object {
+        Get-ChildItem -Path $script:BucketRoot -Filter '*.json' -File -Recurse | ForEach-Object {
             [pscustomobject]@{
                 Name = $_.Name
                 Path = $_.FullName

--- a/bucket/CompletionCoverage.Tests.ps1
+++ b/bucket/CompletionCoverage.Tests.ps1
@@ -35,7 +35,7 @@ Describe 'Completion coverage catalog is honoured' -Tag 'Light','CompletionCover
         # Every `Register-CliCompletion -Cli <name>` actually present in the
         # bucket scripts (the registrations that must each be catalogued).
         $script:registeredClis = @(
-            Get-ChildItem -Path $script:bucketDir -Filter '*.ps1' -File |
+            Get-ChildItem -Path $script:bucketDir -Filter '*.ps1' -File -Recurse |
                 Where-Object { $_.Name -notlike '*.Tests.ps1' } |
                 ForEach-Object {
                     $text = Get-Content -Raw -Path $_.FullName

--- a/bucket/FolderedDiscovery.Tests.ps1
+++ b/bucket/FolderedDiscovery.Tests.ps1
@@ -1,0 +1,98 @@
+<#
+.SYNOPSIS
+    Phase 1 enabler regression coverage for the grouped bucket layout (#302, #300).
+
+.DESCRIPTION
+    The bucket reorg files member manifests/bundles into category subfolders
+    (os/ client/ developer/ ai/ + admin/). Two engine behaviors must keep
+    working once files are no longer flat in bucket/:
+
+      * Get-BundlePackages must discover a bundle that lives in a SUBFOLDER
+        (it globs bucket/*.ps1 -- the glob must be -Recurse).
+      * A bundle discovered from a subfolder must still surface its companion
+        package + completion metadata, so a member like "Everything" still
+        auto-installs its companion CLI and registers completions after it is
+        moved into os/.
+
+    The module loader (MarkMichaelis.ScoopBucket.psm1) must also stop
+    dot-sourcing *.Tests.ps1 from Public/Private/Classes, so that module tests
+    can be co-located beside the code they exercise without being loaded at
+    import time.
+
+    Each test fails for a behavioral reason (missing bundle / missing metadata /
+    leaked sentinel function) when the corresponding -Recurse / *.Tests.ps1
+    skip is reverted.
+#>
+
+BeforeAll {
+    $script:moduleManifest = Resolve-Path (Join-Path (Split-Path -Parent $PSScriptRoot) 'module\MarkMichaelis.ScoopBucket\MarkMichaelis.ScoopBucket.psd1')
+    Import-Module $script:moduleManifest -Force
+
+    function script:Invoke-GetBundlePackages {
+        param([string]$BucketPath)
+        & (Get-Module MarkMichaelis.ScoopBucket) {
+            param($p) Get-BundlePackages -BucketPath $p
+        } $BucketPath
+    }
+}
+
+Describe 'Get-BundlePackages foldered discovery' -Tag 'Light', 'Module' {
+
+    BeforeAll {
+        # A migrated declarative bundle nested one level deep inside the bucket.
+        $script:groupDir = Join-Path $TestDrive 'os'
+        New-Item -ItemType Directory -Path $script:groupDir -Force | Out-Null
+        $script:bundlePath = Join-Path $script:groupDir 'Widget.ps1'
+        Set-Content -LiteralPath $script:bundlePath -Encoding utf8 -Value @'
+$Packages = [Package[]]@(
+    [Package]@{
+        Name                = 'Widget'
+        Installer           = 'winget'
+        Id                  = 'Acme.Widget'
+        Companions          = @('Acme.Widget.Cli')
+        ExpectedCompletions = @{ widget = @('--help', '--version') }
+    }
+)
+Invoke-PackageInstall -Packages $Packages -Bundle 'Widget'
+'@
+        $script:result = @(script:Invoke-GetBundlePackages -BucketPath $TestDrive)
+        $script:widget = $script:result | Where-Object { $_.Bundle -eq 'Widget' }
+    }
+
+    It 'discovers a bundle that lives in a bucket subfolder' {
+        $script:widget | Should -Not -BeNullOrEmpty
+        @($script:widget.Packages).Count | Should -Be 1
+        $script:widget.Packages[0].Name | Should -Be 'Widget'
+    }
+
+    It 'preserves the companion package + completion metadata of a foldered bundle' {
+        $pkg = $script:widget.Packages[0]
+        @($pkg.Companions) | Should -Contain 'Acme.Widget.Cli'
+        $pkg.ExpectedCompletions.widget | Should -Contain '--help'
+    }
+}
+
+Describe 'Module loader skips co-located *.Tests.ps1' -Tag 'Light', 'Module' {
+
+    It 'does not dot-source a *.Tests.ps1 dropped into Public/ at import' {
+        $moduleRoot = Split-Path -Parent (Split-Path -Parent $script:moduleManifest)
+        $sourceDir = Join-Path $moduleRoot 'MarkMichaelis.ScoopBucket'
+        $copyRoot = Join-Path $TestDrive 'ModuleCopy'
+        Copy-Item -Path $sourceDir -Destination $copyRoot -Recurse -Force
+
+        $sentinelName = 'SBLoaderSentinel_' + [guid]::NewGuid().ToString('N')
+        $sentinel = Join-Path (Join-Path $copyRoot 'Public') 'ZzzLoader.Tests.ps1'
+        Set-Content -LiteralPath $sentinel -Encoding utf8 -Value "function global:$sentinelName { 'loaded' }"
+
+        try {
+            Import-Module (Join-Path $copyRoot 'MarkMichaelis.ScoopBucket.psd1') -Force
+            Get-Command $sentinelName -ErrorAction SilentlyContinue |
+                Should -BeNullOrEmpty -Because 'a *.Tests.ps1 file in Public/ must not be dot-sourced at module import'
+        }
+        finally {
+            Remove-Item "Function:\$sentinelName" -ErrorAction SilentlyContinue
+            Remove-Module MarkMichaelis.ScoopBucket -Force -ErrorAction SilentlyContinue
+            Import-Module $script:moduleManifest -Force
+        }
+    }
+}

--- a/bucket/ManifestUrlSelfReferences.Tests.ps1
+++ b/bucket/ManifestUrlSelfReferences.Tests.ps1
@@ -24,7 +24,7 @@ BeforeDiscovery {
     $script:SelfRefPrefix = 'https://raw.githubusercontent.com/MarkMichaelis/ScoopBucket/main/'
 
     $script:UrlCases = @()
-    Get-ChildItem -Path $script:BucketRoot -Filter '*.json' -File | ForEach-Object {
+    Get-ChildItem -Path $script:BucketRoot -Filter '*.json' -File -Recurse | ForEach-Object {
         $manifestPath = $_.FullName
         $manifestName = $_.BaseName
         try {

--- a/bucket/PSCompletionsNotAutoInstalled.Tests.ps1
+++ b/bucket/PSCompletionsNotAutoInstalled.Tests.ps1
@@ -22,7 +22,7 @@ Describe 'PSCompletions hard dependency removed' -Tag 'Light','Module' {
 
     It 'no production bucket file declares Completion=pscompletions' {
         $bucketDir = Join-Path $script:repoRoot 'bucket'
-        $offenders = Get-ChildItem -Path $bucketDir -Filter '*.ps1' |
+        $offenders = Get-ChildItem -Path $bucketDir -Filter '*.ps1' -Recurse |
             Where-Object { $_.Name -notmatch '\.Tests\.ps1$' } |
             Where-Object {
                 $raw = Get-Content -Raw -Encoding UTF8 -LiteralPath $_.FullName

--- a/module/MarkMichaelis.ScoopBucket/MarkMichaelis.ScoopBucket.psm1
+++ b/module/MarkMichaelis.ScoopBucket/MarkMichaelis.ScoopBucket.psm1
@@ -21,7 +21,7 @@ $ErrorActionPreference = 'Stop'
 foreach ($dir in @('Private', 'Public')) {
     $folder = Join-Path $PSScriptRoot $dir
     if (-not (Test-Path $folder)) { continue }
-    foreach ($file in Get-ChildItem -Path $folder -Filter '*.ps1' -File) {
+    foreach ($file in Get-ChildItem -Path $folder -Filter '*.ps1' -File | Where-Object { $_.Name -notmatch '\.Tests\.ps1$' }) {
         . $file.FullName
     }
 }

--- a/module/MarkMichaelis.ScoopBucket/Private/Get-BundlePackages.ps1
+++ b/module/MarkMichaelis.ScoopBucket/Private/Get-BundlePackages.ps1
@@ -38,7 +38,7 @@ function Get-BundlePackages {
         return @()
     }
 
-    $bundles = Get-ChildItem -Path $BucketPath -Filter '*.ps1' -File |
+    $bundles = Get-ChildItem -Path $BucketPath -Filter '*.ps1' -File -Recurse |
         Where-Object { $_.Name -notmatch '\.Tests\.ps1$' } |
         Where-Object { $_.Name -ne 'Utils.ps1' -and $_.Name -ne 'Invoke-Tests.ps1' }
 

--- a/module/MarkMichaelis.ScoopBucket/Private/Get-PackageNameSuggestion.ps1
+++ b/module/MarkMichaelis.ScoopBucket/Private/Get-PackageNameSuggestion.ps1
@@ -37,11 +37,11 @@ function Get-PackageNameSuggestion {
         return @()
     }
 
-    $bundleFiles = Get-ChildItem -Path $BucketPath -Filter '*.ps1' -File |
+    $bundleFiles = Get-ChildItem -Path $BucketPath -Filter '*.ps1' -File -Recurse |
         Where-Object { $_.Name -notmatch '\.Tests\.ps1$' } |
         Where-Object { $_.Name -ne 'Utils.ps1' -and $_.Name -ne 'Invoke-Tests.ps1' }
 
-    $manifestFiles = Get-ChildItem -Path $BucketPath -Filter '*.json' -File -ErrorAction SilentlyContinue
+    $manifestFiles = Get-ChildItem -Path $BucketPath -Filter '*.json' -File -Recurse -ErrorAction SilentlyContinue
 
     if (-not $bundleFiles -and -not $manifestFiles) { return @() }
 


### PR DESCRIPTION
## Phase 1 of #300 -- recursion + loader enablers (no file moves)

Prepares the bucket for the approved grouped layout (os/client/developer/ai + admin
subfolders, tests co-located beside their subject). This PR adds only the
discovery/loader changes that make subfolders work; **no files are moved**, so every
change is a behavior-preserving no-op against today's flat `bucket/`.

### Changes
- `-Recurse` on the bundle/manifest discovery globs so foldered manifests + bundle
  scripts resolve by basename:
  - `module/.../Private/Get-BundlePackages.ps1`
  - `module/.../Private/Get-PackageNameSuggestion.ps1` (bundle + manifest globs)
  - `.github/scripts/Get-PackageCommands.ps1`
  - bucket tests: `BucketManifestVersion`, `CompletionCoverage`,
    `ManifestUrlSelfReferences`, `PSCompletionsNotAutoInstalled`
- `*.Tests.ps1` skip in the module loader (`MarkMichaelis.ScoopBucket.psm1`) so
  co-located module tests are not dot-sourced at import.

### Regression tests (`bucket/FolderedDiscovery.Tests.ps1`)
Each fails for a behavioral reason when its enabler is reverted:
- a bundle in a `bucket` subfolder is discovered;
- that foldered bundle still surfaces its companion package + completion metadata
  (the "install a member -> companion CLI + completions register" guarantee);
- a `*.Tests.ps1` dropped into `Public/` is NOT loaded at import.

### Verification
Safe Pester sweep (ExcludeTag Heavy/CliAvailability/Integration/Slow/Install) green:
the 3 new tests pass, and the impacted existing suites
(GetBundlePackageObjects, PackageNameCompletion, the 4 bucket tests) stay green --
160 passed, 0 failed. No manifest basenames renamed; `scoop install <Name>` unchanged.

Closes #302