### PR TITLE
fix(manifests): winget-based manifests must call winget upgrade, not just install (#339)

### DIFF
--- a/bucket/WingetManifestUpgrade.Tests.ps1
+++ b/bucket/WingetManifestUpgrade.Tests.ps1
@@ -1,0 +1,48 @@
+#requires -Version 7.0
+#requires -Modules @{ ModuleName = 'Pester'; ModuleVersion = '5.0.0' }
+
+# ----------------------------------------------------------------------------
+# #339: scoop manifests that wrap winget must invoke `winget upgrade`, not
+# just `winget install`. `winget install` on an already-installed package is
+# idempotent (returns "Package already installed") and never moves the
+# package to a newer version. Combined with scoop only re-running the
+# installer when the manifest version bumps, install-only manifests leave
+# users stuck on whatever winget version was current when the manifest last
+# bumped -- exactly the bug reported on PowerShellCore (pwsh 7.4 not
+# advancing to 7.6 despite `scoop update powershellcore`).
+#
+# This guard scans every JSON manifest in bucket/** and asserts: if the
+# installer script invokes `winget install --id <ID>`, it must also invoke
+# `winget upgrade --id <ID>` for the same id (typically via an if/else that
+# upgrades when present, installs when missing). Tagged 'Light' -- parses
+# manifest JSON only; no install side effects.
+# ----------------------------------------------------------------------------
+
+BeforeDiscovery {
+    $bucketRoot = Join-Path $PSScriptRoot ''
+    $script:WingetManifestCases = @(
+        Get-ChildItem -Path $bucketRoot -Filter '*.json' -Recurse -File |
+            ForEach-Object {
+                try {
+                    $manifest = Get-Content -Raw -LiteralPath $_.FullName | ConvertFrom-Json
+                } catch { return }
+                $scriptText = @($manifest.installer.script) -join "`n"
+                $installMatches = [regex]::Matches($scriptText, '(?i)winget\s+install\b[^\r\n]*?--id\s+([A-Za-z0-9._-]+)')
+                foreach ($m in $installMatches) {
+                    @{
+                        Manifest = $_.FullName.Substring($bucketRoot.Length).TrimStart('\','/')
+                        Id       = $m.Groups[1].Value
+                        Script   = $scriptText
+                    }
+                }
+            }
+    )
+}
+
+Describe 'winget-based manifests must invoke winget upgrade (#339)' -Tag 'Light' {
+    It "<Manifest> invokes 'winget upgrade --id <Id>' so re-runs actually upgrade" -ForEach $script:WingetManifestCases {
+        $pattern = '(?i)winget\s+upgrade\b[^\r\n]*--id\s+' + [regex]::Escape($Id) + '\b'
+        $Script | Should -Match $pattern `
+            -Because "winget install --id $Id is idempotent when the package is present; only winget upgrade moves it to a newer version"
+    }
+}

--- a/bucket/ai/Claude.json
+++ b/bucket/ai/Claude.json
@@ -1,10 +1,10 @@
 {
     "$schema": "https://raw.githubusercontent.com/lukesampson/scoop/master/schema.json",
-    "version": "1.02.000",
+    "version": "1.03.000",
     "url": ["https://raw.githubusercontent.com/MarkMichaelis/ScoopBucket/main/bucket/_placeholder"],
     "installer": {
         "script": [
-            "winget install --id Anthropic.Claude -e --silent --accept-package-agreements --accept-source-agreements"
+            "$listed = (winget list --id Anthropic.Claude -e --accept-source-agreements 2>$null | Select-String -SimpleMatch 'Anthropic.Claude'); if ($listed) { winget upgrade --id Anthropic.Claude -e --silent --accept-package-agreements --accept-source-agreements } else { winget install --id Anthropic.Claude -e --silent --accept-package-agreements --accept-source-agreements }"
         ]
     }
 }

--- a/bucket/ai/ClaudeCode.json
+++ b/bucket/ai/ClaudeCode.json
@@ -1,10 +1,10 @@
 {
     "$schema": "https://raw.githubusercontent.com/lukesampson/scoop/master/schema.json",
-    "version": "1.02.000",
+    "version": "1.03.000",
     "url": ["https://raw.githubusercontent.com/MarkMichaelis/ScoopBucket/main/bucket/_placeholder"],
     "installer": {
         "script": [
-            "winget install --id Anthropic.ClaudeCode -e --silent --accept-package-agreements --accept-source-agreements"
+            "$listed = (winget list --id Anthropic.ClaudeCode -e --accept-source-agreements 2>$null | Select-String -SimpleMatch 'Anthropic.ClaudeCode'); if ($listed) { winget upgrade --id Anthropic.ClaudeCode -e --silent --accept-package-agreements --accept-source-agreements } else { winget install --id Anthropic.ClaudeCode -e --silent --accept-package-agreements --accept-source-agreements }"
         ]
     }
 }

--- a/bucket/ai/Codex.json
+++ b/bucket/ai/Codex.json
@@ -1,10 +1,10 @@
 {
     "$schema": "https://raw.githubusercontent.com/lukesampson/scoop/master/schema.json",
-    "version": "1.02.000",
+    "version": "1.03.000",
     "url": ["https://raw.githubusercontent.com/MarkMichaelis/ScoopBucket/main/bucket/_placeholder"],
     "installer": {
         "script": [
-            "winget install --id OpenAI.Codex -e --silent --accept-package-agreements --accept-source-agreements"
+            "$listed = (winget list --id OpenAI.Codex -e --accept-source-agreements 2>$null | Select-String -SimpleMatch 'OpenAI.Codex'); if ($listed) { winget upgrade --id OpenAI.Codex -e --silent --accept-package-agreements --accept-source-agreements } else { winget install --id OpenAI.Codex -e --silent --accept-package-agreements --accept-source-agreements }"
         ]
     }
 }

--- a/bucket/ai/GitHubCopilotCli.json
+++ b/bucket/ai/GitHubCopilotCli.json
@@ -1,10 +1,10 @@
 {
     "$schema": "https://raw.githubusercontent.com/lukesampson/scoop/master/schema.json",
-    "version": "1.02.000",
+    "version": "1.03.000",
     "url": ["https://raw.githubusercontent.com/MarkMichaelis/ScoopBucket/main/bucket/_placeholder"],
     "installer": {
         "script": [
-            "winget install --id GitHub.Copilot -e --silent --accept-package-agreements --accept-source-agreements"
+            "$listed = (winget list --id GitHub.Copilot -e --accept-source-agreements 2>$null | Select-String -SimpleMatch 'GitHub.Copilot'); if ($listed) { winget upgrade --id GitHub.Copilot -e --silent --accept-package-agreements --accept-source-agreements } else { winget install --id GitHub.Copilot -e --silent --accept-package-agreements --accept-source-agreements }"
         ]
     }
 }

--- a/bucket/developer/PowerShellCore.Tests.ps1
+++ b/bucket/developer/PowerShellCore.Tests.ps1
@@ -34,6 +34,16 @@ Describe 'PowerShellCore install source policy' -Tag 'Light' {
             -Because 'the winget source serves the MSI; the msstore source serves the sealed MSIX'
     }
 
+    It 'upgrades PowerShell on subsequent runs (winget install alone is a no-op when installed)' {
+        # #339: scoop only re-runs the installer when the manifest version bumps,
+        # and `winget install` on an installed package is a no-op. Without an
+        # explicit `winget upgrade`, the manifest can ship a version bump and
+        # still leave the underlying Microsoft.PowerShell package on an old
+        # release. The installer must invoke `winget upgrade` for the same id.
+        $script:Script | Should -Match '(?i)winget\s+upgrade\b[^\r\n]*--id\s+Microsoft\.PowerShell\b' `
+            -Because 'winget install is idempotent; only winget upgrade moves an installed package to a newer version'
+    }
+
     It 'does not install PowerShell via choco (which let the Store build shadow the MSI)' {
         $script:Script | Should -Not -Match '(?i)choco\s+install\s+powershell-core' `
             -Because 'choco install powershell-core regressed to a Store-shadowed pwsh'

--- a/bucket/developer/PowerShellCore.json
+++ b/bucket/developer/PowerShellCore.json
@@ -1,12 +1,12 @@
 {
     "$schema": "https://raw.githubusercontent.com/lukesampson/scoop/master/schema.json",
-    "version": "1.14.000",
+    "version": "1.15.000",
     "url": [
         "https://raw.githubusercontent.com/MarkMichaelis/ScoopBucket/main/bucket/developer/PowerShell.ps1"
     ],
     "installer": {
         "script":  [
-            "winget install --id Microsoft.PowerShell -e --source winget --scope machine --silent --accept-package-agreements --accept-source-agreements",
+            "$listed = (winget list --id Microsoft.PowerShell -e --source winget --accept-source-agreements 2>$null | Select-String -SimpleMatch 'Microsoft.PowerShell'); if ($listed) { winget upgrade --id Microsoft.PowerShell -e --source winget --silent --accept-package-agreements --accept-source-agreements } else { winget install --id Microsoft.PowerShell -e --source winget --scope machine --silent --accept-package-agreements --accept-source-agreements }",
             "$pwsh = Join-Path $env:ProgramFiles 'PowerShell\\7\\pwsh.exe'; if (-not (Test-Path $pwsh)) { $pwsh = 'pwsh.exe' }; & $pwsh -File \"$dir\\PowerShell.ps1\""
         ]
     }


### PR DESCRIPTION
Closes #339.

## Bug

`winget install --id X` on an already-installed package is a no-op (prints "Package already installed" and exits). Scoop only re-runs an installer when the manifest `version` bumps, so install-only manifests leave users stuck on whatever winget version was current when the manifest last bumped. Reproduced on PowerShellCore: pwsh 7.4.14 stayed put across multiple `scoop update powershellcore` cycles while `winget upgrade --id Microsoft.PowerShell` would have moved it to 7.6.2.

## Fix

Probe with `winget list`, then dispatch:

```powershell
$listed = winget list --id X -e --accept-source-agreements 2>$null | Select-String -SimpleMatch 'X'
if ($listed) {
    winget upgrade --id X -e --silent --accept-package-agreements --accept-source-agreements
} else {
    winget install --id X -e --scope machine --silent --accept-package-agreements --accept-source-agreements
}
```

- **Not installed** -> falls through to `winget install` (preserves the original fresh-install behavior, including `--scope machine` where it was set).
- **Installed, newer available** -> `winget upgrade` advances the package.
- **Installed, latest** -> `winget upgrade` exits no-op (winget NO_APPLICABLE_UPGRADE).

Manifest `version` bumped in each so existing installs trigger the new installer on the next `scoop update`.

## Manifests fixed

| Manifest | Version | winget id |
|---|---|---|
| `bucket/developer/PowerShellCore.json` | 1.14 -> 1.15 | `Microsoft.PowerShell` |
| `bucket/ai/Claude.json` | 1.02 -> 1.03 | `Anthropic.Claude` |
| `bucket/ai/ClaudeCode.json` | 1.02 -> 1.03 | `Anthropic.ClaudeCode` |
| `bucket/ai/Codex.json` | 1.02 -> 1.03 | `OpenAI.Codex` |
| `bucket/ai/GitHubCopilotCli.json` | 1.02 -> 1.03 | `GitHub.Copilot` |

## Tests

- `bucket/WingetManifestUpgrade.Tests.ps1` (new, Tag `Light`): walks every `bucket/**/*.json`, extracts every `winget install --id X`, asserts a matching `winget upgrade --id X`. Prevents reintroducing the bug in any future winget-based manifest.
- `bucket/developer/PowerShellCore.Tests.ps1`: dedicated assertion for the manifest that triggered the report.

Both fail RED before the manifest edits and pass GREEN after. Full Light suite: **1452 passed / 0 failed / 3 skipped**.

## Follow-up

Same idempotency bug pattern exists in 9 choco-based manifests (`dotnet`, `WSL-*`, `VisualStudio2026Enterprise`, `PowerShellWindows`, `PowerShellCorePreview`, `TotalCommander`, `GeminiCli`, etc.). The fix is simpler there -- `choco upgrade -y X` installs if missing per choco docs -- and will be tracked in a follow-up issue.