### PR TITLE
fix(os): allow OneDrive move into an existing empty target directory

### DIFF
--- a/bucket/os/MarkMichaelisOneDriveConfiguration.Tests.ps1
+++ b/bucket/os/MarkMichaelisOneDriveConfiguration.Tests.ps1
@@ -691,6 +691,58 @@ Describe 'Move-OneDriveFolder' -Tag 'Light' {
         Should -Invoke Move-Item -Times 1
         Should -Invoke Remove-Item -Times 0
     }
+
+    It 'moves into an existing but empty destination by removing the empty directory first' {
+        # A partial prior run -- or OneDrive re-creating an empty sync folder --
+        # can leave an empty target. An empty destination is safe to move into.
+        Mock -CommandName Test-Path -MockWith {
+            param($Path)
+            switch ($Path) {
+                'C:\Users\me\OneDrive - IntelliTect' { $true; break }
+                'C:\OneDrive\OneDrive - IntelliTect' { $true; break }
+                'C:\OneDrive' { $true; break }
+                default { $false }
+            }
+        }
+        Mock -CommandName Get-Item -MockWith { param($Path) [pscustomobject]@{ FullName = $Path } }
+        Mock -CommandName Get-ChildItem -MockWith { @() }
+        Mock -CommandName Test-IsSameVolume -MockWith { $true }
+        Mock -CommandName Move-Item
+        Mock -CommandName Remove-Item
+
+        { Move-OneDriveFolder -Source 'C:\Users\me\OneDrive - IntelliTect' -Destination 'C:\OneDrive\OneDrive - IntelliTect' -Confirm:$false } |
+            Should -Not -Throw
+
+        Should -Invoke Remove-Item -Times 1 -ParameterFilter {
+            $LiteralPath -eq 'C:\OneDrive\OneDrive - IntelliTect'
+        }
+        Should -Invoke Move-Item -Times 1 -ParameterFilter {
+            $LiteralPath -eq 'C:\Users\me\OneDrive - IntelliTect' -and
+            $Destination -eq 'C:\OneDrive\OneDrive - IntelliTect'
+        }
+    }
+
+    It 'refuses to move into an existing non-empty destination' {
+        Mock -CommandName Test-Path -MockWith {
+            param($Path)
+            switch ($Path) {
+                'C:\Users\me\OneDrive - IntelliTect' { $true; break }
+                'C:\OneDrive\OneDrive - IntelliTect' { $true; break }
+                'C:\OneDrive' { $true; break }
+                default { $false }
+            }
+        }
+        Mock -CommandName Get-Item -MockWith { param($Path) [pscustomobject]@{ FullName = $Path } }
+        Mock -CommandName Get-ChildItem -MockWith { [pscustomobject]@{ Name = 'leftover.txt' } }
+        Mock -CommandName Move-Item
+        Mock -CommandName Remove-Item
+
+        { Move-OneDriveFolder -Source 'C:\Users\me\OneDrive - IntelliTect' -Destination 'C:\OneDrive\OneDrive - IntelliTect' -Confirm:$false } |
+            Should -Throw -ExpectedMessage '*already exists and is not empty*'
+
+        Should -Invoke Move-Item -Times 0
+        Should -Invoke Remove-Item -Times 0
+    }
 }
 
 Describe 'Remove-OneDriveAccountLink' -Tag 'Light' {

--- a/bucket/os/MarkMichaelisOneDriveConfiguration.ps1
+++ b/bucket/os/MarkMichaelisOneDriveConfiguration.ps1
@@ -743,7 +743,16 @@ function Move-OneDriveFolder {
         return $result
     }
     if (Test-Path $Destination) {
-        throw "Refusing to merge: destination '$Destination' already exists. Resolve manually."
+        $destChildren = @(Get-ChildItem -LiteralPath $Destination -Force -ErrorAction SilentlyContinue)
+        if ($destChildren.Count -gt 0) {
+            throw "Refusing to merge: destination '$Destination' already exists and is not empty. Resolve manually."
+        }
+        # An empty pre-existing destination is safe: remove it so the move
+        # recreates the destination path itself (a same-volume rename moves the
+        # source onto the path, not into an existing directory).
+        if ($PSCmdlet.ShouldProcess($Destination, 'Remove empty pre-existing destination directory')) {
+            Remove-Item -LiteralPath $Destination -Force
+        }
     }
 
     $parent = Split-Path -Parent $Destination


### PR DESCRIPTION
## Summary

`Move-OneDriveFolder` refused **any** pre-existing destination:

```powershell
if (Test-Path $Destination) {
    throw "Refusing to merge: destination '$Destination' already exists. Resolve manually."
}
```

A partial prior run -- or OneDrive re-creating an empty sync folder right after the
script stops it -- can leave an **empty** target directory, after which the migration
refused to proceed and demanded manual cleanup. An empty directory is safe to move
into, so this brittleness broke idempotency across partial runs.

## Change

A move now proceeds when the destination **does not exist or is empty**. "Empty" means
zero child items including hidden/system entries (`Get-ChildItem -Force`), so a stray
`desktop.ini` still counts as non-empty. When the destination exists and is empty, the
empty directory is removed first (gated by `ShouldProcess`) so the same-volume NTFS
rename recreates the destination path itself. A **non-empty** destination still refuses,
now with a message that names the non-empty condition.

Per-account targets remain distinct (`\\OneDrive - <DisplayName>`), so
multi-account runs do not collide; two accounts sharing a DisplayName would still be a
refused merge conflict (out of scope).

## Tests

Two new `Light`-tagged behavior tests in the `Move-OneDriveFolder` describe:

- proceeds into an existing empty destination, removing the empty directory first
- refuses an existing non-empty destination (`*already exists and is not empty*`)

Both confirmed RED against the prior production guard. Full file: 90 passed, 2 failed
(both pre-existing `Heavy` tests requiring a `D:` drive absent on this machine --
they fail on pristine `main` too and are excluded from the CI Light suite).

Closes #330