### PR TITLE
fix(aiagents): quiet npm warn/funding noise during MCP server install

### DIFF
--- a/bucket/AIAgents.Mcp.Tests.ps1
+++ b/bucket/AIAgents.Mcp.Tests.ps1
@@ -203,6 +203,24 @@ exit /b 1
         }
     }
 
+    Context 'Get-AIAgentsNpmInstallArgument' {
+        It 'suppresses warn-level deprecation/EBADENGINE noise and funding banners' {
+            # The whole point of #348: a successful global install must not be
+            # buried in npm warn/funding chatter. These flags are the behavior.
+            $args = Get-AIAgentsNpmInstallArgument -Package '@upstash/context7-mcp@latest'
+            $args | Should -Contain '--loglevel=error'
+            $args | Should -Contain '--no-fund'
+            $args | Should -Contain '--no-audit'
+        }
+
+        It 'still performs a global install of the requested package' {
+            $args = Get-AIAgentsNpmInstallArgument -Package '@playwright/test'
+            $args[0] | Should -Be 'install'
+            $args | Should -Contain '--global'
+            $args | Should -Contain '@playwright/test'
+        }
+    }
+
     Context 'Resolve-NpmBin' {
         BeforeEach {
             $script:TmpRoot = New-TempDir

--- a/bucket/AIAgents.Mcp.ps1
+++ b/bucket/AIAgents.Mcp.ps1
@@ -490,6 +490,42 @@ function Get-AIAgentsMcpNpmPackage {
     )
 }
 
+function Get-AIAgentsNpmInstallArgument {
+    <#
+    .SYNOPSIS
+        Build the `npm install --global` argument vector for an MCP package,
+        with quieting flags so a successful run is not buried in noise.
+    .DESCRIPTION
+        Pre-installing the MCP server packages globally drags in transitive
+        dependencies that emit warn-level deprecation / EBADENGINE notices and
+        funding banners. None of it is actionable by the user, yet it reads
+        like a failure on an otherwise successful `Update-Package` run. These
+        flags suppress that chatter while leaving real errors intact:
+
+          --no-fund        drop the "N packages are looking for funding" banner
+          --no-audit       skip the post-install audit summary
+          --loglevel=error silence warn-level (deprecated / EBADENGINE) output;
+                           genuine errors still print and still set a non-zero
+                           exit code, so the caller's npx fallback still fires
+
+        Returned as a typed array so the call site can splat it to `npm.cmd`
+        and so the flags are independently testable.
+    .PARAMETER Package
+        The npm package spec to install (a version suffix such as `@latest`
+        may already be appended by the caller).
+    .OUTPUTS
+        String[].
+    #>
+    [CmdletBinding()]
+    [OutputType([string[]])]
+    param(
+        [Parameter(Mandatory)]
+        [ValidateNotNullOrEmpty()]
+        [string]$Package
+    )
+    @('install', '--global', $Package, '--no-fund', '--no-audit', '--loglevel=error')
+}
+
 function Get-AIAgentsDeprecatedMcpServer {
     <#
     .SYNOPSIS
@@ -652,7 +688,8 @@ function Install-AIAgentsMcpConfiguration {
     # install just chromium.
     if (Get-Command npm -ErrorAction SilentlyContinue) {
         if (-not (Get-Command playwright -ErrorAction SilentlyContinue)) {
-            & npm.cmd install --global '@playwright/test'
+            $playwrightNpmArgs = Get-AIAgentsNpmInstallArgument -Package '@playwright/test'
+            & npm.cmd @playwrightNpmArgs
             if ($LASTEXITCODE -ne 0) {
                 Write-Warning "npm install --global @playwright/test exited with code $LASTEXITCODE; falling back to npx for browser install."
             }
@@ -730,7 +767,8 @@ function Install-AIAgentsMcpConfiguration {
     if (Get-Command npm -ErrorAction SilentlyContinue) {
         foreach ($pkg in $mcpNpmPackages) {
             Write-Host "Installing $pkg globally (latest)..."
-            & npm.cmd install --global "$pkg@latest" 2>&1 | Out-Host
+            $npmArgs = Get-AIAgentsNpmInstallArgument -Package "$pkg@latest"
+            & npm.cmd @npmArgs 2>&1 | Out-Host
             if ($LASTEXITCODE -ne 0) {
                 Write-Warning "npm install -g $pkg failed; that MCP entry will fall back to 'npx -y'."
             }


### PR DESCRIPTION
## Summary

`Update-Package 'MCP Server Configuration'` printed a wall of npm noise that
looked alarming even on a fully successful run -- warn-level deprecation /
EBADENGINE notices and funding banners from transitive dependencies of the
MCP server packages. It buried the meaningful per-agent "configured X MCP in
Y" confirmations and read like a failure.

This adds a pure `Get-AIAgentsNpmInstallArgument` helper that builds the
`npm install --global` argument vector with quieting flags
(`--no-fund`, `--no-audit`, `--loglevel=error`) and routes both npm install
call sites in `Install-AIAgentsMcpConfiguration` through it. Genuine errors
(error level + non-zero exit code) still surface and still trigger the
existing npx fallback warning.

## Tests

`AIAgents.Mcp.Tests.ps1` gains a `Get-AIAgentsNpmInstallArgument` context:
- asserts the quieting flags (`--no-fund`, `--no-audit`, `--loglevel=error`)
  are present -- fails for a behavioral reason if they are removed
- asserts the helper still performs a global install of the requested package

## Out of scope

Routing the per-agent "configured X MCP in Y" status lines through the
`PackageUpdateResult` table needs an engine-contract change (the ConfigScript
return is discarded in Invoke-PackageUpdate) plus a UX decision about hiding
those lines by default. Left for a follow-up.

Closes #348