### PR TITLE
fix(ci): classify Warp + Todoist CLI as untested, not fail, in install validation

### DIFF
--- a/.github/scripts/Test-Installs.Tests.ps1
+++ b/.github/scripts/Test-Installs.Tests.ps1
@@ -897,3 +897,39 @@ Describe 'Install helper command construction' -Tag 'Unit' {
         $script:CapturedCommands[0] | Should -Match '--scope user'
     }
 }
+
+# ============================================================================
+# CISkipPackages  recurring-failure classification (#322)
+# ============================================================================
+#
+# Packages that cannot install on a headless Windows Server runner must be
+# recorded as 'untested' (skip) rather than 'fail', so install-validation does
+# not surface a permanent red regression for an upstream/environment limitation.
+# These guards fail behaviorally if an entry is removed from the skip list.
+
+Describe 'CISkipPackages recurring-failure skip list' {
+    BeforeAll {
+        $scriptPath = Join-Path $PSScriptRoot 'Test-Installs.ps1'
+        $content = Get-Content $scriptPath -Raw
+        # Extract the literal hashtable assignment and evaluate it into a local
+        # (the closing brace sits at column 0; inner lines are all indented).
+        if ($content -match '(?ms)\$script:CISkipPackages\s*=\s*@\{.+?^\}') {
+            $eval = $Matches[0] -replace '\$script:CISkipPackages', '$skip'
+            Invoke-Expression $eval
+            $script:SkipList = $skip
+        }
+        else {
+            throw 'Could not locate $script:CISkipPackages block in Test-Installs.ps1'
+        }
+    }
+
+    It 'classifies the flaky Warp GUI install (Warp.Warp) as untested, not fail' {
+        $script:SkipList.ContainsKey('Warp.Warp') | Should -BeTrue
+        $script:SkipList['Warp.Warp'] | Should -Not -BeNullOrEmpty
+    }
+
+    It 'classifies Todoist CLI (Sachaos.Todoist) as untested, not fail' {
+        $script:SkipList.ContainsKey('Sachaos.Todoist') | Should -BeTrue
+        $script:SkipList['Sachaos.Todoist'] | Should -Not -BeNullOrEmpty
+    }
+}

--- a/.github/scripts/Test-Installs.ps1
+++ b/.github/scripts/Test-Installs.ps1
@@ -52,6 +52,10 @@ $ProgressPreference = 'SilentlyContinue'  # Speed up web requests
 $script:CISkipPackages = @{
     # winget: user-scope-only MSIX apps (no machine-scope MSI/EXE installer)
     'Pushbullet.Pushbullet'         = 'User-scope MSIX only — no machine installer; no msstore/scoop/choco alternative (#8)'
+    # winget: GUI app requiring VCRedist + an interactive/desktop session
+    'Warp.Warp'                     = 'GUI terminal; pulls a VCRedist dependency and expects a desktop session — installer returns -1/0xFFFFFFFF on the headless Server runner (persistently flaky). Revisit if upstream ships a headless-clean installer (#322)'
+    # winget: no-applicable-installer headless; depends on an msstore desktop app
+    'Sachaos.Todoist'               = 'Todoist CLI DependsOn the msstore Todoist desktop (itself untested headless); winget reports -1978335212 NO_APPLICABLE_INSTALLER on the headless Server runner. Scope=user mitigation (#213) is unchanged (#322)'
     # choco: delisted or CI-incompatible
     'Office365ProPlus'              = 'Requires GUI session and license activation (exit 17004)'
     # scoop: browser-watch installers requiring interactive Download click


### PR DESCRIPTION
## Summary

The install-validation run (`validate-installs.yml` -> `Test-Installs.ps1`) reports
two recurring `fail` rows that are not bucket bugs and cannot pass on a headless
Windows Server runner:

- **Warp** (`Warp.Warp`) -- installer returns `-1` / `0xFFFFFFFF`. GUI terminal that
  pulls a VCRedist dependency and expects a desktop session; persistently flaky headless.
- **Todoist CLI** (`Sachaos.Todoist`) -- winget `-1978335212` `NO_APPLICABLE_INSTALLER`.
  DependsOn the msstore Todoist desktop (itself untested headless).

Adds both to the existing `\` allowlist so they are recorded as
`untested` (skip) instead of `fail` -- the build stays green while the coverage gap is
documented with a reason string. Reversible if upstream ships a headless-clean installer.

No bucket-config change; the Todoist `Scope=user` mitigation (#213) is untouched.

A behavior-first guard asserts both ids are skip-listed (verified red-on-revert against main).

## Note (separate, pre-existing)

While testing I found `.github/scripts/Test-Installs.Tests.ps1` has 27 failures caused by
the group-foldering reorg (stale `bucket\<script>.ps1` paths for scripts that moved to
subfolders) and that `Get-AllPackages` discovery (line 887) is non-recursive. These tests
run in no CI gate, so it went unnoticed. Tracked separately -- out of scope for this PR.

Closes #322