### PR TITLE
feat(packages): capture ConfigScript output into transient channel (#352)

### DIFF
--- a/bucket/AIAgents.Mcp.ps1
+++ b/bucket/AIAgents.Mcp.ps1
@@ -765,7 +765,7 @@ function Install-AIAgentsMcpConfiguration {
         }
         else {
             Write-Host 'Installing PoshMcp dotnet global tool...'
-            & dotnet tool install -g poshmcp 2>&1 | Tee-Object -Variable poshOut | Out-Host
+            & dotnet tool install -g poshmcp 2>&1 | Tee-Object -Variable poshOut | ForEach-Object { Write-Host "$_" }
         }
         $installExit = $LASTEXITCODE
 
@@ -812,7 +812,7 @@ function Install-AIAgentsMcpConfiguration {
         foreach ($pkg in $mcpNpmPackages) {
             Write-Host "Installing $pkg globally (latest)..."
             $npmArgs = Get-AIAgentsNpmInstallArgument -Package "$pkg@latest"
-            & npm.cmd @npmArgs 2>&1 | Out-Host
+            & npm.cmd @npmArgs 2>&1 | ForEach-Object { Write-Host "$_" }
             if ($LASTEXITCODE -ne 0) {
                 Write-Warning "npm install -g $pkg failed; that MCP entry will fall back to 'npx -y'."
             }
@@ -938,7 +938,7 @@ function Reset-AIAgentsMcpConfiguration {
     if (Get-Command npm -ErrorAction SilentlyContinue) {
         Write-Host '-Reset: uninstalling MCP npm packages globally...'
         foreach ($pkg in $mcpNpmPackages) {
-            & npm.cmd uninstall --global $pkg 2>&1 | Out-Host
+            & npm.cmd uninstall --global $pkg 2>&1 | ForEach-Object { Write-Host "$_" }
         }
     }
 }

--- a/bucket/UpdatePackage.Tests.ps1
+++ b/bucket/UpdatePackage.Tests.ps1
@@ -513,6 +513,37 @@ Describe 'Invoke-PackageUpdate pipeline' -Tag 'Light','Module' {
         $ours.Count | Should -Be 1
     }
 
+    It 'does not leak ConfigScript console output onto the result pipeline (#352)' {
+        $pkgs = [Package[]]@(
+            [Package]@{ Name='A'; Installer='winget'; Id='Foo.A'
+                        ConfigScript = { Write-Host 'SENTINEL-npm-noise-line' } }
+        )
+        $r = @(Invoke-PackageUpdate -Packages $pkgs -Bundle 'Test' -SkipCompletion 6>$null)
+        # Every emitted object is a structured result, never the captured line.
+        $r | ForEach-Object { $_ | Should -BeOfType ([PackageResult]) }
+        ($r | Where-Object { "$_" -match 'SENTINEL-npm-noise-line' }) | Should -BeNullOrEmpty
+    }
+
+    It 'writes a per-run failure log to the current directory when a ConfigScript fails (#352)' {
+        $tmp = Join-Path ([System.IO.Path]::GetTempPath()) ("sb-cfgfail-" + [guid]::NewGuid().ToString('N'))
+        New-Item -ItemType Directory -Path $tmp -Force | Out-Null
+        Push-Location $tmp
+        try {
+            $pkgs = [Package[]]@(
+                [Package]@{ Name='A'; Installer='winget'; Id='Foo.A'
+                            ConfigScript = { Write-Host 'pre-throw-line'; throw 'cfgboom' } }
+            )
+            $null = Invoke-PackageUpdate -Packages $pkgs -Bundle 'Test' -SkipCompletion `
+                -ErrorAction SilentlyContinue 6>$null 3>$null
+            $log = Get-ChildItem -Path $tmp -Filter 'ScoopBucket-Update-Package-*-failures.log'
+            @($log).Count | Should -Be 1
+            (Get-Content -LiteralPath $log.FullName -Raw) | Should -Match 'pre-throw-line'
+        } finally {
+            Pop-Location
+            Remove-Item -LiteralPath $tmp -Recurse -Force -ErrorAction SilentlyContinue
+        }
+    }
+
     It 'does not run ConfigScript under -WhatIf' {
         Mock -ModuleName MarkMichaelis.ScoopBucket Update-WingetPackage { throw 'engine must not run under -WhatIf' }
         Mock -ModuleName MarkMichaelis.ScoopBucket Get-PackageUpdateIndex {

--- a/module/MarkMichaelis.ScoopBucket/Private/ConfigScriptCapture.Tests.ps1
+++ b/module/MarkMichaelis.ScoopBucket/Private/ConfigScriptCapture.Tests.ps1
@@ -1,0 +1,149 @@
+<#
+.SYNOPSIS
+    Light-suite Pester coverage for the private ConfigScript live-output capture
+    helpers (#352).
+
+.DESCRIPTION
+    Pins the behavior that the AIAgents MCP noise problem depends on:
+
+      * Invoke-ConfigScriptCaptured collects a ConfigScript's Write-Host + native
+        stdout into the caller's buffer WITHOUT leaking onto the success (object)
+        pipeline -- so a clean run shows only the result table.
+      * Genuine warnings are re-emitted (persist past the transient pane).
+      * A throwing ConfigScript leaves the lines captured before the throw in the
+        buffer (so the failure flush + log have something to show) and the throw
+        propagates to the caller.
+      * The per-run failure-log file name follows the agreed sortable format.
+      * Get-FailureLogPath falls back to $env:TEMP when the preferred directory is
+        not writable, and never throws.
+#>
+
+BeforeAll {
+    $script:moduleManifest = Resolve-Path (Join-Path $PSScriptRoot '..\MarkMichaelis.ScoopBucket.psd1')
+    Import-Module $script:moduleManifest -Force
+    $script:mod = Get-Module MarkMichaelis.ScoopBucket
+}
+
+Describe 'Invoke-ConfigScriptCaptured' {
+    It 'captures Write-Host and native-style stdout into the buffer without polluting the success pipeline' {
+        $buf = New-Object System.Collections.Generic.List[string]
+        $sb = { param($p) Write-Host 'npm: added 3 packages'; Write-Output 'tool-stdout-line' }
+
+        $emitted = & $script:mod {
+            param($sb, $buf)
+            Invoke-ConfigScriptCaptured -ConfigScript $sb -Package ([pscustomobject]@{ Name = 'X' }) -Buffer $buf -Activity 'Update-Package'
+        } $sb $buf 3>$null
+
+        # Nothing reaches the cmdlet's object pipeline.
+        @($emitted) | Should -BeNullOrEmpty
+        # Both lines were captured into the buffer.
+        $buf | Should -Contain 'npm: added 3 packages'
+        $buf | Should -Contain 'tool-stdout-line'
+    }
+
+    It 're-emits genuine warnings so they persist past the transient pane' {
+        $buf = New-Object System.Collections.Generic.List[string]
+        $sb = { param($p) Write-Warning 'deprecated package' }
+
+        $warnings = & $script:mod {
+            param($sb, $buf)
+            Invoke-ConfigScriptCaptured -ConfigScript $sb -Package ([pscustomobject]@{ Name = 'X' }) -Buffer $buf -Activity 'Update-Package'
+        } $sb $buf 3>&1 2>$null
+
+        @($warnings | Where-Object { $_ -is [System.Management.Automation.WarningRecord] }) |
+            Should -Not -BeNullOrEmpty
+        $buf | Should -Contain 'deprecated package'
+    }
+
+    It 'leaves pre-throw lines in the buffer and lets the throw propagate' {
+        $buf = New-Object System.Collections.Generic.List[string]
+        $sb = { param($p) Write-Host 'before the boom'; throw 'kaboom' }
+
+        {
+            & $script:mod {
+                param($sb, $buf)
+                Invoke-ConfigScriptCaptured -ConfigScript $sb -Package ([pscustomobject]@{ Name = 'X' }) -Buffer $buf -Activity 'Update-Package'
+            } $sb $buf 3>$null
+        } | Should -Throw
+
+        $buf | Should -Contain 'before the boom'
+    }
+}
+
+Describe 'ConvertTo-CapturedLine' {
+    It 'renders a warning record as its message text' {
+        $rec = [System.Management.Automation.WarningRecord]::new('hello warn')
+        $line = & $script:mod { param($r) ConvertTo-CapturedLine $r } $rec
+        $line | Should -Be 'hello warn'
+    }
+
+    It 'returns $null for whitespace-only input' {
+        $line = & $script:mod { ConvertTo-CapturedLine '   ' }
+        $line | Should -BeNullOrEmpty
+    }
+}
+
+Describe 'Get-FailureLogFileName' {
+    It 'produces the sortable ScoopBucket-<Verb>-Package-<timestamp>-failures.log name' {
+        $ts = [datetime]'2026-01-02T03:04:05'
+        $name = & $script:mod { param($t) Get-FailureLogFileName -Verb 'Update' -Timestamp $t } $ts
+        $name | Should -Be 'ScoopBucket-Update-Package-20260102-030405-failures.log'
+    }
+
+    It 'reflects the Install verb' {
+        $ts = [datetime]'2026-01-02T03:04:05'
+        $name = & $script:mod { param($t) Get-FailureLogFileName -Verb 'Install' -Timestamp $t } $ts
+        $name | Should -Match '^ScoopBucket-Install-Package-'
+    }
+}
+
+Describe 'Get-FailureLogPath' {
+    It 'uses the preferred directory when it is writable' {
+        $tmp = Join-Path ([System.IO.Path]::GetTempPath()) ("sb-pref-" + [guid]::NewGuid().ToString('N'))
+        New-Item -ItemType Directory -Path $tmp -Force | Out-Null
+        try {
+            $path = & $script:mod {
+                param($f, $pref, $fb) Get-FailureLogPath -FileName $f -PreferredDirectory $pref -FallbackDirectory $fb
+            } 'x.log' $tmp $env:TEMP
+            (Split-Path $path -Parent) | Should -Be $tmp
+        } finally {
+            Remove-Item -LiteralPath $tmp -Recurse -Force -ErrorAction SilentlyContinue
+        }
+    }
+
+    It 'falls back to the fallback directory when the preferred directory is not writable' {
+        $missing = Join-Path ([System.IO.Path]::GetTempPath()) ("sb-missing-" + [guid]::NewGuid().ToString('N'))
+        $path = & $script:mod {
+            param($f, $pref, $fb) Get-FailureLogPath -FileName $f -PreferredDirectory $pref -FallbackDirectory $fb
+        } 'x.log' $missing $env:TEMP
+        (Split-Path $path -Parent) | Should -Be $env:TEMP
+    }
+}
+
+Describe 'Write-FailureLog' {
+    It 'writes a UTF-8 (no BOM) log containing each failed package full output' {
+        $dir = Join-Path ([System.IO.Path]::GetTempPath()) ("sb-log-" + [guid]::NewGuid().ToString('N'))
+        New-Item -ItemType Directory -Path $dir -Force | Out-Null
+        $path = Join-Path $dir 'failures.log'
+        try {
+            $failures = @(
+                [pscustomobject]@{ Name = 'MCP Server Configuration'; Reason = 'ConfigScript threw: boom'; Output = "line-one`nline-two" }
+            )
+            $written = & $script:mod {
+                param($p, $fs) Write-FailureLog -Path $p -Verb 'Update' -Failures $fs
+            } $path $failures
+
+            $written | Should -Be $path
+            $content = Get-Content -LiteralPath $path -Raw
+            $content | Should -Match 'MCP Server Configuration'
+            $content | Should -Match 'line-one'
+            $content | Should -Match 'line-two'
+
+            # No UTF-8 BOM (first 3 bytes must not be EF BB BF).
+            $bytes = [System.IO.File]::ReadAllBytes($path)
+            ($bytes[0] -eq 0xEF -and $bytes[1] -eq 0xBB -and $bytes[2] -eq 0xBF) | Should -BeFalse
+        } finally {
+            Remove-Item -LiteralPath $dir -Recurse -Force -ErrorAction SilentlyContinue
+        }
+    }
+}

--- a/module/MarkMichaelis.ScoopBucket/Private/ConfigScriptCapture.ps1
+++ b/module/MarkMichaelis.ScoopBucket/Private/ConfigScriptCapture.ps1
@@ -1,0 +1,259 @@
+# Capture a package ConfigScript's underlying-tool output (npm/dotnet/Write-Host
+# chatter) into the transient live-output channel instead of letting it pile up in
+# the scrollback (#352).
+#
+# Both engines used to run the ConfigScript as `[void](& $p.ConfigScript $p 2>$null)`
+# -- output discarded, errors suppressed -- so the AIAgents MCP installer's wall of
+# npm/dotnet text hit the host directly and read like a failure on a successful run.
+#
+# Invoke-ConfigScriptCaptured runs the script with `*>&1` so every stream (including
+# Write-Host, which lands on the Information stream in PS5+) flows back through one
+# pipeline. Each line is routed to Write-UpdateStatus (transient Write-Progress +
+# -Verbose mirror) and appended to a caller-supplied buffer so a failure can flush
+# the captured output to the scrollback and to a per-run log file.
+#
+# NOTE: output written via Out-Host inside a ConfigScript is NOT capturable (it goes
+# straight to the host, bypassing every stream). ConfigScripts that want their tool
+# output to be transient must therefore use Write-Host, not Out-Host.
+
+function Out-CapturedFailure {
+    <#
+    .SYNOPSIS
+        Flush a failed package's captured ConfigScript output to the host so the
+        cause stays visible after the transient pane clears.
+    .PARAMETER Name
+        The package name (used in the section header).
+    .PARAMETER Lines
+        The captured output lines to print.
+    #>
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)][string]$Name,
+        [Parameter(Mandatory)][AllowEmptyCollection()][System.Collections.Generic.List[string]]$Lines
+    )
+
+    if ($Lines.Count -eq 0) { return }
+    Write-Host "----- captured output: $Name -----" -ForegroundColor Yellow
+    foreach ($line in $Lines) { Write-Host $line }
+    Write-Host "----- end captured output: $Name -----" -ForegroundColor Yellow
+}
+
+function ConvertTo-CapturedLine {
+    <#
+    .SYNOPSIS
+        Render a single pipeline record captured from a ConfigScript (`*>&1`) as a
+        plain display string.
+    .DESCRIPTION
+        `*>&1` yields a mix of raw objects and stream records (Warning / Error /
+        Verbose / Debug / Information). This normalizes any of them to a single
+        line of text for the transient pane and the recoverable buffer. Returns
+        `$null` for a record that has no meaningful text so the caller can skip it.
+    .PARAMETER Record
+        One item emitted by `& $ConfigScript $pkg *>&1`.
+    .OUTPUTS
+        System.String (or $null).
+    #>
+    [CmdletBinding()]
+    [OutputType([string])]
+    param(
+        [Parameter(Position = 0)][AllowNull()]$Record
+    )
+
+    if ($null -eq $Record) { return $null }
+
+    $text = switch ($Record) {
+        { $_ -is [System.Management.Automation.WarningRecord] }     { $_.Message; break }
+        { $_ -is [System.Management.Automation.ErrorRecord] }       { $_.ToString(); break }
+        { $_ -is [System.Management.Automation.VerboseRecord] }     { $_.Message; break }
+        { $_ -is [System.Management.Automation.DebugRecord] }       { $_.Message; break }
+        { $_ -is [System.Management.Automation.InformationRecord] } { $_.ToString(); break }
+        default                                                     { "$Record" }
+    }
+
+    if ([string]::IsNullOrWhiteSpace($text)) { return $null }
+    return $text
+}
+
+function Invoke-ConfigScriptCaptured {
+    <#
+    .SYNOPSIS
+        Run a package ConfigScript, routing its output to the transient live channel
+        and a recoverable buffer instead of the scrollback.
+    .DESCRIPTION
+        Streams `& $ConfigScript $Package *>&1` lazily: every line is appended to
+        $Buffer (so a failure can flush it) and shown via Write-UpdateStatus
+        (transient + -Verbose mirror). Genuine warnings are re-emitted via
+        Write-Warning so they survive past the auto-clearing pane. Captured errors
+        are kept in the buffer only -- they are NOT re-emitted as errors, so a
+        non-terminating ConfigScript error cannot trip a caller's
+        $ErrorActionPreference='Stop' and abort the package sweep. A terminating
+        throw propagates to the caller (which records the package Failed); the lines
+        captured before the throw remain in $Buffer.
+
+        Nothing is written to the success (object) stream, so the cmdlet's pipeline
+        output stays clean -- identical to the old `[void](... 2>$null)` contract.
+    .PARAMETER ConfigScript
+        The package's ConfigScript scriptblock.
+    .PARAMETER Package
+        The [Package] passed as the script's single argument.
+    .PARAMETER Buffer
+        A caller-owned list that receives each captured line (for failure flush/log).
+    .PARAMETER Activity
+        Progress activity label (e.g. 'Update-Package' or 'Install-Package').
+    .PARAMETER PercentComplete
+        Optional 0-100 progress value; omit (-1) when none applies.
+    #>
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)][scriptblock]$ConfigScript,
+        [Parameter(Mandatory)]$Package,
+        [Parameter(Mandatory)][AllowEmptyCollection()][System.Collections.Generic.List[string]]$Buffer,
+        [string]$Activity = 'Update-Package',
+        [int]$PercentComplete = -1
+    )
+
+    & $ConfigScript $Package *>&1 | ForEach-Object {
+        $record = $_
+        $line = ConvertTo-CapturedLine $record
+        if ($null -ne $line) {
+            [void]$Buffer.Add($line)
+            $statusArgs = @{ Status = $line; Activity = $Activity }
+            if ($PercentComplete -ge 0) { $statusArgs['PercentComplete'] = $PercentComplete }
+            Write-UpdateStatus @statusArgs
+        }
+        if ($record -is [System.Management.Automation.WarningRecord]) {
+            Write-Warning $record.Message
+        }
+    }
+}
+
+function Get-FailureLogFileName {
+    <#
+    .SYNOPSIS
+        Build the per-run failure-log file name.
+    .DESCRIPTION
+        Returns `ScoopBucket-<Verb>-Package-<yyyyMMdd-HHmmss>-failures.log`. The
+        timestamp (run start) keeps names sortable and collision-free.
+    .PARAMETER Verb
+        'Update' or 'Install' (reflecting the cmdlet that produced the failures).
+    .PARAMETER Timestamp
+        The run-start time used in the name. Defaults to now.
+    .OUTPUTS
+        System.String.
+    #>
+    [CmdletBinding()]
+    [OutputType([string])]
+    param(
+        [Parameter(Mandatory)][ValidateSet('Update', 'Install')][string]$Verb,
+        [datetime]$Timestamp = (Get-Date)
+    )
+    return "ScoopBucket-$Verb-Package-$($Timestamp.ToString('yyyyMMdd-HHmmss'))-failures.log"
+}
+
+function Get-FailureLogPath {
+    <#
+    .SYNOPSIS
+        Resolve the full path for the per-run failure log, preferring the current
+        directory and falling back when it is not writable.
+    .DESCRIPTION
+        Logging must never break a run. The preferred directory (the current
+        directory) is probed by writing and deleting a tiny test file; if that
+        fails (read-only location, permission denied), the fallback directory
+        ($env:TEMP) is used instead.
+    .PARAMETER FileName
+        The log file name (see Get-FailureLogFileName).
+    .PARAMETER PreferredDirectory
+        First-choice directory (typically the caller's current directory).
+    .PARAMETER FallbackDirectory
+        Used when PreferredDirectory is not writable.
+    .OUTPUTS
+        System.String -- the full path under whichever directory is writable.
+    #>
+    [CmdletBinding()]
+    [OutputType([string])]
+    param(
+        [Parameter(Mandatory)][string]$FileName,
+        [Parameter(Mandatory)][string]$PreferredDirectory,
+        [Parameter(Mandatory)][string]$FallbackDirectory
+    )
+
+    $dir = if (Test-DirectoryWritable -Path $PreferredDirectory) {
+        $PreferredDirectory
+    } else {
+        $FallbackDirectory
+    }
+    return (Join-Path $dir $FileName)
+}
+
+function Test-DirectoryWritable {
+    <#
+    .SYNOPSIS
+        Return $true when a tiny probe file can be created (and removed) in $Path.
+    .PARAMETER Path
+        Directory to probe.
+    .OUTPUTS
+        System.Boolean.
+    #>
+    [CmdletBinding()]
+    [OutputType([bool])]
+    param([Parameter(Mandatory)][string]$Path)
+
+    if (-not (Test-Path -LiteralPath $Path -PathType Container)) { return $false }
+    $probe = Join-Path $Path ".sb-write-probe-$([guid]::NewGuid().ToString('N')).tmp"
+    try {
+        [System.IO.File]::WriteAllText($probe, 'x')
+        Remove-Item -LiteralPath $probe -Force -ErrorAction SilentlyContinue
+        return $true
+    } catch {
+        return $false
+    }
+}
+
+function Write-FailureLog {
+    <#
+    .SYNOPSIS
+        Write the per-run failure log (run header + each failed package's full
+        captured output) as UTF-8 without a BOM.
+    .PARAMETER Path
+        Destination file (see Get-FailureLogPath).
+    .PARAMETER Verb
+        'Update' or 'Install'.
+    .PARAMETER Failures
+        One object per failed package with .Name, .Reason and .Output (the full
+        captured ConfigScript text).
+    .OUTPUTS
+        System.String -- the path written.
+    #>
+    [CmdletBinding()]
+    [OutputType([string])]
+    param(
+        [Parameter(Mandatory)][string]$Path,
+        [Parameter(Mandatory)][ValidateSet('Update', 'Install')][string]$Verb,
+        [Parameter(Mandatory)][object[]]$Failures
+    )
+
+    $nl = [Environment]::NewLine
+    $sb = New-Object System.Text.StringBuilder
+    [void]$sb.AppendLine("ScoopBucket $Verb-Package failure log")
+    [void]$sb.AppendLine("Generated: $((Get-Date).ToString('u')) (local $((Get-Date).ToString('s')))")
+    [void]$sb.AppendLine("Machine:   $env:COMPUTERNAME")
+    [void]$sb.AppendLine("Failures:  $($Failures.Count)")
+    [void]$sb.AppendLine(('=' * 72))
+
+    foreach ($f in $Failures) {
+        [void]$sb.AppendLine('')
+        [void]$sb.AppendLine("### $($f.Name)")
+        if ($f.Reason) { [void]$sb.AppendLine("Reason: $($f.Reason)") }
+        [void]$sb.AppendLine('--- captured output ---')
+        $out = if ($null -ne $f.Output) { [string]$f.Output } else { '' }
+        if ([string]::IsNullOrWhiteSpace($out)) {
+            [void]$sb.AppendLine('(no captured output)')
+        } else {
+            [void]$sb.AppendLine($out)
+        }
+    }
+
+    $utf8NoBom = New-Object System.Text.UTF8Encoding($false)
+    [System.IO.File]::WriteAllText($Path, ($sb.ToString() -replace "`r?`n", $nl), $utf8NoBom)
+    return $Path
+}

--- a/module/MarkMichaelis.ScoopBucket/Public/Invoke-PackageInstall.ps1
+++ b/module/MarkMichaelis.ScoopBucket/Public/Invoke-PackageInstall.ps1
@@ -114,6 +114,8 @@ function Invoke-PackageInstall {
     # deferred until after the loop so an interactive run renders a single
     # table; failures additionally go to the error stream at each failure site.
     $states = New-Object System.Collections.Generic.List[object]
+    $configFailures = New-Object System.Collections.Generic.List[object]
+    $runStart = Get-Date
     $isCi = [bool]$env:CI
 
     $addState = {
@@ -236,11 +238,20 @@ function Invoke-PackageInstall {
             if ($isWhatIf) {
                 Write-UpdateStatus -Activity 'Install-Package' "  [DryRun] ConfigScript ($($pkg.Name))"
             } else {
+                # Capture ConfigScript output into the transient channel + a buffer
+                # so success runs stay quiet and failures stay visible (#352).
+                $buf = New-Object System.Collections.Generic.List[string]
                 try {
-                    [void](& $pkg.ConfigScript $pkg 2>$null)
+                    Invoke-ConfigScriptCaptured -ConfigScript $pkg.ConfigScript -Package $pkg -Buffer $buf -Activity 'Install-Package'
                 } catch {
-                    $reason = "ConfigScript threw: $($_.Exception.Message)"
+                    $reason = "ConfigScript threw: $($_.Exception.Message)$(Get-CapturedOutputTail (($buf) -join [Environment]::NewLine))"
                     & $failPackage $pkg $reason
+                    Out-CapturedFailure -Name $pkg.Name -Lines $buf
+                    $configFailures.Add([pscustomobject]@{
+                            Name   = $pkg.Name
+                            Reason = "ConfigScript threw: $($_.Exception.Message)"
+                            Output = ($buf -join [Environment]::NewLine)
+                        })
                     continue
                 }
             }
@@ -281,6 +292,18 @@ function Invoke-PackageInstall {
     # Tear down the transient progress line before emitting results so the
     # two don't fight over the host's rendering.
     Write-UpdateStatus -Activity 'Install-Package' -Completed
+
+    # Persist a per-run failure log when any ConfigScript failed (#352).
+    if ($configFailures.Count -gt 0 -and -not $isWhatIf) {
+        try {
+            $logName = Get-FailureLogFileName -Verb 'Install' -Timestamp $runStart
+            $logPath = Get-FailureLogPath -FileName $logName -PreferredDirectory (Get-Location).Path -FallbackDirectory $env:TEMP
+            $written = Write-FailureLog -Path $logPath -Verb 'Install' -Failures $configFailures.ToArray()
+            Write-Host "Install-Package: wrote failure log to $written" -ForegroundColor Yellow
+        } catch {
+            Write-Warning "Install-Package: could not write failure log: $($_.Exception.Message)"
+        }
+    }
 
     # Emit one PackageResult per package on the success stream. The
     # format.ps1xml view renders Status as a colored glyph for interactive

--- a/module/MarkMichaelis.ScoopBucket/Public/Invoke-PackageUpdate.ps1
+++ b/module/MarkMichaelis.ScoopBucket/Public/Invoke-PackageUpdate.ps1
@@ -90,6 +90,8 @@ function Invoke-PackageUpdate {
     } else { @{} }
 
     $states = New-Object System.Collections.Generic.List[object]
+    $configFailures = New-Object System.Collections.Generic.List[object]
+    $runStart = Get-Date
     $total  = $ordered.Count
     $idx    = 0
     $isCi   = [bool]$env:CI
@@ -130,11 +132,24 @@ function Invoke-PackageUpdate {
             Write-UpdateStatus "  [WhatIf] ConfigScript ($($p.Name))"
             return $true
         }
+        # Capture the ConfigScript's underlying-tool output (npm/dotnet/Write-Host)
+        # into the transient channel + a recoverable buffer instead of letting it
+        # flood the scrollback (#352). On a throw we flush the buffer to the host so
+        # the cause stays visible, fold a tail into the Failed row, and retain the
+        # output for the per-run failure log.
+        $buf = New-Object System.Collections.Generic.List[string]
         try {
-            [void](& $p.ConfigScript $p 2>$null)
+            Invoke-ConfigScriptCaptured -ConfigScript $p.ConfigScript -Package $p -Buffer $buf -Activity 'Update-Package'
             return $true
         } catch {
-            & $failPackage $p "ConfigScript threw: $($_.Exception.Message)"
+            $reason = "ConfigScript threw: $($_.Exception.Message)$(Get-CapturedOutputTail (($buf) -join [Environment]::NewLine))"
+            & $failPackage $p $reason
+            Out-CapturedFailure -Name $p.Name -Lines $buf
+            $configFailures.Add([pscustomobject]@{
+                    Name   = $p.Name
+                    Reason = "ConfigScript threw: $($_.Exception.Message)"
+                    Output = ($buf -join [Environment]::NewLine)
+                })
             return $false
         }
     }
@@ -338,6 +353,19 @@ function Invoke-PackageUpdate {
     # Tear down the transient progress line before emitting results so the
     # two don't fight over the host's rendering.
     Write-UpdateStatus -Completed
+
+    # When any package's ConfigScript failed, persist its full captured output to a
+    # per-run log so the cause survives the transient pane (#352).
+    if ($configFailures.Count -gt 0 -and -not $isWhatIf) {
+        try {
+            $logName = Get-FailureLogFileName -Verb 'Update' -Timestamp $runStart
+            $logPath = Get-FailureLogPath -FileName $logName -PreferredDirectory (Get-Location).Path -FallbackDirectory $env:TEMP
+            $written = Write-FailureLog -Path $logPath -Verb 'Update' -Failures $configFailures.ToArray()
+            Write-Host "Update-Package: wrote failure log to $written" -ForegroundColor Yellow
+        } catch {
+            Write-Warning "Update-Package: could not write failure log: $($_.Exception.Message)"
+        }
+    }
 
     # Emit one PackageResult per package on the success stream. The
     # format.ps1xml view renders Status as a colored glyph for interactive


### PR DESCRIPTION
## Summary

`Install-Package` / `Update-Package` runs that invoke a package **ConfigScript**
(notably the AIAgents MCP installer) dumped a wall of npm/dotnet/Write-Host output
into the scrollback, burying the result table on otherwise-successful runs. Both
engines ran the script as `[void](& $pkg.ConfigScript $pkg 2>$null)` -- output
discarded, errors suppressed.

## Changes

- New `Private/ConfigScriptCapture.ps1`:
  - `Invoke-ConfigScriptCaptured` runs the script with `*>&1`, routes each line
    through the existing #276 transient `Write-UpdateStatus` channel + a
    recoverable buffer, re-emits genuine warnings, and keeps ConfigScript output
    off the object pipeline (clean `[PackageResult]` stream).
  - `Out-CapturedFailure` flushes a failed package's captured output to the host.
  - `Get-FailureLogFileName` / `Get-FailureLogPath` / `Write-FailureLog` write a
    per-run `ScoopBucket-<Verb>-Package-<yyyyMMdd-HHmmss>-failures.log` (cwd if
    writable, else `\$env:TEMP`), UTF-8 no BOM, containing each failed package's
    full captured output.
- Wired the helper into `Invoke-PackageUpdate` and `Invoke-PackageInstall`;
  failures flush the buffer, fold a tail into the Reason, and write the log.
- Switched `AIAgents.Mcp.ps1` npm/dotnet pipes from `Out-Host` to `Write-Host`
  (Out-Host bypasses every stream, so it was not capturable).

## Tests

- `Private/ConfigScriptCapture.Tests.ps1` -- capture without pipeline leak,
  warning re-emit, pre-throw lines retained, log-name format, cwd-not-writable
  fallback, UTF-8 no BOM.
- `UpdatePackage.Tests.ps1` -- result pipeline carries no captured line on
  success; a failing ConfigScript writes the per-run failure log to cwd.

Closes #352