### PR TITLE
Bucket reorg Phase 4: README group index + structure drift guard

### DIFF
--- a/bucket/BucketStructure.Tests.ps1
+++ b/bucket/BucketStructure.Tests.ps1
@@ -1,0 +1,54 @@
+#requires -Version 7.0
+#requires -Modules @{ ModuleName = 'Pester'; ModuleVersion = '5.0.0' }
+
+<#
+.SYNOPSIS
+    Structure drift guard for the foldered bucket layout (issue #314).
+
+.DESCRIPTION
+    Enforces the group-folder organisation introduced in #300:
+      - exactly the four aggregator manifests live at the bucket root;
+      - every other manifest lives directly under a known group folder
+        (os / client / developer / ai / admin).
+    A manifest dropped loosely at root, or filed under an unknown or nested
+    folder, fails this test until it is placed in a recognised group.
+#>
+
+BeforeAll {
+    $script:bucketDir       = $PSScriptRoot
+    $script:rootAggregators = @('AIAgents', 'ClientBasePackages', 'DeveloperBasePackages', 'OSBasePackages')
+    $script:knownGroups     = @('admin', 'ai', 'client', 'developer', 'os')
+}
+
+Describe 'Bucket group-folder structure' -Tag 'Light', 'Bucket' {
+
+    It 'keeps only the four aggregator manifests at bucket root' {
+        $rootManifests = Get-ChildItem -Path $script:bucketDir -Filter '*.json' -File |
+            ForEach-Object { $_.BaseName } | Sort-Object
+        $rootManifests | Should -Be ($script:rootAggregators | Sort-Object) `
+            -Because 'only the four group aggregators may sit at bucket root'
+    }
+
+    It 'files every member manifest directly under a known group folder' {
+        $offenders = @()
+        Get-ChildItem -Path $script:bucketDir -Filter '*.json' -File -Recurse |
+            Where-Object { $_.DirectoryName -ne $script:bucketDir } |
+            ForEach-Object {
+                $rel   = $_.FullName.Substring($script:bucketDir.Length).TrimStart('\', '/')
+                $parts = $rel -split '[\\/]'
+                if ($parts.Count -ne 2 -or $script:knownGroups -notcontains $parts[0]) {
+                    $offenders += $rel
+                }
+            }
+        $offenders | Should -BeNullOrEmpty `
+            -Because 'member manifests must live directly in os/client/developer/ai/admin'
+    }
+
+    It 'has a manifest in every known group folder' {
+        foreach ($group in $script:knownGroups) {
+            $groupDir = Join-Path $script:bucketDir $group
+            (Get-ChildItem -Path $groupDir -Filter '*.json' -File).Count |
+                Should -BeGreaterThan 0 -Because "$group should contain at least one manifest"
+        }
+    }
+}

--- a/bucket/README.md
+++ b/bucket/README.md
@@ -1,0 +1,57 @@
+# Bucket layout
+
+This bucket is organised by **package group**. The four group-defining
+aggregator bundles live at the bucket root and act as the table of contents;
+their member manifests, helper scripts, and member-specific tests live in
+group subfolders.
+
+```
+bucket/
+  OSBasePackages.{json,ps1}          # 4 aggregator bundles (root = table of contents)
+  ClientBasePackages.{json,ps1}
+  DeveloperBasePackages.{json,ps1}
+  AIAgents.{json,ps1}
+  os/          OS tweaks + their *.Tests.ps1
+  client/      client apps + their *.Tests.ps1
+  developer/   dev tools / shells / git-config + their *.Tests.ps1
+  ai/          AI assistant apps + their *.Tests.ps1
+  admin/       bucket-bootstrap manifests (infrastructure, NOT an installable group)
+  *.Tests.ps1  bucket-wide / aggregator-level tests (subject = the whole bucket)
+  README.md
+```
+
+## Groups
+
+| Group | Folder | Aggregator | Contents |
+|-------|--------|-----------|----------|
+| OS | `os/` | `OSBasePackages` | OS configuration tweaks (power, hibernate, OneDrive, McAfee removal, key remap) |
+| Client | `client/` | `ClientBasePackages` | End-user apps (Office, Dropbox CLI, Lightroom, Overdrive, SmugMug, Total Commander, Epubor) |
+| Developer | `developer/` | `DeveloperBasePackages` | Dev tools, PowerShell editions, WSL, git config, Visual Studio, .NET |
+| AI | `ai/` | `AIAgents` | AI assistant apps and CLIs (Claude, ChatGPT, Gemini, Copilot, Codex) |
+| Admin | `admin/` | _(none)_ | Bucket-bootstrap manifests + the `Invoke-GitDiffCode` helper. Infrastructure, not installed by any bundle. |
+
+`AIAgents` is nested under `ClientBasePackages`.
+
+## Conventions
+
+- **Aggregators stay at root.** A manifest's basename **is** its scoop app name,
+  so the four group definitions cannot be renamed or prefixed to sort first.
+  Keeping them at root keeps the group definitions visible together.
+- **Basenames are globally unique** across all folders and are never renamed
+  (`scoop install <Name>` and installed app dirs resolve by basename).
+- **Scoop recurses subfolders**, so foldering members does not affect
+  `scoop install` / `scoop update` or nested bundle references
+  (`Id = 'MarkMichaelis/<Name>'`).
+- **Tests live beside their subject.** Member-manifest tests sit in the group
+  folder with the manifest. Aggregator-level and bucket-wide tests
+  (those that use `Get-Package -BucketPath $PSScriptRoot` against a root
+  aggregator) stay at the bucket root.
+- **`url[]` self-references** in each manifest must point at the script's real
+  on-disk path (enforced by `ManifestUrlSelfReferences.Tests.ps1`). When a
+  script moves into a group folder, every manifest `url[]` that downloads it is
+  repointed to `bucket/<group>/<script>.ps1`.
+- **`_placeholder`** (a shared no-op download target) stays at root.
+
+The structure is enforced by `BucketStructure.Tests.ps1`: only the four
+aggregators may sit at bucket root, and every other manifest must live directly
+under a known group folder.


### PR DESCRIPTION
## Bucket reorg Phase 4 -- README group index + structure drift guard

Part of #300. Capstone for the bucket foldering (os PR #305, ai PR #307, client PR #309, admin PR #311, developer PR #313).

### Added
- `bucket/README.md` -- group-layout reference: 4 root aggregators + os/client/developer/ai member folders + admin/ infrastructure, plus the conventions (unique basenames, scoop recursion, co-located tests, url[] self-refs, `_placeholder` at root).
- `bucket/BucketStructure.Tests.ps1` -- drift guard: only the four aggregators may sit at bucket root; every member manifest must live directly under a known group folder (os/client/developer/ai/admin); each group has at least one manifest.

### Verification
- New test: 3 passed.
- Safe Pester sweep (ExcludeTag Heavy/CliAvailability/Integration/Slow/Install): 1485 passed, 0 failed.

Closes #314