### PR TITLE
feat(tests): co-locate engine tests in module/ + Light-gate module discovery

### DIFF
--- a/bucket/Invoke-Tests.ps1
+++ b/bucket/Invoke-Tests.ps1
@@ -44,7 +44,19 @@ param(
 # Discover recursively so member tests co-located in group subfolders
 # (bucket/os, bucket/developer, bucket/admin, ...) rejoin the gate. A
 # non-recursive glob silently dropped them after the group reorg (#300).
-$matched = @(Get-ChildItem -Path $PSScriptRoot -Filter "$Pattern.Tests.ps1" -File -Recurse -ErrorAction SilentlyContinue)
+#
+# Engine tests are co-located beside the code they exercise under module/
+# (#318), so search BOTH roots. Without the module/ root those moved tests
+# silently drop from the Light gate -- the same regression class as #316.
+$searchRoots = @(
+    $PSScriptRoot
+    Join-Path (Split-Path -Parent $PSScriptRoot) 'module'
+) | Where-Object { Test-Path -LiteralPath $_ }
+$matched = @(
+    $searchRoots | ForEach-Object {
+        Get-ChildItem -Path $_ -Filter "$Pattern.Tests.ps1" -File -Recurse -ErrorAction SilentlyContinue
+    }
+)
 if (-not $matched) {
     Write-Warning "No test files matched: $Pattern.Tests.ps1 under $PSScriptRoot"
     return

--- a/bucket/InvokeTestsDiscovery.Tests.ps1
+++ b/bucket/InvokeTestsDiscovery.Tests.ps1
@@ -45,4 +45,13 @@ Describe 'Invoke-Tests.ps1 discovery' -Tag 'Light', 'Unit' {
         $discovered = & $script:runner -Pattern 'Package' -ListOnly
         ($discovered.Name) | Should -Contain 'Package.Tests.ps1'
     }
+
+    It 'discovers engine tests co-located under module/' {
+        # GetBundlePackageObjects.Tests.ps1 lives beside its subject in
+        # module/MarkMichaelis.ScoopBucket/Private/ (#318). Dropping the
+        # module/ search root silently removes it from the Light gate.
+        $discovered = & $script:runner -Pattern 'GetBundlePackageObjects' -ListOnly
+        @($discovered).Count | Should -BeGreaterThan 0
+        ($discovered.FullName -join ';') | Should -Match 'module[\\/].+GetBundlePackageObjects\.Tests\.ps1'
+    }
 }

--- a/module/MarkMichaelis.ScoopBucket/Private/GetBundlePackageObjects.Tests.ps1
+++ b/module/MarkMichaelis.ScoopBucket/Private/GetBundlePackageObjects.Tests.ps1
@@ -22,7 +22,7 @@
 #>
 
 BeforeAll {
-    $script:moduleManifest = Resolve-Path (Join-Path (Split-Path -Parent $PSScriptRoot) 'module\MarkMichaelis.ScoopBucket\MarkMichaelis.ScoopBucket.psd1')
+    $script:moduleManifest = Resolve-Path (Join-Path $PSScriptRoot '..\MarkMichaelis.ScoopBucket.psd1')
     Import-Module $script:moduleManifest -Force
 
     function script:Invoke-GetBundlePackageObjects {


### PR DESCRIPTION
## Summary

Phase 3 pilot for the bucket reorg (#300): co-locate engine tests beside the code
they exercise, and teach the Light gate to discover them. Proves the mechanism
end-to-end through CI before any bulk move.

### Changes

- `bucket/Invoke-Tests.ps1` now searches **both** `bucket/` and `module/`
  recursively. Engine tests co-located under `module/` would otherwise silently
  drop from the Light gate -- the same regression class as #316.
- Moved `GetBundlePackageObjects.Tests.ps1` next to its subject in
  `module/MarkMichaelis.ScoopBucket/Private/` and rewrote its manifest path to the
  module-relative `..\MarkMichaelis.ScoopBucket.psd1`. The module loader already
  skips `*.Tests.ps1` (psm1 line 24), so it is not dot-sourced at import.
- `InvokeTestsDiscovery.Tests.ps1` gains a behavior-first guard asserting a
  `module/`-co-located test is discovered; removing the `module/` search root
  fails it for a behavioral reason.

### Scope

Workflow-pinned tests (PackageCommands, CliAvailabilityPinned, CompletionPinned,
CompletionIdempotency, CliCompletionOutput -- hardcoded in
`validate-installs.yml`) stay at bucket root. The remaining engine tests follow
in subsequent incremental batches.

### Verification

- Local safe sweep across both roots (ExcludeTag Heavy/CliAvailability/Integration/Slow/Install):
  1489 passed, 0 failed.
- The moved test passes from its new home; the new discovery guard passes.

Closes #318