### PR TITLE
fix(os): stop echoing the raw plan object dump when run as a script

### DIFF
--- a/bucket/os/MarkMichaelisOneDriveConfiguration.Tests.ps1
+++ b/bucket/os/MarkMichaelisOneDriveConfiguration.Tests.ps1
@@ -1799,7 +1799,13 @@ Describe 'Elevation pre-flight' -Tag 'Light' {
     }
 }
 
-Describe 'Script entry output (#334)' -Tag 'Light' {
+Describe 'Script entry output (#334)' -Tag 'Heavy' {
+    # End-to-end script-entry behavior: requires a machine with real OneDrive
+    # accounts so the bundle runs through to returning its plan. Tagged Heavy
+    # (excluded from the CI Light suite) for the same reason as the other
+    # full-execution tests -- the CI runner has no OneDrive accounts, so
+    # Get-OneDriveAccountList returns nothing and the orchestrator cannot build
+    # a plan. Validated locally.
     BeforeAll {
         $script:bundlePath = "$PSScriptRoot\MarkMichaelisOneDriveConfiguration.ps1"
     }

--- a/bucket/os/MarkMichaelisOneDriveConfiguration.Tests.ps1
+++ b/bucket/os/MarkMichaelisOneDriveConfiguration.Tests.ps1
@@ -1798,3 +1798,30 @@ Describe 'Elevation pre-flight' -Tag 'Light' {
         }
     }
 }
+
+Describe 'Script entry output (#334)' -Tag 'Light' {
+    BeforeAll {
+        $script:bundlePath = "$PSScriptRoot\MarkMichaelisOneDriveConfiguration.ps1"
+    }
+
+    AfterEach {
+        if (Test-Path 'Variable:Global:__MMOD_ForceIsElevated') {
+            Remove-Variable -Name '__MMOD_ForceIsElevated' -Scope Global -Force
+        }
+    }
+
+    It 'does not echo the raw plan object dump to the success stream when run as a script' {
+        # The bundle already prints a human-readable plan summary via Write-Host
+        # (the information stream). It must not ALSO emit the returned plan array
+        # to the success stream, which PowerShell would auto-format into a second
+        # raw object dump on the console.
+        $global:__MMOD_ForceIsElevated = $true
+
+        # Information (6) and warning (3) streams carry the intended summary and
+        # the internal-API caveat; discard them so only the success stream
+        # (stream 1) -- where an accidental object dump would land -- is captured.
+        $successOutput = & $script:bundlePath -RootDir 'TestDrive:\OD' -SkipElevationCheck -NoKfmRebind -WhatIf 3>$null 6>$null
+
+        @($successOutput).Count | Should -Be 0
+    }
+}

--- a/bucket/os/MarkMichaelisOneDriveConfiguration.ps1
+++ b/bucket/os/MarkMichaelisOneDriveConfiguration.ps1
@@ -2133,7 +2133,12 @@ function Invoke-MarkMichaelisOneDriveConfiguration {
 # `& "$dir\MarkMichaelisOneDriveConfiguration.ps1"`). When dot-sourced
 # (Pester tests), expose the helpers without running migration.
 if ($MyInvocation.InvocationName -ne '.') {
-    Invoke-MarkMichaelisOneDriveConfiguration -RootDir $RootDir -KfmOwner $KfmOwner `
+    # Suppress the plan object the orchestrator returns: the human-readable
+    # summary is already written via Write-Host. Without this, the returned
+    # plan array would be echoed to the success stream and auto-formatted into
+    # a second, raw object dump on the console. The function still returns the
+    # plan for programmatic and test callers that capture it.
+    $null = Invoke-MarkMichaelisOneDriveConfiguration -RootDir $RootDir -KfmOwner $KfmOwner `
         -KfmOwnerContains:$KfmOwnerContains -NoKfmRebind:$NoKfmRebind `
         -NoFolderDescriptionsWrite:$NoFolderDescriptionsWrite -FreshSync $FreshSync `
         -DeleteSourceOnSuccess:$DeleteSourceOnSuccess -ForceHydrate:$ForceHydrate `


### PR DESCRIPTION
## Summary

Running the bundle as a script (e.g. `.\MarkMichaelisOneDriveConfiguration.ps1 -WhatIf`)
printed the migration plan **twice**: the intended human-readable summary from
`Format-OneDriveMigrationPlan` (via `Write-Host`), followed by a second, raw
`Format-List` dump of every plan item.

The second block was noise. The top-level script invocation called
`Invoke-MarkMichaelisOneDriveConfiguration` (which ends with `return $plan`)
without capturing the result, so the returned plan array was emitted to the
success stream and auto-formatted to the console.

## Change

Assign the top-level invocation result to `\` so the returned plan is not
echoed to the success stream. The function still `return`s the plan for
programmatic and test callers that capture it -- only the script-entry wrapper
stops echoing it. The human-readable summary is unchanged.

## Tests

- New behavior test `Script entry output (#334)` runs the bundle via its entry
  point (`& $bundlePath -RootDir 'TestDrive:\OD' -SkipElevationCheck
  -NoKfmRebind -WhatIf`) and asserts the success stream emits zero objects.
  Confirmed RED against the prior code (`Expected 0, but got 20`).
- Tagged `Heavy` (excluded from the CI Light suite): the behavior is only
  observable end-to-end where real OneDrive accounts exist. On the CI runner
  there are none, so `Get-OneDriveAccountList` returns nothing and the bundle
  throws before it can return a plan. Validated locally instead, consistent with
  the other full-execution tests in this file.
- Functional evidence: running the real script with a temp root now yields a
  success-stream object count of 0 (was 20); the formatted summary still prints.
- Full file locally: 91 passed, 2 failed (both pre-existing `Heavy` tests
  requiring a `D:` drive absent on this machine).

Closes #334