### PR TITLE
feat(aiagents): expose full write-capable PowerShell via posh MCP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -509,6 +509,17 @@ package owns, such as the AIAgents MCP-server wiring (`mcpServers` JSON /
 Codex TOML entries, the persisted GitHub PAT, the profile self-heal
 block) -- gets the same treatment via the `[Package].ConfigScript` hook.
 
+> **`posh` MCP server -- full, write-capable PowerShell.** The `posh`
+> server (PoshMcp) is wired with a generated config
+> (`~\.poshmcp\appsettings.full.json`) whose `PowerShellConfiguration`
+> sets `IncludePatterns: ["*"]`, exposing the **entire** PowerShell command
+> surface -- including destructive cmdlets and `Invoke-Expression` -- so
+> agents get a real interactive terminal rather than a read-only `Get-*`
+> subset. This grants every wired agent unrestricted PowerShell on the
+> machine; it is a deliberate posture for this personal bucket. Narrow it
+> by editing `IncludePatterns` / `ExcludePatterns` in that config if you
+> want a more conservative surface.
+
 A `ConfigScript` is:
 
 - **Always run.** Invoked on every install (for both freshly `Installed`

--- a/bucket/AIAgents.Mcp.Tests.ps1
+++ b/bucket/AIAgents.Mcp.Tests.ps1
@@ -289,6 +289,54 @@ exit /b 1
         }
     }
 
+    Context 'PoshMcp full-access config' {
+        BeforeEach {
+            $script:TmpDir = New-TempDir
+            $script:TempRoots.Add($script:TmpDir)
+            $script:PoshCfg = Join-Path $script:TmpDir 'sub\appsettings.full.json'
+        }
+
+        It 'exposes the full PowerShell surface via IncludePatterns *' {
+            Write-PoshMcpFullAccessConfig -Path $script:PoshCfg | Should -Be $script:PoshCfg
+            $cfg = Get-Content -Path $script:PoshCfg -Raw | ConvertFrom-Json
+            @($cfg.PowerShellConfiguration.IncludePatterns) | Should -Be @('*')
+            @($cfg.PowerShellConfiguration.ExcludePatterns) | Should -Be @()
+        }
+
+        It 'creates the parent directory when missing' {
+            Test-Path (Split-Path -Parent $script:PoshCfg) | Should -BeFalse
+            Write-PoshMcpFullAccessConfig -Path $script:PoshCfg | Out-Null
+            Test-Path $script:PoshCfg | Should -BeTrue
+        }
+
+        It 'is idempotent: re-running leaves a single valid full-access config' {
+            Write-PoshMcpFullAccessConfig -Path $script:PoshCfg | Out-Null
+            Write-PoshMcpFullAccessConfig -Path $script:PoshCfg | Out-Null
+            $cfg = Get-Content -Path $script:PoshCfg -Raw | ConvertFrom-Json
+            @($cfg.PowerShellConfiguration.IncludePatterns) | Should -Be @('*')
+        }
+    }
+
+    Context 'Get-PoshMcpServerEntry' {
+        It 'points poshmcp serve at the supplied --config path' {
+            $entry = Get-PoshMcpServerEntry -ConfigPath 'C:\cfg\appsettings.full.json'
+            $entry.Name    | Should -Be 'posh'
+            $entry.Command | Should -Be 'poshmcp'
+            $entry.Arguments | Should -Contain 'serve'
+            $entry.Arguments | Should -Contain '--transport'
+            $entry.Arguments | Should -Contain 'stdio'
+            $entry.Arguments | Should -Contain '--config'
+            $entry.Arguments | Should -Contain 'C:\cfg\appsettings.full.json'
+        }
+
+        It 'orders --config immediately before its value' {
+            $entry = Get-PoshMcpServerEntry -ConfigPath 'C:\cfg\x.json'
+            $idx = [array]::IndexOf($entry.Arguments, '--config')
+            $idx | Should -BeGreaterThan -1
+            $entry.Arguments[$idx + 1] | Should -Be 'C:\cfg\x.json'
+        }
+    }
+
     Context 'Add-McpServerToJsonConfig: env emission' {
         BeforeEach {
             $script:TmpDir = New-TempDir

--- a/bucket/AIAgents.Mcp.ps1
+++ b/bucket/AIAgents.Mcp.ps1
@@ -503,6 +503,85 @@ function Get-AIAgentsDeprecatedMcpServer {
     @('shell')
 }
 
+# ---------------------------------------------------------------------------
+# PoshMcp full-access PowerShell surface.
+#
+# PoshMcp filters which PowerShell commands it exposes as MCP tools via the
+# PowerShellConfiguration section of its config (CommandNames / Modules /
+# IncludePatterns / ExcludePatterns). Its default surface is read-only
+# (Get-* style commands only). To give agents a full, write-capable
+# interactive PowerShell, we ship a config with IncludePatterns '*' and
+# point `poshmcp serve --config <path>` at it.
+#
+# SECURITY: IncludePatterns '*' exposes EVERY command, including destructive
+# cmdlets and Invoke-Expression. This is a deliberate, owner-approved posture
+# for this bucket; every wired agent inherits unrestricted PowerShell.
+# ---------------------------------------------------------------------------
+
+function Get-PoshMcpConfigPath {
+    <#
+    .SYNOPSIS
+        Per-user path of the PoshMcp full-access config file.
+    .OUTPUTS
+        String.
+    #>
+    [CmdletBinding()]
+    [OutputType([string])]
+    param()
+    Join-Path $env:USERPROFILE '.poshmcp\appsettings.full.json'
+}
+
+function Write-PoshMcpFullAccessConfig {
+    <#
+    .SYNOPSIS
+        Idempotently write a PoshMcp config exposing the full (write-capable)
+        PowerShell command surface via IncludePatterns '*'.
+    .OUTPUTS
+        The config file path that was written.
+    #>
+    [CmdletBinding()]
+    [OutputType([string])]
+    param(
+        [Parameter(Mandatory)][string]$Path
+    )
+
+    $dir = Split-Path -Parent $Path
+    if ($dir -and -not (Test-Path $dir)) {
+        New-Item -ItemType Directory -Path $dir -Force | Out-Null
+    }
+
+    $config = [ordered]@{
+        PowerShellConfiguration = [ordered]@{
+            CommandNames    = @()
+            Modules         = @()
+            IncludePatterns = @('*')
+            ExcludePatterns = @()
+        }
+    }
+    $config | ConvertTo-Json -Depth 10 | Set-Content -Path $Path -Encoding UTF8
+    return $Path
+}
+
+function Get-PoshMcpServerEntry {
+    <#
+    .SYNOPSIS
+        Build the `posh` MCP server entry that points poshmcp at a full-access
+        config so agents get the complete (write-capable) PowerShell surface.
+    .OUTPUTS
+        Hashtable with Name, Command, and Arguments keys.
+    #>
+    [CmdletBinding()]
+    [OutputType([hashtable])]
+    param(
+        [Parameter(Mandatory)][string]$ConfigPath
+    )
+    @{
+        Name      = 'posh'
+        Command   = 'poshmcp'
+        Arguments = @('serve', '--transport', 'stdio', '--config', $ConfigPath)
+    }
+}
+
 function Install-AIAgentsMcpConfiguration {
     <#
     .SYNOPSIS
@@ -621,11 +700,9 @@ function Install-AIAgentsMcpConfiguration {
     )
 
     if ($poshMcpAvailable) {
-        $mcpServers += @{
-            Name      = 'posh'
-            Command   = 'poshmcp'
-            Arguments = @('serve', '--transport', 'stdio')
-        }
+        $poshConfigPath = Write-PoshMcpFullAccessConfig -Path (Get-PoshMcpConfigPath)
+        Write-Host "PoshMcp: wrote full-access PowerShell config to $poshConfigPath (IncludePatterns '*')."
+        $mcpServers += Get-PoshMcpServerEntry -ConfigPath $poshConfigPath
     }
 
     $jsonAgents = Get-AIAgentsMcpJsonAgent

--- a/bucket/AIAgents.Tests.ps1
+++ b/bucket/AIAgents.Tests.ps1
@@ -63,6 +63,28 @@ Describe 'AIAgents bundle: MCP configuration is declarative' -Tag 'Light','Bundl
     It 'depends on Node.js so npx-based MCP servers resolve at agent start-up' {
         $script:mcpCfgPkg.DependsOn | Should -Contain 'Node.js'
     }
+
+    It 'resolves the helper dot-source under harvest with an empty $PSScriptRoot (#341)' {
+        # Regression: a deferred `{ . (Join-Path $PSScriptRoot ...) }` body sees an
+        # EMPTY automatic $PSScriptRoot when Update-Package invokes the harvested
+        # scriptblock (a [scriptblock]::Create has no source file), so Join-Path
+        # throws "Cannot bind argument to parameter 'Path' because it is an empty
+        # string". The fix bakes the resolved helper path in eagerly at harvest
+        # time. Isolate the dot-source (AIAgents.Mcp.ps1 is side-effect free on
+        # dot-source) by dropping the Install call; the rebuilt probe is itself a
+        # ::Create scriptblock, so its $PSScriptRoot is empty -- faithfully
+        # reproducing the harvested run-time scope.
+        $dotSourceOnly = ($script:mcpCfgPkg.ConfigScript.ToString() -split "`r?`n" |
+                Where-Object { $_ -notmatch 'Install-AIAgentsMcpConfiguration' }) -join "`n"
+        $probe = [scriptblock]::Create($dotSourceOnly)
+
+        { & $probe } | Should -Not -Throw
+        # Observable proof the helper actually loaded: dot-source the probe into
+        # this scope and confirm a function defined only in AIAgents.Mcp.ps1 is
+        # now available.
+        . $probe
+        Get-Command Get-PoshMcpServerEntry -ErrorAction SilentlyContinue | Should -Not -BeNullOrEmpty
+    }
 }
 
 Describe 'AIAgents bundle: Gemini desktop -> Gemini CLI Companions' -Tag 'Light','Bundle' {

--- a/bucket/AIAgents.ps1
+++ b/bucket/AIAgents.ps1
@@ -356,10 +356,16 @@ Register-ArgumentCompleter -Native -CommandName copilot -ScriptBlock {
         Notes     = 'Idempotent MCP-server wiring for every MCP-capable agent. Re-applied on every install/update; refresh on demand with Update-Package "MCP Server Configuration".'
         # Engine no-op: the configuration IS the work, performed in ConfigScript.
         CustomInstallScript = { }
-        ConfigScript = {
-            . (Join-Path $PSScriptRoot 'AIAgents.Mcp.ps1')
-            Install-AIAgentsMcpConfiguration
-        }
+        # Resolve the helper path eagerly (at $Packages-assignment time) and bake
+        # it into the ConfigScript as a literal. $PSScriptRoot is correct here on
+        # a real bundle dot-source AND under the Get-BundlePackageObjects AST
+        # harvest, which seeds $PSScriptRoot for the assignment scope. A deferred
+        # `{ ... $PSScriptRoot ... }` body would instead see an EMPTY automatic
+        # $PSScriptRoot when Update-Package runs the harvested scriptblock (the
+        # ::Create scriptblock has no source file), breaking the dot-source.
+        ConfigScript = [scriptblock]::Create(
+            ". '" + ((Join-Path $PSScriptRoot 'AIAgents.Mcp.ps1') -replace "'", "''") + "'`n" +
+            'Install-AIAgentsMcpConfiguration')
     }
 )
 


### PR DESCRIPTION
## Summary

Closes #341.

Reconfigures the existing `posh` MCP server (PoshMcp / `poshmcp`) to expose
the **full, write-capable** PowerShell surface to every wired AI agent, instead
of the previous read-only default. No separate `mcp-shell` server is needed --
the read-only behavior came from PoshMcp's default `PowerShellConfiguration`,
not a missing server.

## Changes

- `bucket/AIAgents.Mcp.ps1`: new `Get-PoshMcpConfigPath`,
  `Write-PoshMcpFullAccessConfig` (idempotent), and `Get-PoshMcpServerEntry`
  helpers. The `posh` server now starts with
  `serve --transport stdio --config <full-access-config>` where the config
  sets `IncludePatterns: ["*"]`.
- `bucket/AIAgents.Mcp.Tests.ps1`: 5 behavior-first tests for the full-access
  config writer and the server entry.
- `README.md`: security note about the full-access `posh` surface.

## Bug fix: Update-Package 'MCP Server Configuration'

While verifying the apply path, `Update-Package 'MCP Server Configuration'`
failed with `Cannot bind argument to parameter 'Path' because it is an empty
string`. Root cause: the MCP package's `ConfigScript` dot-sourced the helper
via Join-Path on ``. Under `Update-Package` the ConfigScript is
a harvested `[scriptblock]::Create` scriptblock with no source file, so the
automatic `` was empty at run time and `Join-Path` threw.

Fix: resolve the helper path eagerly at ``-assignment time (where
`` is seeded correctly for both a real bundle dot-source and the
AST harvest) and bake a literal absolute path into the ConfigScript. A
behavior-first regression test in `bucket/AIAgents.Tests.ps1` reproduces the
empty-`` harvest scenario; reverting the fix throws the original
binding error.

## Security note

`IncludePatterns: ["*"]` grants every wired AI agent unrestricted,
write-capable PowerShell on the machine (delete files, change system state, run
arbitrary code via `Invoke-Expression`). This is a deliberate, owner-approved
posture for this personal bucket. Narrow `IncludePatterns` / `ExcludePatterns`
in the generated config for a more conservative surface.

## Tests

- `Invoke-Pester bucket/AIAgents.Mcp.Tests.ps1` -- 38 pass
- `Invoke-Pester bucket/AIAgents.Tests.ps1` -- 8 pass
- `Invoke-ScriptAnalyzer bucket/AIAgents.ps1` -- only pre-existing warnings