### PR TITLE
fix(aiagents): wire posh MCP server when poshmcp is already installed

### DIFF
--- a/bucket/AIAgents.Mcp.Tests.ps1
+++ b/bucket/AIAgents.Mcp.Tests.ps1
@@ -337,6 +337,24 @@ exit /b 1
         }
     }
 
+    Context 'Test-PoshMcpShouldConfigure' {
+        It 'configures when poshmcp is already present even if the update failed (#344)' {
+            # Regression: a running MCP client locks the tool store, so
+            # `dotnet tool update -g poshmcp` returns non-zero with
+            # "Access to the path '...\.store\poshmcp\<ver>' is denied" -- but the
+            # already-installed tool is still usable, so the server must be wired.
+            Test-PoshMcpShouldConfigure -ToolPresent $true -InstallExitCode 1 | Should -BeTrue
+        }
+
+        It 'configures when a fresh install succeeded' {
+            Test-PoshMcpShouldConfigure -ToolPresent $false -InstallExitCode 0 | Should -BeTrue
+        }
+
+        It 'skips when the tool is absent and the install failed' {
+            Test-PoshMcpShouldConfigure -ToolPresent $false -InstallExitCode 1 | Should -BeFalse
+        }
+    }
+
     Context 'Add-McpServerToJsonConfig: env emission' {
         BeforeEach {
             $script:TmpDir = New-TempDir

--- a/bucket/AIAgents.Mcp.ps1
+++ b/bucket/AIAgents.Mcp.ps1
@@ -582,6 +582,51 @@ function Get-PoshMcpServerEntry {
     }
 }
 
+function Test-PoshMcpToolPresent {
+    <#
+    .SYNOPSIS
+        Report whether the poshmcp dotnet global tool is already installed.
+    .DESCRIPTION
+        The tool is "present" when its shim exists under the dotnet global-tools
+        directory OR resolves on PATH. The on-disk check matters because a fresh
+        `dotnet tool install` does not add the tools dir to the current session
+        PATH, so Get-Command alone would miss a just-installed tool.
+    .OUTPUTS
+        Boolean.
+    #>
+    [CmdletBinding()]
+    [OutputType([bool])]
+    param()
+    $exe = Join-Path $env:USERPROFILE '.dotnet\tools\poshmcp.exe'
+    return ((Test-Path $exe) -or [bool](Get-Command poshmcp -ErrorAction SilentlyContinue))
+}
+
+function Test-PoshMcpShouldConfigure {
+    <#
+    .SYNOPSIS
+        Decide whether the `posh` MCP server should be wired, given whether the
+        poshmcp tool is already present and the exit code of the install/update
+        attempt.
+    .DESCRIPTION
+        A tool that is already present stays usable even when a re-install or
+        update returns non-zero -- the common cause is a locked tool store
+        because a running MCP client holds poshmcp open ("Access to the path
+        '...\.store\poshmcp\<ver>' is denied"). In that case the existing version
+        is perfectly serviceable, so we still configure the server. Only a tool
+        that is genuinely absent AND failed to install is treated as unavailable.
+    .OUTPUTS
+        Boolean.
+    #>
+    [CmdletBinding()]
+    [OutputType([bool])]
+    param(
+        [Parameter(Mandatory)][bool]$ToolPresent,
+        [Parameter(Mandatory)][int]$InstallExitCode
+    )
+    if ($ToolPresent) { return $true }
+    return ($InstallExitCode -eq 0)
+}
+
 function Install-AIAgentsMcpConfiguration {
     <#
     .SYNOPSIS
@@ -627,19 +672,36 @@ function Install-AIAgentsMcpConfiguration {
     }
 
     # PoshMcp ships as a .NET global tool. Skip silently if dotnet isn't present.
+    # If the tool is already installed, a re-install/update can fail merely
+    # because a running MCP client locks the tool store -- the existing version
+    # is still usable, so we configure the server regardless of that exit code.
     $poshMcpAvailable = $false
     if (Get-Command dotnet -ErrorAction SilentlyContinue) {
-        Write-Host 'Installing PoshMcp dotnet global tool...'
-        & dotnet tool install -g poshmcp 2>&1 | Tee-Object -Variable poshOut
-        if ($LASTEXITCODE -eq 0 -or ($poshOut -join "`n") -match 'already installed') {
-            $poshMcpAvailable = $true
+        $toolPresent = Test-PoshMcpToolPresent
+        if ($toolPresent) {
+            Write-Host 'PoshMcp already installed; attempting best-effort update...'
+            & dotnet tool update -g poshmcp 2>&1 | Tee-Object -Variable poshOut | Out-Host
+        }
+        else {
+            Write-Host 'Installing PoshMcp dotnet global tool...'
+            & dotnet tool install -g poshmcp 2>&1 | Tee-Object -Variable poshOut | Out-Host
+        }
+        $installExit = $LASTEXITCODE
+
+        $poshMcpAvailable = Test-PoshMcpShouldConfigure -ToolPresent $toolPresent -InstallExitCode $installExit
+        if ($poshMcpAvailable) {
+            if ($installExit -ne 0) {
+                $detail = (@($poshOut) | Select-Object -Last 1)
+                Write-Warning "PoshMcp install/update returned $installExit but poshmcp is already present (tool store likely locked by a running MCP client); using the installed version. Detail: $detail"
+            }
             $dotnetTools = Join-Path $env:USERPROFILE '.dotnet\tools'
             if ((Test-Path $dotnetTools) -and ($env:Path -notlike "*$dotnetTools*")) {
                 $env:Path = "$env:Path;$dotnetTools"
             }
         }
         else {
-            Write-Warning 'dotnet tool install -g poshmcp failed; PoshMcp MCP server will not be configured.'
+            $detail = (@($poshOut) | Select-Object -Last 3) -join '; '
+            Write-Warning "dotnet tool install -g poshmcp failed and poshmcp is not present; PoshMcp MCP server will not be configured. Detail: $detail"
         }
     }
     else {


### PR DESCRIPTION
## Summary

Closes #344.

`Update-Package "MCP Server Configuration"` skipped the `posh` MCP server with:

```
WARNING: dotnet tool install -g poshmcp failed; PoshMcp MCP server will not be configured.
```

whenever `poshmcp` was already installed.

## Root cause

When `poshmcp` is already installed, `dotnet tool install -g poshmcp` attempts to
**update** it. The update first uninstalls the old version, which fails when a
running MCP client locks the tool store:

```
Failed to uninstall tool package 'poshmcp':
Access to the path 'C:\Users\<u>\.dotnet\tools\.store\poshmcp\0.8.11' is denied.
```

The installer treated this non-zero exit as "not available" and skipped the
server -- even though the installed tool is fully usable. It also hid the real
`dotnet` error behind a generic warning.

## Fix

- Add `Test-PoshMcpToolPresent` (exe-on-disk OR on-PATH) and the pure,
  unit-testable `Test-PoshMcpShouldConfigure` decision helper.
- When `poshmcp` is already present, run a best-effort `dotnet tool update` and
  wire the server regardless of a locked-store failure.
- Surface the real `dotnet` output when the tool is genuinely absent and the
  install fails.

## Behavior-first tests

`Test-PoshMcpShouldConfigure`:
- already present + non-zero install exit -> configure (regression for #344)
- absent + successful install -> configure
- absent + failed install -> skip

Reverting the decision (ignoring `ToolPresent`) fails the first test with an
assertion -- a behavioral failure.

## Tests

```powershell
Invoke-Pester -Path .\bucket\AIAgents.Mcp.Tests.ps1 -Output Detailed
```

Note: local `pwsh` 7 was unavailable in the authoring shell (Store-install not
visible to the constrained session), so the PS7 Pester suite runs authoritatively
in CI. The pure decision logic was sanity-checked on Windows PowerShell 5.1.