### PR TITLE
fix(update-winget): drop --scope from upgrade to stop masking stale installs as AlreadyLatest (#336)

### DIFF
--- a/bucket/UpdatePackage.Tests.ps1
+++ b/bucket/UpdatePackage.Tests.ps1
@@ -26,7 +26,14 @@ Describe 'Update engine dispatchers' -Tag 'Light','Module' {
             $r.State | Should -Be 'NotInstalled'
         }
 
-        It 'invokes winget upgrade --id <Id> --silent with --scope machine for global' {
+        It 'invokes winget upgrade --id <Id> --silent WITHOUT --scope, even when Package.Scope=global (#336)' {
+            # Regression for #336: winget upgrade filtered by --scope misses
+            # installs at the other scope and returns NO_APPLICABLE_UPGRADE
+            # (exit -1978335212), which our engine maps to AlreadyLatest --
+            # silently hiding stale installs (the real-world Bitwarden CLI
+            # case: user-scope install vs Scope='global' bundle entry).
+            # Upgrade always operates on whatever scope is installed; only
+            # Install-WingetPackage should ever choose a scope.
             $script:captured = $null
             Mock -ModuleName MarkMichaelis.ScoopBucket winget {
                 if ($args[0] -eq 'list') { $global:LASTEXITCODE = 0; return 'row' }
@@ -43,11 +50,7 @@ Describe 'Update engine dispatchers' -Tag 'Light','Module' {
             ($script:captured -contains '--silent')                      | Should -BeTrue
             ($script:captured -contains '--accept-package-agreements')   | Should -BeTrue
             ($script:captured -contains '--accept-source-agreements')    | Should -BeTrue
-            $hasScope = $false
-            for ($i=0; $i -lt $script:captured.Count; $i++) {
-                if ($script:captured[$i] -eq '--scope' -and $script:captured[$i+1] -eq 'machine') { $hasScope = $true }
-            }
-            $hasScope | Should -BeTrue
+            ($script:captured -contains '--scope') | Should -BeFalse -Because 'winget upgrade --scope filters to one scope and misses cross-scope installs (#336)'
         }
 
         It 'maps exit -1978335212 (no applicable upgrade) to AlreadyLatest' {

--- a/module/MarkMichaelis.ScoopBucket/Private/Update-WingetPackage.ps1
+++ b/module/MarkMichaelis.ScoopBucket/Private/Update-WingetPackage.ps1
@@ -45,10 +45,15 @@ function Update-WingetPackage {
     $upgradeArgs = @('upgrade', '--id', $id, '--silent', '--accept-package-agreements', '--accept-source-agreements')
     if ($Package.Source -eq 'msstore') {
         $upgradeArgs += @('--source', 'msstore')
-    } else {
-        $scope = if ($Package.Scope -eq 'user') { 'user' } else { 'machine' }
-        $upgradeArgs += @('--scope', $scope)
     }
+    # Intentionally NOT passing --scope on upgrade (see #336): `winget upgrade`
+    # filters by --scope and returns NO_APPLICABLE_UPGRADE (-1978335212) when
+    # no install matches that scope -- which our engine then maps to
+    # AlreadyLatest, silently hiding stale installs. The real-world case is
+    # Bitwarden CLI: bundle declares Scope='global' (default) but winget
+    # installs it at user scope, so --scope machine masked a real upgrade.
+    # Scope selection matters at INSTALL time (Install-WingetPackage keeps it);
+    # for upgrades we always operate on whatever scope the package is at.
     if ($Package.WingetExtraArgs -and $Package.WingetExtraArgs.Count -gt 0) {
         $upgradeArgs += @($Package.WingetExtraArgs)
     }


### PR DESCRIPTION
## Summary

`Update-WingetPackage` was unconditionally passing `--scope machine` (for the default `global` Scope) to `winget upgrade`. winget upgrade *filters* by `--scope`: when no install matches that scope, winget exits with `-1978335212` (NO_APPLICABLE_UPGRADE), which our engine maps to `State="AlreadyLatest"` -- silently hiding stale installs.

## Repro

```
Update-Package bitwarden -IncludeUnchanged
=  Bitwarden CLI              winget      global   2023.9.0 (latest)
```

The bundle declares no Scope (defaults to `global`), but winget installed Bitwarden CLI at user scope. `winget upgrade --id Bitwarden.CLI --scope machine` returned NO_APPLICABLE_UPGRADE, masking the real available 2026.5.0.

## Fix

`winget upgrade` always operates on whatever scope the package is installed at -- scope selection only matters at *install* time (`Install-WingetPackage` still passes `--scope`). Drop `--scope` from the upgrade command line.

## Tests

- `bucket/UpdatePackage.Tests.ps1`: invert the existing "passes `--scope machine` for global" test to assert `--scope` is NOT on the upgrade command. Verified RED before the fix, GREEN after.
- Light suite: **1447 passed / 0 failed**.

Closes #336