### PR TITLE
fix(bucket): recursive test discovery + repair stale module paths in moved scripts

### DIFF
--- a/bucket/Invoke-Tests.ps1
+++ b/bucket/Invoke-Tests.ps1
@@ -34,8 +34,25 @@
 param(
     [string[]]$Tag = @('Light'),
     [string[]]$ExcludeTag = @(),
-    [string]$Pattern = '*'
+    [string]$Pattern = '*',
+
+    # Emit the discovered test files and return WITHOUT running Pester. Lets
+    # the discovery contract be asserted in a fast, side-effect-free test.
+    [switch]$ListOnly
 )
+
+# Discover recursively so member tests co-located in group subfolders
+# (bucket/os, bucket/developer, bucket/admin, ...) rejoin the gate. A
+# non-recursive glob silently dropped them after the group reorg (#300).
+$matched = @(Get-ChildItem -Path $PSScriptRoot -Filter "$Pattern.Tests.ps1" -File -Recurse -ErrorAction SilentlyContinue)
+if (-not $matched) {
+    Write-Warning "No test files matched: $Pattern.Tests.ps1 under $PSScriptRoot"
+    return
+}
+
+if ($ListOnly) {
+    return $matched
+}
 
 # Ensure Pester v5+ is available. v3 is the Windows in-box version and won't
 # understand BeforeAll/AfterAll the way our templates use them.
@@ -48,12 +65,6 @@ if (-not $pester -or $pester.Version.Major -lt 5) {
 }
 Import-Module Pester -MinimumVersion 5.0.0
 
-$testPath = Join-Path $PSScriptRoot "$Pattern.Tests.ps1"
-$matched = @(Get-ChildItem -Path $testPath -ErrorAction SilentlyContinue)
-if (-not $matched) {
-    Write-Warning "No test files matched: $testPath"
-    return
-}
 Write-Host "Found $($matched.Count) test file(s) matching '$Pattern.Tests.ps1':"
 $matched | ForEach-Object { Write-Host "  $($_.Name)" }
 

--- a/bucket/InvokeTestsDiscovery.Tests.ps1
+++ b/bucket/InvokeTestsDiscovery.Tests.ps1
@@ -1,0 +1,48 @@
+<#
+.SYNOPSIS
+    Light-suite guard for Invoke-Tests.ps1 test discovery.
+
+.DESCRIPTION
+    After the bucket group reorganization (#300) member tests live in group
+    subfolders (bucket/os, bucket/developer, bucket/admin, ...). Invoke-Tests.ps1
+    must discover them recursively, otherwise they silently drop out of the CI
+    Light gate (./bucket/Invoke-Tests.ps1 -Tag Light).
+
+    These tests drive Invoke-Tests.ps1 via its -ListOnly switch (which returns the
+    discovered FileInfo set without running Pester) and assert that subfolder
+    member tests are included. Reverting the runner to a non-recursive glob makes
+    these assertions fail for a behavioral reason (the subfolder file is absent
+    from the discovered set).
+#>
+
+BeforeAll {
+    $script:runner = Join-Path $PSScriptRoot 'Invoke-Tests.ps1'
+}
+
+Describe 'Invoke-Tests.ps1 discovery' -Tag 'Light', 'Unit' {
+
+    It 'discovers member tests located in group subfolders' {
+        $discovered = & $script:runner -ListOnly
+        $relative = $discovered | ForEach-Object {
+            $_.FullName.Substring($PSScriptRoot.Length).TrimStart('\', '/')
+        }
+
+        # At least one test must come from a known group subfolder. A
+        # non-recursive glob would only ever return bucket-root tests.
+        ($relative | Where-Object { $_ -match '[\\/]' }) | Should -Not -BeNullOrEmpty
+    }
+
+    It 'discovers a specific subfolder test by pattern' {
+        # McAfeeUninstall.Tests.ps1 lives under bucket/os/. A non-recursive
+        # runner returns nothing for this pattern (and warns "No test files
+        # matched"); the recursive runner finds it.
+        $discovered = & $script:runner -Pattern 'McAfeeUninstall' -ListOnly
+        @($discovered).Count | Should -BeGreaterThan 0
+        ($discovered.FullName -join ';') | Should -Match 'os[\\/]McAfeeUninstall\.Tests\.ps1'
+    }
+
+    It 'still discovers bucket-root engine tests' {
+        $discovered = & $script:runner -Pattern 'Package' -ListOnly
+        ($discovered.Name) | Should -Contain 'Package.Tests.ps1'
+    }
+}

--- a/bucket/ai/ChatGPT.ps1
+++ b/bucket/ai/ChatGPT.ps1
@@ -1,4 +1,4 @@
-$scoopBucketPsd1 = Join-Path $PSScriptRoot '..\module\MarkMichaelis.ScoopBucket\MarkMichaelis.ScoopBucket.psd1'
+$scoopBucketPsd1 = Join-Path $PSScriptRoot '..\..\module\MarkMichaelis.ScoopBucket\MarkMichaelis.ScoopBucket.psd1'
 if (Test-Path $scoopBucketPsd1) { Import-Module $scoopBucketPsd1 -Force } else { Import-Module MarkMichaelis.ScoopBucket -Force }
 
 # OpenAI ships the official ChatGPT desktop app via the Microsoft Store

--- a/bucket/ai/ClaudeExcel.ps1
+++ b/bucket/ai/ClaudeExcel.ps1
@@ -1,5 +1,5 @@
 
-$scoopBucketPsd1 = Join-Path $PSScriptRoot '..\module\MarkMichaelis.ScoopBucket\MarkMichaelis.ScoopBucket.psd1'
+$scoopBucketPsd1 = Join-Path $PSScriptRoot '..\..\module\MarkMichaelis.ScoopBucket\MarkMichaelis.ScoopBucket.psd1'
 if (Test-Path $scoopBucketPsd1) { Import-Module $scoopBucketPsd1 -Force } else { Import-Module MarkMichaelis.ScoopBucket -Force }
 
 # Claude for Excel is an Office Web Add-in (Microsoft 365 only), distributed

--- a/bucket/ai/Gemini.ps1
+++ b/bucket/ai/Gemini.ps1
@@ -1,5 +1,5 @@
 
-$scoopBucketPsd1 = Join-Path $PSScriptRoot '..\module\MarkMichaelis.ScoopBucket\MarkMichaelis.ScoopBucket.psd1'
+$scoopBucketPsd1 = Join-Path $PSScriptRoot '..\..\module\MarkMichaelis.ScoopBucket\MarkMichaelis.ScoopBucket.psd1'
 if (Test-Path $scoopBucketPsd1) { Import-Module $scoopBucketPsd1 -Force } else { Import-Module MarkMichaelis.ScoopBucket -Force }
 
 # Google's "Google app for desktop" (which embeds Gemini and binds Alt+Space)

--- a/bucket/client/MicrosoftOffice365.ps1
+++ b/bucket/client/MicrosoftOffice365.ps1
@@ -1,4 +1,4 @@
-$scoopBucketPsd1 = Join-Path $PSScriptRoot '..\module\MarkMichaelis.ScoopBucket\MarkMichaelis.ScoopBucket.psd1'
+$scoopBucketPsd1 = Join-Path $PSScriptRoot '..\..\module\MarkMichaelis.ScoopBucket\MarkMichaelis.ScoopBucket.psd1'
 if (Test-Path $scoopBucketPsd1) { Import-Module $scoopBucketPsd1 -Force } else { Import-Module MarkMichaelis.ScoopBucket -Force }
 
 # Microsoft 365 baseline: Office ProPlus + Teams + any Office Web Add-ins.

--- a/bucket/developer/Aspire.ps1
+++ b/bucket/developer/Aspire.ps1
@@ -1,4 +1,4 @@
-$scoopBucketPsd1 = Join-Path $PSScriptRoot '..\module\MarkMichaelis.ScoopBucket\MarkMichaelis.ScoopBucket.psd1'
+$scoopBucketPsd1 = Join-Path $PSScriptRoot '..\..\module\MarkMichaelis.ScoopBucket\MarkMichaelis.ScoopBucket.psd1'
 if (Test-Path $scoopBucketPsd1) { Import-Module $scoopBucketPsd1 -Force } else { Import-Module MarkMichaelis.ScoopBucket -Force }
 
 # Microsoft .NET Aspire delivers two artefacts:

--- a/bucket/developer/Chocolatey.ps1
+++ b/bucket/developer/Chocolatey.ps1
@@ -1,6 +1,6 @@
 Write-Verbose 'Installing and configuring Chocolatey...'
 
-$scoopBucketPsd1 = Join-Path $PSScriptRoot '..\module\MarkMichaelis.ScoopBucket\MarkMichaelis.ScoopBucket.psd1'
+$scoopBucketPsd1 = Join-Path $PSScriptRoot '..\..\module\MarkMichaelis.ScoopBucket\MarkMichaelis.ScoopBucket.psd1'
 if (Test-Path $scoopBucketPsd1) { Import-Module $scoopBucketPsd1 -Force } else { Import-Module MarkMichaelis.ScoopBucket -Force }
 
 Function Install-Chocolatey {

--- a/bucket/developer/GitConfigBeyondCompare.ps1
+++ b/bucket/developer/GitConfigBeyondCompare.ps1
@@ -1,5 +1,5 @@
 
-$scoopBucketPsd1 = Join-Path $PSScriptRoot '..\module\MarkMichaelis.ScoopBucket\MarkMichaelis.ScoopBucket.psd1'
+$scoopBucketPsd1 = Join-Path $PSScriptRoot '..\..\module\MarkMichaelis.ScoopBucket\MarkMichaelis.ScoopBucket.psd1'
 if (Test-Path $scoopBucketPsd1) { Import-Module $scoopBucketPsd1 -Force } else { Import-Module MarkMichaelis.ScoopBucket -Force }
 
 

--- a/bucket/developer/GitConfigVSCode.ps1
+++ b/bucket/developer/GitConfigVSCode.ps1
@@ -1,5 +1,5 @@
 
-$scoopBucketPsd1 = Join-Path $PSScriptRoot '..\module\MarkMichaelis.ScoopBucket\MarkMichaelis.ScoopBucket.psd1'
+$scoopBucketPsd1 = Join-Path $PSScriptRoot '..\..\module\MarkMichaelis.ScoopBucket\MarkMichaelis.ScoopBucket.psd1'
 if (Test-Path $scoopBucketPsd1) { Import-Module $scoopBucketPsd1 -Force } else { Import-Module MarkMichaelis.ScoopBucket -Force }
 
 

--- a/bucket/developer/GitConfigVisualStudio.ps1
+++ b/bucket/developer/GitConfigVisualStudio.ps1
@@ -1,5 +1,5 @@
 
-$scoopBucketPsd1 = Join-Path $PSScriptRoot '..\module\MarkMichaelis.ScoopBucket\MarkMichaelis.ScoopBucket.psd1'
+$scoopBucketPsd1 = Join-Path $PSScriptRoot '..\..\module\MarkMichaelis.ScoopBucket\MarkMichaelis.ScoopBucket.psd1'
 if (Test-Path $scoopBucketPsd1) { Import-Module $scoopBucketPsd1 -Force } else { Import-Module MarkMichaelis.ScoopBucket -Force }
 
 

--- a/bucket/developer/GitConfigure.ps1
+++ b/bucket/developer/GitConfigure.ps1
@@ -1,5 +1,5 @@
 
-$scoopBucketPsd1 = Join-Path $PSScriptRoot '..\module\MarkMichaelis.ScoopBucket\MarkMichaelis.ScoopBucket.psd1'
+$scoopBucketPsd1 = Join-Path $PSScriptRoot '..\..\module\MarkMichaelis.ScoopBucket\MarkMichaelis.ScoopBucket.psd1'
 if (Test-Path $scoopBucketPsd1) { Import-Module $scoopBucketPsd1 -Force } else { Import-Module MarkMichaelis.ScoopBucket -Force }
 . "$PSScriptRoot\GitConfigBeyondCompare.ps1" # Runs Invoke-GitConfigBeyondCompare
 . "$PSScriptRoot\GitConfigVSCode.ps1"        # Runs Invoke-GitConfigVSCode

--- a/bucket/developer/PowerShell.ps1
+++ b/bucket/developer/PowerShell.ps1
@@ -1,6 +1,6 @@
 
 Write-Verbose 'Installing and configuring PowerShell...'
-$scoopBucketPsd1 = Join-Path $PSScriptRoot '..\module\MarkMichaelis.ScoopBucket\MarkMichaelis.ScoopBucket.psd1'
+$scoopBucketPsd1 = Join-Path $PSScriptRoot '..\..\module\MarkMichaelis.ScoopBucket\MarkMichaelis.ScoopBucket.psd1'
 if (Test-Path $scoopBucketPsd1) { Import-Module $scoopBucketPsd1 -Force } else { Import-Module MarkMichaelis.ScoopBucket -Force }
 
 # Remove the Microsoft Store / MSIX build of PowerShell 7 so the first-party

--- a/bucket/os/McAfeeUninstall.ps1
+++ b/bucket/os/McAfeeUninstall.ps1
@@ -1,7 +1,7 @@
 
 Write-Host "Uninstalling McAfee Applications..."
 
-$scoopBucketPsd1 = Join-Path $PSScriptRoot '..\module\MarkMichaelis.ScoopBucket\MarkMichaelis.ScoopBucket.psd1'
+$scoopBucketPsd1 = Join-Path $PSScriptRoot '..\..\module\MarkMichaelis.ScoopBucket\MarkMichaelis.ScoopBucket.psd1'
 if (Test-Path $scoopBucketPsd1) { Import-Module $scoopBucketPsd1 -Force } else { Import-Module MarkMichaelis.ScoopBucket -Force }
 
 Function Uninstall-McAfeeApplications {


### PR DESCRIPTION
## Summary

Two related fixes that restore the CI Light gate after the group-foldering reorg.

### 1. Recursive test discovery in Invoke-Tests.ps1

`bucket/Invoke-Tests.ps1` discovered test files with a non-recursive glob, so the member tests that moved into `bucket/{os,client,developer,ai,admin}/` during the reorg were silently excluded from the Light gate. Discovery is now recursive (`Get-ChildItem -File -Recurse`). Added a `-ListOnly` switch that returns the discovered files without invoking Pester, and a behavior-first guard (`InvokeTestsDiscovery.Tests.ps1`) that fails if discovery stops recursing.

### 2. Stale `..\module` paths in 12 moved scripts

The reorg moved 12 production scripts into subfolders but left their module-import path at single-level `..\module`, which resolves to a nonexistent `bucket\module` from a subfolder. The Test-Path guard then fell back to a by-name Import-Module that works on a dev machine but throws in CI. Once recursive discovery (fix #1) started running the foldered tests, this surfaced as two Light-gate failures (GitConfigVSCode and a downstream UpdatePackage mock leak). All 12 are corrected to `..\..\module`.

## Verification

- Local safe sweep (ExcludeTag Heavy/CliAvailability/Integration/Slow/Install): 1488 passed, 0 failed.
- Reverting `-Recurse` fails the new discovery guard for a behavioral reason.

Closes #316