### PR TITLE
feat(onedrive): add -PassThru and tabular -WhatIf plan output

### DIFF
--- a/bucket/os/MarkMichaelisOneDriveConfiguration.Tests.ps1
+++ b/bucket/os/MarkMichaelisOneDriveConfiguration.Tests.ps1
@@ -1815,6 +1815,25 @@ Describe 'Format-OneDriveMigrationPlan' -Tag 'Light' {
         $joined | Should -Match ([regex]::Escape('(~ = C:\Users\Mark,  . = C:\OneDrive)'))
         $joined | Should -Not -Match 'Current:'
     }
+
+    It 'enforces a path boundary and trims trailing separators when shortening' {
+        $plan = @([pscustomobject]@{
+            Type = 'MoveAccount'; Target = 'C:\OneDrive\Tenant'
+            CurrentValue = 'C:\Users\Markus\OneDrive'
+            DesiredValue = 'C:\OneDrive\Tenant'
+            Reason = 'Migrate account folder'; Skipped = $false; SkipReason = $null; Warnings = @()
+        })
+        Format-OneDriveMigrationPlan -Plan $plan -Accounts @() `
+            -RootDir 'C:\OneDrive\' -KfmOwner 'Michaelis' `
+            -FreshSyncAccounts @() -HomeDir 'C:\Users\Mark'
+        $joined = $script:capturedPlanLines -join "`n"
+        # 'C:\Users\Markus' must NOT be shortened against HomeDir 'C:\Users\Mark'.
+        $joined | Should -Match ([regex]::Escape('C:\Users\Markus\OneDrive'))
+        $joined | Should -Not -Match '~us'
+        # Trailing-slash RootDir still yields a clean '.\Tenant'.
+        $joined | Should -Match ([regex]::Escape('.\Tenant'))
+        $joined | Should -Not -Match ([regex]::Escape('.Tenant '))
+    }
 }
 
 Describe 'Elevation pre-flight' -Tag 'Light' {

--- a/bucket/os/MarkMichaelisOneDriveConfiguration.Tests.ps1
+++ b/bucket/os/MarkMichaelisOneDriveConfiguration.Tests.ps1
@@ -1390,7 +1390,8 @@ Describe 'Plan-then-execute architecture' -Tag 'Heavy' {
         Mock -CommandName New-Item
         Mock -CommandName Get-Process -MockWith { $null }
 
-        Invoke-MarkMichaelisOneDriveConfiguration -RootDir 'C:\OneDrive' -KfmOwner 'Michaelis' -FreshSync @() -Confirm:$false | Out-Null
+        $firstRun = Invoke-MarkMichaelisOneDriveConfiguration -RootDir 'C:\OneDrive' -KfmOwner 'Michaelis' -FreshSync @() -Confirm:$false
+        $firstRun | Should -BeNullOrEmpty
         $secondPlan = Invoke-MarkMichaelisOneDriveConfiguration -RootDir 'C:\OneDrive' -KfmOwner 'Michaelis' -FreshSync @() -Confirm:$false -PassThru
 
         Should -Invoke Move-OneDriveFolder -Times 1
@@ -1810,6 +1811,8 @@ Describe 'Format-OneDriveMigrationPlan' -Tag 'Light' {
         $joined | Should -Match 'To'
         $joined | Should -Match 'MoveAccount'
         $joined | Should -Match ([regex]::Escape('~\OneDrive - Michaelis'))
+        $joined | Should -Match ([regex]::Escape('.\OneDrive - Michaelis'))
+        $joined | Should -Match ([regex]::Escape('(~ = C:\Users\Mark,  . = C:\OneDrive)'))
         $joined | Should -Not -Match 'Current:'
     }
 }

--- a/bucket/os/MarkMichaelisOneDriveConfiguration.Tests.ps1
+++ b/bucket/os/MarkMichaelisOneDriveConfiguration.Tests.ps1
@@ -1391,7 +1391,7 @@ Describe 'Plan-then-execute architecture' -Tag 'Heavy' {
         Mock -CommandName Get-Process -MockWith { $null }
 
         Invoke-MarkMichaelisOneDriveConfiguration -RootDir 'C:\OneDrive' -KfmOwner 'Michaelis' -FreshSync @() -Confirm:$false | Out-Null
-        $secondPlan = Invoke-MarkMichaelisOneDriveConfiguration -RootDir 'C:\OneDrive' -KfmOwner 'Michaelis' -FreshSync @() -Confirm:$false
+        $secondPlan = Invoke-MarkMichaelisOneDriveConfiguration -RootDir 'C:\OneDrive' -KfmOwner 'Michaelis' -FreshSync @() -Confirm:$false -PassThru
 
         Should -Invoke Move-OneDriveFolder -Times 1
         @($secondPlan | Where-Object { $_.Type -eq 'MoveAccount' -and -not $_.Skipped }).Count | Should -Be 0
@@ -1667,6 +1667,45 @@ Describe 'Resolve-FreshSyncAccounts' -Tag 'Light' {
 }
 
 
+Describe 'PassThru output suppression' -Tag 'Heavy' {
+    BeforeEach {
+        $acct = [pscustomobject]@{
+            Slot = 'Business1'; AccountType = 'Business'; DisplayName = 'IntelliTect'
+            UserEmail = 'user@example.com'; UserFolder = 'C:\Users\me\OneDrive - IntelliTect'; TenantId = 'tid-1'; RegistryPath = 'HKCU:\Software\Microsoft\OneDrive\Accounts\Business1'
+        }
+
+        Mock -CommandName Test-Path -MockWith {
+            param($Path)
+            switch ($Path) {
+                'C:\OneDrive' { $true; break }
+                'C:\OneDrive\IntelliTect' { $true; break }
+                'C:\Users\me\OneDrive - IntelliTect' { $true; break }
+                default { $false }
+            }
+        }
+        Mock -CommandName Get-OneDriveAccountList -MockWith { @($acct) }
+        Mock -CommandName Resolve-FreshSyncAccounts -MockWith { @() }
+        Mock -CommandName Get-OneDriveSharePointSiteList -MockWith { @() }
+        Mock -CommandName Get-CurrentKfmPath -MockWith { $null }
+        Mock -CommandName Resolve-KfmRebindAction -MockWith {
+            [pscustomobject]@{ Action = 'None'; OwnerAccount = $null; Reason = 'KFM inactive' }
+        }
+        Mock -CommandName Get-Process -MockWith { [pscustomobject]@{ Name = 'OneDrive' } }
+        Mock -CommandName Write-Host -MockWith { }
+    }
+
+    It 'does not emit the plan object to the pipeline by default under -WhatIf' {
+        $out = Invoke-MarkMichaelisOneDriveConfiguration -RootDir 'C:\OneDrive' -KfmOwner 'Michaelis' -FreshSync @() -WhatIf
+        $out | Should -BeNullOrEmpty
+    }
+
+    It 'emits the plan object when -PassThru is supplied under -WhatIf' {
+        $out = Invoke-MarkMichaelisOneDriveConfiguration -RootDir 'C:\OneDrive' -KfmOwner 'Michaelis' -FreshSync @() -WhatIf -PassThru
+        @($out).Count | Should -BeGreaterThan 0
+        @($out | Where-Object { $_.Type -eq 'MoveAccount' }).Count | Should -BeGreaterThan 0
+    }
+}
+
 Describe 'Format-OneDriveMigrationPlan' -Tag 'Light' {
     BeforeAll {
         $script:b1 = [pscustomobject]@{
@@ -1754,6 +1793,24 @@ Describe 'Format-OneDriveMigrationPlan' -Tag 'Light' {
             -RootDir 'C:\OneDrive' -KfmOwner 'Michaelis' `
             -FreshSyncAccounts @() -IsElevated $true -HomeDir 'C:\Users\Mark'
         ($script:capturedPlanLines -join "`n") | Should -Match 'Elevation:\s+OK \(Administrator\)'
+    }
+
+    It 'renders the plan listing as a table with shortened paths and no per-item Current line' {
+        $plan = @([pscustomobject]@{
+            Type = 'MoveAccount'; Target = 'C:\OneDrive\OneDrive - Michaelis'
+            CurrentValue = 'C:\Users\Mark\OneDrive - Michaelis'
+            DesiredValue = 'C:\OneDrive\OneDrive - Michaelis'
+            Reason = 'Migrate account folder'; Skipped = $false; SkipReason = $null; Warnings = @()
+        })
+        Format-OneDriveMigrationPlan -Plan $plan -Accounts @() `
+            -RootDir 'C:\OneDrive' -KfmOwner 'Michaelis' `
+            -FreshSyncAccounts @() -HomeDir 'C:\Users\Mark'
+        $joined = $script:capturedPlanLines -join "`n"
+        $joined | Should -Match 'Type'
+        $joined | Should -Match 'To'
+        $joined | Should -Match 'MoveAccount'
+        $joined | Should -Match ([regex]::Escape('~\OneDrive - Michaelis'))
+        $joined | Should -Not -Match 'Current:'
     }
 }
 

--- a/bucket/os/MarkMichaelisOneDriveConfiguration.ps1
+++ b/bucket/os/MarkMichaelisOneDriveConfiguration.ps1
@@ -1712,11 +1712,17 @@ function Format-OneDriveMigrationPlan {
         function Format-PlanPath {
             param([string]$Path)
             if ([string]::IsNullOrEmpty($Path)) { return '' }
-            if ($HomeDir -and $Path.StartsWith($HomeDir, [System.StringComparison]::OrdinalIgnoreCase)) {
-                return '~' + $Path.Substring($HomeDir.Length)
-            }
-            if ($RootDir -and $Path.StartsWith($RootDir, [System.StringComparison]::OrdinalIgnoreCase)) {
-                return '.' + $Path.Substring($RootDir.Length)
+            foreach ($pair in @(
+                @{ Root = $HomeDir; Token = '~' },
+                @{ Root = $RootDir; Token = '.' })) {
+                $root = ([string]$pair.Root).TrimEnd('\')
+                if (-not $root) { continue }
+                if ([string]::Equals($Path, $root, [System.StringComparison]::OrdinalIgnoreCase)) {
+                    return $pair.Token
+                }
+                if ($Path.StartsWith($root + '\', [System.StringComparison]::OrdinalIgnoreCase)) {
+                    return $pair.Token + $Path.Substring($root.Length)
+                }
             }
             return $Path
         }

--- a/bucket/os/MarkMichaelisOneDriveConfiguration.ps1
+++ b/bucket/os/MarkMichaelisOneDriveConfiguration.ps1
@@ -142,6 +142,13 @@
     Policy) and you intentionally want to preview or run the remaining
     per-user work from a non-elevated shell.
 
+.PARAMETER PassThru
+    Return the computed migration plan objects to the pipeline. By default
+    the bundle prints the human-readable plan (and, in apply mode, the
+    migration summary) but emits no objects, so an interactive -WhatIf run
+    stays clean. Supply -PassThru when you want to capture or post-process
+    the plan objects programmatically.
+
 .EXAMPLE
     .\MarkMichaelisOneDriveConfiguration.ps1 -WhatIf
 
@@ -217,7 +224,8 @@ param(
     [string[]] $FreshSync = @(),
     [switch] $DeleteSourceOnSuccess,
     [switch] $ForceHydrate,
-    [switch] $SkipElevationCheck
+    [switch] $SkipElevationCheck,
+    [switch] $PassThru
 )
 
 $ErrorActionPreference = 'Stop'
@@ -1700,19 +1708,42 @@ function Format-OneDriveMigrationPlan {
     }
 
     Write-Host 'Planned OneDrive migration:'
-    foreach ($item in $Plan) {
-        $status = if ($item.Skipped) { '[Skip]' } else { '[Plan]' }
-        Write-Host ("  {0} {1}: {2}" -f $status, $item.Type, $item.Target)
-        if ($null -ne $item.CurrentValue -or $null -ne $item.DesiredValue) {
-            Write-Host ("      Current: {0}" -f $item.CurrentValue)
-            Write-Host ("      Desired: {0}" -f $item.DesiredValue)
+    if (@($Plan).Count -gt 0) {
+        function Format-PlanPath {
+            param([string]$Path)
+            if ([string]::IsNullOrEmpty($Path)) { return '' }
+            if ($HomeDir -and $Path.StartsWith($HomeDir, [System.StringComparison]::OrdinalIgnoreCase)) {
+                return '~' + $Path.Substring($HomeDir.Length)
+            }
+            if ($RootDir -and $Path.StartsWith($RootDir, [System.StringComparison]::OrdinalIgnoreCase)) {
+                return '.' + $Path.Substring($RootDir.Length)
+            }
+            return $Path
         }
-        Write-Host ("      Reason : {0}" -f $item.Reason)
-        if ($item.SkipReason) {
-            Write-Host ("      Skip   : {0}" -f $item.SkipReason)
+
+        $rows = foreach ($item in $Plan) {
+            $to = if ($item.DesiredValue) { $item.DesiredValue } else { $item.Target }
+            [pscustomobject]@{
+                Action = if ($item.Skipped) { 'Skip' } else { 'Plan' }
+                Type   = $item.Type
+                From   = Format-PlanPath -Path ([string]$item.CurrentValue)
+                To     = Format-PlanPath -Path ([string]$to)
+            }
         }
-        foreach ($warning in @($item.Warnings)) {
-            Write-Host ("      Warning: {0}" -f $warning)
+
+        $table = ($rows | Format-Table -AutoSize | Out-String -Width 4096).TrimEnd()
+        Write-Host $table
+        Write-Host ("  (~ = {0},  . = {1})" -f $HomeDir, $RootDir)
+
+        foreach ($item in $Plan) {
+            if ($item.Skipped -and $item.SkipReason) {
+                Write-Host ("  [Skip] {0}: {1}" -f $item.Type, $item.SkipReason)
+            }
+            foreach ($warning in @($item.Warnings)) {
+                if ($warning) {
+                    Write-Host ("  [Warn] {0}: {1}" -f $item.Type, $warning)
+                }
+            }
         }
     }
     Write-Host ''
@@ -2029,7 +2060,8 @@ function Invoke-MarkMichaelisOneDriveConfiguration {
         [switch]$DeleteSourceOnSuccess,
         [switch]$ForceHydrate,
         [switch]$SkipElevationCheck,
-        [bool]$IsElevated = $true
+        [bool]$IsElevated = $true,
+        [switch]$PassThru
     )
 
     Write-Warning 'Mutates OneDrive client internal registry state (Accounts\<slot>\UserFolder, ScopeIdToMountPointPathCache*); these are not Microsoft-documented migration APIs.'
@@ -2068,7 +2100,8 @@ function Invoke-MarkMichaelisOneDriveConfiguration {
         -IsElevated $IsElevated
 
     if ($WhatIfPreference) {
-        return $plan
+        if ($PassThru) { return $plan }
+        return
     }
 
     $backupPath = ($plan | Where-Object Type -eq 'RegistryBackup' | Select-Object -First 1).Target
@@ -2126,7 +2159,7 @@ function Invoke-MarkMichaelisOneDriveConfiguration {
     }
 
     Write-Warning 'MRU staleness: Office recent docs / Snagit Recent File List / VS recent files may reference old OneDrive paths; reopen as needed.'
-    return $plan
+    if ($PassThru) { return $plan }
 }
 
 # Only run when invoked as a script (Scoop's installer does
@@ -2137,5 +2170,6 @@ if ($MyInvocation.InvocationName -ne '.') {
         -KfmOwnerContains:$KfmOwnerContains -NoKfmRebind:$NoKfmRebind `
         -NoFolderDescriptionsWrite:$NoFolderDescriptionsWrite -FreshSync $FreshSync `
         -DeleteSourceOnSuccess:$DeleteSourceOnSuccess -ForceHydrate:$ForceHydrate `
-        -SkipElevationCheck:$SkipElevationCheck -IsElevated $__mmodIsElevated
+        -SkipElevationCheck:$SkipElevationCheck -IsElevated $__mmodIsElevated `
+        -PassThru:$PassThru
 }

--- a/docs/designs/2025-onedrive-whatif-readability-plan.md
+++ b/docs/designs/2025-onedrive-whatif-readability-plan.md
@@ -1,0 +1,26 @@
+# 2025 OneDrive -WhatIf Readability Plan (Issue #332)
+
+## Fix 1 -- `-PassThru` switch suppresses plan-object dump by default
+- Add `[switch] \` to the script-level `param()` block.
+- Add `[switch]\` to `Invoke-MarkMichaelisOneDriveConfiguration` param block.
+- Gate the WhatIf early return: `if (\) { return \ }` else `return`.
+- Gate the final return: `if (\) { return \ }`.
+- Forward `-PassThru:\` from the top-level invocation block.
+- Add `.PARAMETER PassThru` comment-based help.
+- Update the apply-mode capture test (`\ = ...`) to add `-PassThru`.
+
+### Tests (Heavy)
+- "does not emit the plan object to the pipeline by default under -WhatIf" -> `\ | Should -BeNullOrEmpty`.
+- "emits the plan object when -PassThru is supplied under -WhatIf" -> count > 0 and contains MoveAccount.
+
+## Fix 2 -- tabular plan listing
+- Replace the per-item foreach in `Format-OneDriveMigrationPlan` with a `Format-Table` rendering.
+- Columns: Action / Type / From / To with shortened paths (~ = HomeDir, . = RootDir).
+- Legend line + preserved skip/warning visibility.
+- Empty plan renders no table.
+
+### Test (Light)
+- Non-empty plan with one MoveAccount item; assert table header (Type/To), MoveAccount, `~\OneDrive - Michaelis` present, `Current:` absent.
+
+## Verify
+`Invoke-Pester -Path .\bucket\os\MarkMichaelisOneDriveConfiguration.Tests.ps1`

--- a/docs/designs/2025-onedrive-whatif-readability-plan.md
+++ b/docs/designs/2025-onedrive-whatif-readability-plan.md
@@ -1,17 +1,18 @@
 # 2025 OneDrive -WhatIf Readability Plan (Issue #332)
 
 ## Fix 1 -- `-PassThru` switch suppresses plan-object dump by default
-- Add `[switch] \` to the script-level `param()` block.
-- Add `[switch]\` to `Invoke-MarkMichaelisOneDriveConfiguration` param block.
-- Gate the WhatIf early return: `if (\) { return \ }` else `return`.
-- Gate the final return: `if (\) { return \ }`.
-- Forward `-PassThru:\` from the top-level invocation block.
+- Add `[switch] $PassThru` to the script-level `param()` block.
+- Add `[switch]$PassThru` to `Invoke-MarkMichaelisOneDriveConfiguration` param block.
+- Gate the WhatIf early return: `if ($PassThru) { return $plan }` else `return`.
+- Gate the final return: `if ($PassThru) { return $plan }`.
+- Forward `-PassThru:$PassThru` from the top-level invocation block.
 - Add `.PARAMETER PassThru` comment-based help.
-- Update the apply-mode capture test (`\ = ...`) to add `-PassThru`.
+- Update the apply-mode capture test (`$secondPlan = ...`) to add `-PassThru`.
 
 ### Tests (Heavy)
-- "does not emit the plan object to the pipeline by default under -WhatIf" -> `\ | Should -BeNullOrEmpty`.
-- "emits the plan object when -PassThru is supplied under -WhatIf" -> count > 0 and contains MoveAccount.
+- "does not emit the plan object to the pipeline by default under -WhatIf" -> `$out | Should -BeNullOrEmpty`.
+- "emits the plan object when -PassThru is supplied under -WhatIf" -> `@($out).Count` > 0 and contains a `MoveAccount` item.
+- Apply-mode capture test also asserts the first (no -PassThru) invocation emits nothing.
 
 ## Fix 2 -- tabular plan listing
 - Replace the per-item foreach in `Format-OneDriveMigrationPlan` with a `Format-Table` rendering.
@@ -20,7 +21,9 @@
 - Empty plan renders no table.
 
 ### Test (Light)
-- Non-empty plan with one MoveAccount item; assert table header (Type/To), MoveAccount, `~\OneDrive - Michaelis` present, `Current:` absent.
+- Non-empty plan with one MoveAccount item; assert table header (Type/To), `MoveAccount`,
+  `~\OneDrive - Michaelis` (HomeDir shortening), `.\OneDrive - Michaelis` (RootDir shortening),
+  the legend line, and that `Current:` is absent.
 
 ## Verify
 `Invoke-Pester -Path .\bucket\os\MarkMichaelisOneDriveConfiguration.Tests.ps1`


### PR DESCRIPTION
## Summary

Two readability fixes for `.\bucket\os\MarkMichaelisOneDriveConfiguration.ps1 -WhatIf`:

### Fix 1 -- `-PassThru` suppresses the plan-object dump by default
Previously, after the clean `=== PLAN ===` preview, PowerShell rendered ~350 lines
of raw plan objects (a giant `Format-List`) because the top-level invocation did not
capture the function's `return \`. Now `Invoke-MarkMichaelisOneDriveConfiguration`
emits the plan objects to the pipeline only when `-PassThru` is supplied. The switch
was added to both the script-level `param()` and the function `param()` block, and is
forwarded from the top-level invocation. Default `-WhatIf` runs are now quiet.

### Fix 2 -- tabular plan listing
The "Planned OneDrive migration:" listing rendered four verbose lines per item
(`[Plan] Type: Target` / `Current:` / `Desired:` / `Reason :`). It now renders a
compact `Format-Table` with columns Action / Type / From / To, with `\` -> `~`
and `\` -> `.` path shortening and a legend line. Skip and warning lines are
preserved below the table. Empty plans render no table (header + blank line only).

## Before / After (-WhatIf plan listing)

Before:
```
Planned OneDrive migration:
  [Plan] MoveAccount: C:\OneDrive\OneDrive - Michaelis
      Current: C:\Users\Mark\OneDrive - Michaelis
      Desired: C:\OneDrive\OneDrive - Michaelis
      Reason : Migrate account folder
```
(followed by ~350 lines of raw plan-object Format-List)

After:
```
Planned OneDrive migration:

Action Type        From                       To
------ ----        ----                       --
Plan   MoveAccount ~\OneDrive - Michaelis     .\OneDrive - Michaelis
  (~ = C:\Users\Mark,  . = C:\OneDrive)
```
(no trailing object dump unless -PassThru is supplied)

## Testing

```
Invoke-Pester -Path .\bucket\os\MarkMichaelisOneDriveConfiguration.Tests.ps1
```

- Added 2 Heavy tests (PassThru suppression on/off under -WhatIf) and 1 Light test
  (tabular rendering with shortened paths, no `Current:` line).
- Updated the one existing apply-mode capture test to pass `-PassThru`.
- Full file: 93 passed. The only 2 failures are pre-existing and environment-only
  (cross-volume tests require a `D:` drive that is absent on this machine -- they fail
  identically on `main`).
- PSScriptAnalyzer: no new findings (55 vs 57 on main; the table replaced several
  `Write-Host` calls).

Closes #332