### PR TITLE
fix(aiagents): quiet dotnet SDK-not-found noise on PoshMcp update

### DIFF
--- a/bucket/AIAgents.Mcp.Tests.ps1
+++ b/bucket/AIAgents.Mcp.Tests.ps1
@@ -373,6 +373,38 @@ exit /b 1
         }
     }
 
+    Context 'Get-PoshMcpInstallFailureDetail' {
+        It 'classifies a missing .NET SDK (runtime-only machine) (#350)' {
+            # Real `dotnet tool update` output when only the .NET runtime is present.
+            $raw = @(
+                'The command could not be loaded, possibly because:'
+                '  * You intended to execute a .NET application:'
+                "      The application 'tool' does not exist."
+                '  * You intended to execute a .NET SDK command:'
+                '      No .NET SDKs were found.'
+                'Download a .NET SDK:'
+                'https://aka.ms/dotnet/download'
+            )
+            $detail = Get-PoshMcpInstallFailureDetail -RawOutput $raw
+            $detail | Should -Match 'no \.NET SDK found'
+            # The multi-line dotnet block must be collapsed to a single line.
+            $detail | Should -Not -Match "`n"
+        }
+
+        It 'classifies a locked tool store (running MCP client) (#350)' {
+            $raw = @(
+                "Failed to uninstall tool package 'poshmcp':"
+                "Access to the path 'C:\Users\Mark\.dotnet\tools\.store\poshmcp\0.8.11' is denied."
+            )
+            Get-PoshMcpInstallFailureDetail -RawOutput $raw | Should -Match 'tool store locked'
+        }
+
+        It 'falls back to the last meaningful line for an unrecognized failure (#350)' {
+            $raw = @('warming up', '', 'Something specific went wrong')
+            Get-PoshMcpInstallFailureDetail -RawOutput $raw | Should -Be 'Something specific went wrong'
+        }
+    }
+
     Context 'Add-McpServerToJsonConfig: env emission' {
         BeforeEach {
             $script:TmpDir = New-TempDir

--- a/bucket/AIAgents.Mcp.ps1
+++ b/bucket/AIAgents.Mcp.ps1
@@ -663,6 +663,46 @@ function Test-PoshMcpShouldConfigure {
     return ($InstallExitCode -eq 0)
 }
 
+function Get-PoshMcpInstallFailureDetail {
+    <#
+    .SYNOPSIS
+        Condense raw `dotnet tool install/update` output into one concise reason.
+    .DESCRIPTION
+        The best-effort PoshMcp update path captures dotnet's output instead of
+        streaming it, so a single WARNING can explain why the update did not run
+        without dumping dotnet's multi-line SDK-resolution or locked-store error
+        block on an otherwise successful Update-Package run. This classifies the
+        two common failures (no .NET SDK on the machine; tool store locked by a
+        running MCP client) and otherwise falls back to the last meaningful line.
+    .PARAMETER RawOutput
+        The combined (2>&1) output lines captured from the dotnet invocation.
+    .OUTPUTS
+        A short human-readable reason string.
+    #>
+    [CmdletBinding()]
+    [OutputType([string])]
+    param(
+        [Parameter()]
+        [AllowNull()]
+        [object[]]$RawOutput
+    )
+
+    $lines = @($RawOutput | ForEach-Object { "$_" })
+    $text = ($lines -join "`n")
+    if ([string]::IsNullOrWhiteSpace($text)) { return 'no output' }
+
+    if ($text -match 'No \.NET SDKs were found' -or $text -match 'sdk-not-found') {
+        return 'no .NET SDK found (only the runtime is installed); install the .NET SDK to update the tool'
+    }
+    if ($text -match 'denied' -and $text -match '\.store') {
+        return 'tool store locked by a running MCP client'
+    }
+
+    $lastMeaningful = @($lines | Where-Object { $_.Trim() }) | Select-Object -Last 1
+    if ($lastMeaningful) { return $lastMeaningful.Trim() }
+    return 'unknown error'
+}
+
 function Install-AIAgentsMcpConfiguration {
     <#
     .SYNOPSIS
@@ -717,7 +757,11 @@ function Install-AIAgentsMcpConfiguration {
         $toolPresent = Test-PoshMcpToolPresent
         if ($toolPresent) {
             Write-Host 'PoshMcp already installed; attempting best-effort update...'
-            & dotnet tool update -g poshmcp 2>&1 | Tee-Object -Variable poshOut | Out-Host
+            # Capture rather than stream: on a machine with only the .NET runtime
+            # (no SDK) `dotnet tool update` dumps a multi-line "No .NET SDKs were
+            # found" block. We always fall back to the installed tool, so surface
+            # just a one-line reason in the WARNING below instead (#350).
+            $poshOut = & dotnet tool update -g poshmcp 2>&1
         }
         else {
             Write-Host 'Installing PoshMcp dotnet global tool...'
@@ -728,8 +772,8 @@ function Install-AIAgentsMcpConfiguration {
         $poshMcpAvailable = Test-PoshMcpShouldConfigure -ToolPresent $toolPresent -InstallExitCode $installExit
         if ($poshMcpAvailable) {
             if ($installExit -ne 0) {
-                $detail = (@($poshOut) | Select-Object -Last 1)
-                Write-Warning "PoshMcp install/update returned $installExit but poshmcp is already present (tool store likely locked by a running MCP client); using the installed version. Detail: $detail"
+                $detail = Get-PoshMcpInstallFailureDetail -RawOutput $poshOut
+                Write-Warning "PoshMcp install/update returned $installExit but poshmcp is already present (using the installed version). Detail: $detail"
             }
             $dotnetTools = Join-Path $env:USERPROFILE '.dotnet\tools'
             if ((Test-Path $dotnetTools) -and ($env:Path -notlike "*$dotnetTools*")) {
@@ -737,7 +781,7 @@ function Install-AIAgentsMcpConfiguration {
             }
         }
         else {
-            $detail = (@($poshOut) | Select-Object -Last 3) -join '; '
+            $detail = Get-PoshMcpInstallFailureDetail -RawOutput $poshOut
             Write-Warning "dotnet tool install -g poshmcp failed and poshmcp is not present; PoshMcp MCP server will not be configured. Detail: $detail"
         }
     }


### PR DESCRIPTION
## Summary

On a machine that has only the .NET runtime (no SDK), a successful
`Update-Package 'MCP Server Configuration'` run printed the full
`dotnet tool update` SDK-resolution wall:

```
PoshMcp already installed; attempting best-effort update...
The command could not be loaded, possibly because:
  * You intended to execute a .NET application:
      The application 'tool' does not exist.
  * You intended to execute a .NET SDK command:
      No .NET SDKs were found.
Download a .NET SDK: https://aka.ms/dotnet/download
...
```

This is harmless -- the self-heal falls back to the already-installed
`poshmcp` and the `posh` MCP server is still configured -- but the wall reads
like a failure on an otherwise green run. Same class of harmless-noise-on-
success as #348 / #349.

## Change

- On the best-effort *update* path (tool already present, so we always fall
  back), capture dotnet's output instead of streaming it to the host.
- Add a pure `Get-PoshMcpInstallFailureDetail` helper that condenses the
  captured output into a single meaningful reason: missing .NET SDK, locked
  tool store, or the last meaningful line for anything else.
- Both the update and install-absent WARNINGs now surface that one-liner.

Result on the affected machine:

```
PoshMcp already installed; attempting best-effort update...
WARNING: PoshMcp install/update returned -2147450735 but poshmcp is already
present (using the installed version). Detail: no .NET SDK found (only the
runtime is installed); install the .NET SDK to update the tool
```

## Tests

`AIAgents.Mcp.Tests.ps1` gains a `Get-PoshMcpInstallFailureDetail` context
asserting the SDK-not-found classification (and that the multi-line block is
collapsed to one line), the locked-store classification, and the last-line
fallback. Each fails for a behavioral reason if the classifier is reverted.

## Out of scope

Routing the per-agent "configured X MCP in Y" status lines through the
Update-Package result table (the larger formatting ask) still needs an
engine-contract change plus a UX decision -- tracked separately.

Closes #350