### PR TITLE
fix(module): survive a broken foreign format file on import

### DIFF
--- a/module/MarkMichaelis.ScoopBucket/MarkMichaelis.ScoopBucket.psd1
+++ b/module/MarkMichaelis.ScoopBucket/MarkMichaelis.ScoopBucket.psd1
@@ -19,7 +19,14 @@
 
     ScriptsToProcess  = @('Classes\Package.ps1', 'Classes\PackageResult.ps1')
 
-    FormatsToProcess  = @('MarkMichaelis.ScoopBucket.format.ps1xml')
+    # Format data is intentionally NOT loaded via FormatsToProcess. The manifest's
+    # FormatsToProcess triggers a full Update-FormatData rebuild that re-validates
+    # EVERY format file already registered in the session -- including those owned by
+    # unrelated modules (e.g. PSReadLine). If any such foreign file is missing from
+    # disk, the rebuild throws and aborts our entire import. Instead the root .psm1
+    # loads MarkMichaelis.ScoopBucket.format.ps1xml via a guarded Update-FormatData
+    # so a broken foreign format file only degrades our colorized output rather than
+    # blocking the module from loading. See issue #346.
 
     FunctionsToExport = @(
         'Install-Package',

--- a/module/MarkMichaelis.ScoopBucket/MarkMichaelis.ScoopBucket.psm1
+++ b/module/MarkMichaelis.ScoopBucket/MarkMichaelis.ScoopBucket.psm1
@@ -41,6 +41,17 @@ foreach ($dir in @('Private', 'Public')) {
 # that calls them later.
 try { . Initialize-ScoopEnvironment } catch { Write-Verbose "Initialize-ScoopEnvironment: $($_.Exception.Message)" }
 
+# Load our display formatting (PackageUpdateResult colorization etc.) here rather
+# than via the manifest's FormatsToProcess. Update-FormatData rebuilds the WHOLE
+# session format table and re-validates every registered format file, including
+# those owned by unrelated modules (e.g. PSReadLine). If a foreign format file is
+# missing from disk, that rebuild throws -- and via FormatsToProcess it would abort
+# our entire import, making the module unusable through no fault of our own. Guarding
+# it here degrades gracefully: a broken foreign format file only costs us colorized
+# output, never the module load. See issue #346.
+$formatFile = Join-Path $PSScriptRoot 'MarkMichaelis.ScoopBucket.format.ps1xml'
+try { Update-FormatData -PrependPath $formatFile } catch { Write-Warning "MarkMichaelis.ScoopBucket: display formatting was not loaded ($($_.Exception.Message)). Functionality is unaffected." }
+
 # Wire up Tab completion for `Install-Package -Name <tab>` and
 # `Get-Package -Name <tab>` so callers don't need to remember exact
 # package spellings. The completer is regex-driven and cached, so it's

--- a/module/MarkMichaelis.ScoopBucket/ModuleImportResilience.Tests.ps1
+++ b/module/MarkMichaelis.ScoopBucket/ModuleImportResilience.Tests.ps1
@@ -1,0 +1,37 @@
+#requires -Version 7.0
+
+Set-StrictMode -Version Latest
+
+Describe 'Module import resilience to a broken foreign format file' {
+    BeforeAll {
+        $script:ModulePath = Join-Path $PSScriptRoot 'MarkMichaelis.ScoopBucket.psd1'
+        # The pwsh hosting this test -- reused to spawn an isolated child session so
+        # the deliberately-corrupted format table never pollutes the test runner.
+        $script:PwshPath = (Get-Process -Id $PID).Path
+    }
+
+    It 'imports the module even when a previously-registered foreign format file is missing from disk' {
+        # Arrange: a child script that registers a foreign format file, deletes it
+        # from disk (the PSReadLine-style "broken install" scenario), then imports
+        # our module. Update-FormatData rebuilds the whole session format table, so
+        # the missing foreign file is what would otherwise abort the import.
+        $childScript = @'
+param([Parameter(Mandatory)][string]$ModulePath)
+$ErrorActionPreference = 'Stop'
+$broken = Join-Path ([System.IO.Path]::GetTempPath()) ("scoopbucket-brokenfmt-" + [guid]::NewGuid().ToString('N') + ".ps1xml")
+Set-Content -LiteralPath $broken -Encoding utf8 -Value '<?xml version="1.0" encoding="utf-8"?><Configuration></Configuration>'
+Update-FormatData -PrependPath $broken
+Remove-Item -LiteralPath $broken -Force
+Import-Module $ModulePath -Force
+if (Get-Command Update-Package -ErrorAction SilentlyContinue) { 'IMPORT_OK' } else { 'IMPORT_NO_CMD' }
+'@
+        $childPath = Join-Path $TestDrive 'import-with-broken-foreign-format.ps1'
+        Set-Content -LiteralPath $childPath -Value $childScript -Encoding utf8
+
+        # Act
+        $output = & $script:PwshPath -NoProfile -ExecutionPolicy Bypass -File $childPath -ModulePath $script:ModulePath 2>&1
+
+        # Assert: the import completed and the public surface is available.
+        ($output -join "`n") | Should -Match 'IMPORT_OK'
+    }
+}


### PR DESCRIPTION
## Summary

`Import-Module MarkMichaelis.ScoopBucket -Force` could fail outright when an
**unrelated** module had a broken/missing format file registered in the
session:

```
Import-Module: Could not find a part of the path
'C:\program files\powershell\7\Modules\PSReadLine\PSReadLine.format.ps1xml'.
```

PSReadLine (auto-loaded for the interactive prompt) registers its
`PSReadLine.format.ps1xml`. With that file missing on disk, our manifest's
`FormatsToProcess` triggered a full `Update-FormatData` rebuild that
re-validates every registered format file -- including PSReadLine's -- and
aborted the entire import, taking `Update-Package`, `Get-Package`, etc. down
with it.

## Fix

Move format loading out of the manifest's hard-failing `FormatsToProcess`
into a guarded `Update-FormatData` in the root `.psm1`, mirroring the
existing `try/catch` load pattern (Initialize-ScoopEnvironment,
Register-PackageNameCompleter). A broken foreign format file now only
degrades our colorized output -- it no longer blocks the module load.

## Tests

Adds `ModuleImportResilience.Tests.ps1`: a behavior-first test that spawns an
isolated child `pwsh`, registers a foreign format file, deletes it from disk
(the broken-PSReadLine scenario), then imports the module and asserts the
public surface (`Update-Package`) is available. Reverting the fix makes the
import throw, so the test fails for a behavioral reason.

Closes #346