### PR TITLE
fix(bucket): remove dead Todoist CLI (Sachaos.Todoist) winget entry

### DIFF
--- a/.github/scripts/Test-Installs.Tests.ps1
+++ b/.github/scripts/Test-Installs.Tests.ps1
@@ -928,8 +928,7 @@ Describe 'CISkipPackages recurring-failure skip list' {
         $script:SkipList['Warp.Warp'] | Should -Not -BeNullOrEmpty
     }
 
-    It 'classifies Todoist CLI (Sachaos.Todoist) as untested, not fail' {
-        $script:SkipList.ContainsKey('Sachaos.Todoist') | Should -BeTrue
-        $script:SkipList['Sachaos.Todoist'] | Should -Not -BeNullOrEmpty
+    It 'does not skip-list the removed Todoist CLI (Sachaos.Todoist delisted from winget, #326)' {
+        $script:SkipList.ContainsKey('Sachaos.Todoist') | Should -BeFalse
     }
 }

--- a/.github/scripts/Test-Installs.ps1
+++ b/.github/scripts/Test-Installs.ps1
@@ -54,8 +54,6 @@ $script:CISkipPackages = @{
     'Pushbullet.Pushbullet'         = 'User-scope MSIX only — no machine installer; no msstore/scoop/choco alternative (#8)'
     # winget: GUI app requiring VCRedist + an interactive/desktop session
     'Warp.Warp'                     = 'GUI terminal; pulls a VCRedist dependency and expects a desktop session — installer returns -1/0xFFFFFFFF on the headless Server runner (persistently flaky). Revisit if upstream ships a headless-clean installer (#322)'
-    # winget: no-applicable-installer headless; depends on an msstore desktop app
-    'Sachaos.Todoist'               = 'Todoist CLI DependsOn the msstore Todoist desktop (itself untested headless); winget reports -1978335212 NO_APPLICABLE_INSTALLER on the headless Server runner. Scope=user mitigation (#213) is unchanged (#322)'
     # choco: delisted or CI-incompatible
     'Office365ProPlus'              = 'Requires GUI session and license activation (exit 17004)'
     # scoop: browser-watch installers requiring interactive Download click

--- a/bucket/ClientBasePackages.Tests.ps1
+++ b/bucket/ClientBasePackages.Tests.ps1
@@ -3,9 +3,13 @@
 
 <#
 .SYNOPSIS
-    Behavior-first tests for the Todoist + Todoist CLI co-location in
-    ClientBasePackages, including the DependsOn regression guard that
-    locks in "install Todoist, get the CLI too" (issue #208).
+    Behavior-first tests for the Todoist desktop entry in ClientBasePackages.
+
+    The sachaos/todoist CLI companion (winget 'Sachaos.Todoist') was removed
+    in #326 because the package was delisted from winget upstream -- confirmed
+    on a clean CI runner in #325 (winget search/show/install all return
+    -1978335212 "No package found"). The guards below lock in that removal:
+    re-adding the dead CLI entry or its companion link fails them.
 #>
 
 BeforeAll {
@@ -14,7 +18,7 @@ BeforeAll {
     $script:pkgs = @(Get-Package -BucketPath $PSScriptRoot)
 }
 
-Describe 'ClientBasePackages: Todoist CLI co-located with Todoist desktop' -Tag 'Light','Bundle' {
+Describe 'ClientBasePackages: Todoist desktop entry' -Tag 'Light','Bundle' {
 
     It 'declares the existing Todoist desktop entry (regression guard)' {
         $desktop = @($script:pkgs | Where-Object Name -EQ 'Todoist')
@@ -25,52 +29,18 @@ Describe 'ClientBasePackages: Todoist CLI co-located with Todoist desktop' -Tag 
         $desktop[0].Bundle    | Should -Be 'ClientBasePackages'
     }
 
-    It 'declares a Todoist CLI package using sachaos/todoist via winget' {
-        $cli = @($script:pkgs | Where-Object Name -EQ 'Todoist CLI')
-        $cli.Count        | Should -Be 1
-        $cli[0].Installer | Should -Be 'winget'
-        $cli[0].Id        | Should -Be 'Sachaos.Todoist'
-        $cli[0].Bundle    | Should -Be 'ClientBasePackages'
+    It 'no longer declares a Todoist CLI package (Sachaos.Todoist delisted from winget, #326)' {
+        @($script:pkgs | Where-Object Name -EQ 'Todoist CLI').Count | Should -Be 0
+        @($script:pkgs | Where-Object Id -EQ 'Sachaos.Todoist').Count | Should -Be 0
     }
 
-    It 'declares CliCommands=todoist with native completion and expected subcommands' {
-        $cli = @($script:pkgs | Where-Object Name -EQ 'Todoist CLI')[0]
-        $cli.CliCommands              | Should -Be @('todoist')
-        $cli.Completion               | Should -Be 'native'
-        $cli.HasNativeCommandScript   | Should -BeTrue
-        $cli.ExpectedCompletions.ContainsKey('todoist') | Should -BeTrue
-        foreach ($expected in 'add','list','show','completion','--help') {
-            $cli.ExpectedCompletions['todoist'] | Should -Contain $expected
-        }
-    }
-
-    It 'passes --silent and --disable-interactivity to winget' {
-        $cli = @($script:pkgs | Where-Object Name -EQ 'Todoist CLI')[0]
-        $cli.WingetExtraArgs | Should -Contain '--silent'
-        $cli.WingetExtraArgs | Should -Contain '--disable-interactivity'
-    }
-
-    It 'DependsOn the desktop Todoist (auto-install-with-desktop regression guard)' {
-        $cli = @($script:pkgs | Where-Object Name -EQ 'Todoist CLI')[0]
-        @($cli.DependsOn)       | Should -Be @('Todoist')
-    }
-
-    It 'declares Scope=user (Sachaos.Todoist winget manifest has no machine-scope installer) (#213)' {
-        # Regression guard: without Scope=user, Install-WingetPackage defaults to
-        # --scope machine and winget hard-fails with exit -1978335212
-        # (APPINSTALLER_CLI_ERROR_NO_APPLICABLE_INSTALLER) because the
-        # sachaos/todoist manifest only publishes a user-scope portable .exe.
-        $cli = @($script:pkgs | Where-Object Name -EQ 'Todoist CLI')[0]
-        $cli.Scope | Should -Be 'user'
+    It 'Todoist desktop no longer lists a Todoist CLI companion (#326)' {
+        $desktop = @($script:pkgs | Where-Object Name -EQ 'Todoist')[0]
+        @($desktop.Companions) | Should -Not -Contain 'Todoist CLI'
     }
 
     It 'Bitwarden desktop declares Companions=@(Bitwarden CLI) (auto-install CLI with app)' {
         $desktop = @($script:pkgs | Where-Object Name -EQ 'Bitwarden')[0]
         @($desktop.Companions) | Should -Contain 'Bitwarden CLI'
-    }
-
-    It 'Todoist desktop declares Companions=@(Todoist CLI) (auto-install CLI with app)' {
-        $desktop = @($script:pkgs | Where-Object Name -EQ 'Todoist')[0]
-        @($desktop.Companions) | Should -Contain 'Todoist CLI'
     }
 }

--- a/bucket/ClientBasePackages.ps1
+++ b/bucket/ClientBasePackages.ps1
@@ -164,22 +164,7 @@ Register-ArgumentCompleter -Native -CommandName sox -ScriptBlock {
     [Package]@{ Name = 'Snagit';           Installer = 'winget'; Id = 'XPDNSF6TXN2R6Z'; Source = 'msstore'
                 Notes = 'winget default source ships user-scope MSIX only; ms-store is the automated path (#9).' }
     [Package]@{ Name = 'Todoist';          Installer = 'winget'; Id = '9MWF2DWS5Z9N'; Source = 'msstore'
-                Companions = @('Todoist CLI')
-                Notes = 'winget default source ships user-scope MSIX only; ms-store is the automated path (#11).' }
-    [Package]@{
-        Name        = 'Todoist CLI'
-        Installer   = 'winget'
-        Id          = 'Sachaos.Todoist'
-        Scope       = 'user'
-        CliCommands = @('todoist')
-        Completion  = 'native'
-        NativeCompletionKind = 'native'
-        NativeCommandScript = { todoist completion powershell }
-        WingetExtraArgs = @('--silent', '--disable-interactivity')
-        DependsOn   = @('Todoist')
-        Notes       = 'sachaos/todoist Go CLI for Todoist. Co-located with the Todoist desktop entry above so the ClientBasePackages bundle installs both; DependsOn ensures the desktop app is provisioned first when the CLI is installed directly. Mirrors the Bitwarden / Bitwarden CLI pattern (#208). Scope=user because the upstream winget manifest only publishes a user-scope portable .exe -- omitting Scope causes Install-WingetPackage to default to --scope machine and winget hard-fails with -1978335212 APPINSTALLER_CLI_ERROR_NO_APPLICABLE_INSTALLER (#213).'
-        ExpectedCompletions = @{ todoist = @('add','list','show','completion','--help') }
-    }
+                Notes = 'winget default source ships user-scope MSIX only; ms-store is the automated path (#11). The sachaos/todoist CLI companion was removed in #326 because Sachaos.Todoist was delisted from winget (confirmed on CI, #325).' }
 
     [Package]@{
         Name        = 'Readwise Reader'

--- a/bucket/PackageInstall.Tests.ps1
+++ b/bucket/PackageInstall.Tests.ps1
@@ -110,11 +110,11 @@ Describe 'Engine dispatchers' -Tag 'Light','Module' {
         }
 
         It 'passes --scope user (not --scope machine) when Package.Scope=user (#213)' {
-            # Regression guard for Todoist CLI (Sachaos.Todoist): the upstream
-            # winget manifest only publishes a user-scope portable .exe. When
-            # Package.Scope='user' the wrapper must opt into --scope user and
-            # MUST NOT pass --scope machine (which causes winget to fail with
-            # -1978335212 APPINSTALLER_CLI_ERROR_NO_APPLICABLE_INSTALLER).
+            # Generic Scope=user wrapper behavior (originally motivated by the
+            # Todoist CLI, removed in #326). When Package.Scope='user' the wrapper
+            # must opt into --scope user and MUST NOT pass --scope machine (which
+            # makes winget fail -1978335212 APPINSTALLER_CLI_ERROR_NO_APPLICABLE_INSTALLER
+            # for manifests that publish only a user-scope portable .exe).
             $script:installArgs = $null
             Mock -ModuleName MarkMichaelis.ScoopBucket winget {
                 if ($args[0] -eq 'list') { $global:LASTEXITCODE = 1; return '' }


### PR DESCRIPTION
## Summary

Removes the dead **Todoist CLI** entry (`Sachaos.Todoist`) from the bucket. The package is **delisted from winget upstream** -- `winget search`/`show`/`install --id Sachaos.Todoist` all return `-1978335212` "No package found" on a clean Windows Server 2025 runner. Confirmed on CI in #325 ([run 26995437263](https://github.com/MarkMichaelis/ScoopBucket/actions/runs/26995437263)). The entry could never install.

Maintainer chose **option 1 (remove)** over repointing to the `sachaos/todoist` GitHub release.

## Changes

- `bucket/ClientBasePackages.ps1` -- delete the `Todoist CLI` `[Package]` block; drop `Companions = @('Todoist CLI')` from the desktop `Todoist` entry (msstore `9MWF2DWS5Z9N` stays).
- `.github/scripts/Test-Installs.ps1` -- remove the now-moot `Sachaos.Todoist` entry from `CISkipPackages` (nothing to skip once the package is gone).
- `.github/scripts/Test-Installs.Tests.ps1` -- replace the Todoist skip guard with a guard asserting `Sachaos.Todoist` is **not** skip-listed (Warp guard kept).
- `bucket/ClientBasePackages.Tests.ps1` -- replace the CLI co-location tests with behavior-first removal guards (no `Todoist CLI` package; desktop has no `Todoist CLI` companion).
- `bucket/PackageInstall.Tests.ps1` -- keep the generic `Scope=user` wrapper test (synthetic package); refresh its comment.

## Behavior-first

Re-adding the dead CLI entry or its companion link fails the new removal guards.

## Verification

- `bucket/ClientBasePackages.Tests.ps1` + `bucket/PackageInstall.Tests.ps1`: **38 passed**
- `CISkipPackages` guards: **2 passed**
- Safe Light sweep (`bucket` + `module`, excluding Heavy/Integration/Install): **1470 passed, 0 failed, 1 skipped**

Closes #326. Related: #325, #322, #213, #208.