### PR TITLE
feat(packages): host-adaptive multiline live-output pane (#354)

### DIFF
--- a/module/MarkMichaelis.ScoopBucket/Private/ConfigScriptCapture.Tests.ps1
+++ b/module/MarkMichaelis.ScoopBucket/Private/ConfigScriptCapture.Tests.ps1
@@ -24,7 +24,7 @@ BeforeAll {
     $script:mod = Get-Module MarkMichaelis.ScoopBucket
 }
 
-Describe 'Invoke-ConfigScriptCaptured' {
+Describe 'Invoke-ConfigScriptCaptured' -Tag 'Light','Module' {
     It 'captures Write-Host and native-style stdout into the buffer without polluting the success pipeline' {
         $buf = New-Object System.Collections.Generic.List[string]
         $sb = { param($p) Write-Host 'npm: added 3 packages'; Write-Output 'tool-stdout-line' }
@@ -70,7 +70,7 @@ Describe 'Invoke-ConfigScriptCaptured' {
     }
 }
 
-Describe 'ConvertTo-CapturedLine' {
+Describe 'ConvertTo-CapturedLine' -Tag 'Light','Module' {
     It 'renders a warning record as its message text' {
         $rec = [System.Management.Automation.WarningRecord]::new('hello warn')
         $line = & $script:mod { param($r) ConvertTo-CapturedLine $r } $rec
@@ -83,7 +83,7 @@ Describe 'ConvertTo-CapturedLine' {
     }
 }
 
-Describe 'Get-FailureLogFileName' {
+Describe 'Get-FailureLogFileName' -Tag 'Light','Module' {
     It 'produces the sortable ScoopBucket-<Verb>-Package-<timestamp>-failures.log name' {
         $ts = [datetime]'2026-01-02T03:04:05'
         $name = & $script:mod { param($t) Get-FailureLogFileName -Verb 'Update' -Timestamp $t } $ts
@@ -97,7 +97,7 @@ Describe 'Get-FailureLogFileName' {
     }
 }
 
-Describe 'Get-FailureLogPath' {
+Describe 'Get-FailureLogPath' -Tag 'Light','Module' {
     It 'uses the preferred directory when it is writable' {
         $tmp = Join-Path ([System.IO.Path]::GetTempPath()) ("sb-pref-" + [guid]::NewGuid().ToString('N'))
         New-Item -ItemType Directory -Path $tmp -Force | Out-Null
@@ -120,7 +120,7 @@ Describe 'Get-FailureLogPath' {
     }
 }
 
-Describe 'Write-FailureLog' {
+Describe 'Write-FailureLog' -Tag 'Light','Module' {
     It 'writes a UTF-8 (no BOM) log containing each failed package full output' {
         $dir = Join-Path ([System.IO.Path]::GetTempPath()) ("sb-log-" + [guid]::NewGuid().ToString('N'))
         New-Item -ItemType Directory -Path $dir -Force | Out-Null

--- a/module/MarkMichaelis.ScoopBucket/Private/LiveOutputPane.Tests.ps1
+++ b/module/MarkMichaelis.ScoopBucket/Private/LiveOutputPane.Tests.ps1
@@ -1,0 +1,134 @@
+<#
+.SYNOPSIS
+    Light-suite Pester coverage for the host-adaptive live-output pane helpers
+    (#354).
+
+.DESCRIPTION
+    The multiline pane is the portability risk, so its decision logic and frame
+    strings are pure and pinned here:
+
+      * Resolve-LiveOutputMode resolves Multiline only for a genuinely interactive,
+        VT-capable, non-VS-Code, non-CI, non-redirected, non-ISE console; every
+        other signature is Single, and a silenced progress preference is Off.
+      * Get-LivePaneFrame / Get-LivePaneClear emit the exact cursor-move + clear
+        sequences and account for the drawn line count.
+      * Write-LivePane mirrors to verbose in every mode and maintains the pane's
+        line-count state across calls / teardown.
+#>
+
+BeforeAll {
+    $script:moduleManifest = Resolve-Path (Join-Path $PSScriptRoot '..\MarkMichaelis.ScoopBucket.psd1')
+    Import-Module $script:moduleManifest -Force
+    $script:mod = Get-Module MarkMichaelis.ScoopBucket
+    $script:ESC = [char]27
+}
+
+Describe 'Resolve-LiveOutputMode' {
+    It 'returns Off when the progress preference is silenced' {
+        $m = & $script:mod {
+            Resolve-LiveOutputMode -ProgressPreferenceValue 'SilentlyContinue' `
+                -SupportsVirtualTerminal $true -OutputRedirected $false
+        }
+        $m | Should -Be 'Off'
+    }
+
+    It 'returns Single under CI' {
+        $m = & $script:mod {
+            Resolve-LiveOutputMode -Ci 'true' -SupportsVirtualTerminal $true -OutputRedirected $false -ProgressPreferenceValue 'Continue'
+        }
+        $m | Should -Be 'Single'
+    }
+
+    It 'returns Single when output is redirected' {
+        $m = & $script:mod {
+            Resolve-LiveOutputMode -Ci '' -OutputRedirected $true -SupportsVirtualTerminal $true -ProgressPreferenceValue 'Continue'
+        }
+        $m | Should -Be 'Single'
+    }
+
+    It 'returns Single inside the VS Code integrated terminal' {
+        $m = & $script:mod {
+            Resolve-LiveOutputMode -TermProgram 'vscode' -Ci '' -OutputRedirected $false -SupportsVirtualTerminal $true -ProgressPreferenceValue 'Continue'
+        }
+        $m | Should -Be 'Single'
+    }
+
+    It 'returns Single in the ISE host' {
+        $m = & $script:mod {
+            Resolve-LiveOutputMode -HostName 'Windows PowerShell ISE Host' -Ci '' -OutputRedirected $false -SupportsVirtualTerminal $true -ProgressPreferenceValue 'Continue'
+        }
+        $m | Should -Be 'Single'
+    }
+
+    It 'returns Single when the host lacks virtual-terminal support' {
+        $m = & $script:mod {
+            Resolve-LiveOutputMode -Ci '' -OutputRedirected $false -SupportsVirtualTerminal $false -ProgressPreferenceValue 'Continue'
+        }
+        $m | Should -Be 'Single'
+    }
+
+    It 'returns Multiline only for a capable interactive console' {
+        $m = & $script:mod {
+            Resolve-LiveOutputMode -TermProgram 'WindowsTerminal' -Ci '' -OutputRedirected $false `
+                -HostName 'ConsoleHost' -SupportsVirtualTerminal $true -ProgressPreferenceValue 'Continue'
+        }
+        $m | Should -Be 'Multiline'
+    }
+}
+
+Describe 'Get-LivePaneFrame' {
+    It 'draws all lines and reports the count on the first paint (no cursor move)' {
+        $f = & $script:mod { Get-LivePaneFrame -Lines @('a', 'b') -PreviousLineCount 0 }
+        $f.Text | Should -Be "a`nb"
+        $f.LineCount | Should -Be 2
+    }
+
+    It 'prefixes a cursor-up + clear-to-end sequence when repainting over a prior frame' {
+        $f = & $script:mod { Get-LivePaneFrame -Lines @('a', 'b', 'c') -PreviousLineCount 3 }
+        # 3 lines drawn => move up 2 to the top of the block, then clear to end.
+        $expectedReset = "$($script:ESC)[2F$($script:ESC)[0J"
+        $f.Text | Should -Be ($expectedReset + "a`nb`nc")
+        $f.LineCount | Should -Be 3
+    }
+
+    It 'caps the pane to MaxLines (keeps the most recent lines)' {
+        $f = & $script:mod { Get-LivePaneFrame -Lines @('1', '2', '3', '4', '5', '6') -PreviousLineCount 0 -MaxLines 3 }
+        $f.Text | Should -Be "4`n5`n6"
+        $f.LineCount | Should -Be 3
+    }
+}
+
+Describe 'Get-LivePaneClear' {
+    It 'returns an empty string when nothing was drawn' {
+        (& $script:mod { Get-LivePaneClear -PreviousLineCount 0 }) | Should -Be ''
+    }
+
+    It 'moves to the top of the block and clears to the end of the display' {
+        $c = & $script:mod { Get-LivePaneClear -PreviousLineCount 4 }
+        $c | Should -Be "$($script:ESC)[3F$($script:ESC)[0J"
+    }
+}
+
+Describe 'Write-LivePane' {
+    It 'mirrors the status to the verbose stream even when the visual mode is Off' {
+        $v = & $script:mod {
+            $VerbosePreference = 'Continue'
+            Write-LivePane -Status 'hello-pane' -Mode 'Off'
+        } 4>&1
+        @($v | Where-Object { "$_" -match 'hello-pane' }) | Should -Not -BeNullOrEmpty
+    }
+
+    It 'tracks the drawn line count across Multiline calls and resets on completion' {
+        $counts = & $script:mod {
+            $script:LivePaneLineCount = 0
+            $script:LivePaneBuffer = $null
+            Write-LivePane -Status 'one' -Mode 'Multiline'
+            Write-LivePane -Status 'two' -Mode 'Multiline'
+            $after = $script:LivePaneLineCount
+            Write-LivePane -Completed -Mode 'Multiline'
+            [pscustomobject]@{ After = $after; Reset = $script:LivePaneLineCount }
+        } 6>$null
+        $counts.After | Should -Be 2
+        $counts.Reset | Should -Be 0
+    }
+}

--- a/module/MarkMichaelis.ScoopBucket/Private/LiveOutputPane.Tests.ps1
+++ b/module/MarkMichaelis.ScoopBucket/Private/LiveOutputPane.Tests.ps1
@@ -23,7 +23,7 @@ BeforeAll {
     $script:ESC = [char]27
 }
 
-Describe 'Resolve-LiveOutputMode' {
+Describe 'Resolve-LiveOutputMode' -Tag 'Light','Module' {
     It 'returns Off when the progress preference is silenced' {
         $m = & $script:mod {
             Resolve-LiveOutputMode -ProgressPreferenceValue 'SilentlyContinue' `
@@ -76,7 +76,7 @@ Describe 'Resolve-LiveOutputMode' {
     }
 }
 
-Describe 'Get-LivePaneFrame' {
+Describe 'Get-LivePaneFrame' -Tag 'Light','Module' {
     It 'draws all lines and reports the count on the first paint (no cursor move)' {
         $f = & $script:mod { Get-LivePaneFrame -Lines @('a', 'b') -PreviousLineCount 0 }
         $f.Text | Should -Be "a`nb"
@@ -98,7 +98,7 @@ Describe 'Get-LivePaneFrame' {
     }
 }
 
-Describe 'Get-LivePaneClear' {
+Describe 'Get-LivePaneClear' -Tag 'Light','Module' {
     It 'returns an empty string when nothing was drawn' {
         (& $script:mod { Get-LivePaneClear -PreviousLineCount 0 }) | Should -Be ''
     }
@@ -109,7 +109,7 @@ Describe 'Get-LivePaneClear' {
     }
 }
 
-Describe 'Write-LivePane' {
+Describe 'Write-LivePane' -Tag 'Light','Module' {
     It 'mirrors the status to the verbose stream even when the visual mode is Off' {
         $v = & $script:mod {
             $VerbosePreference = 'Continue'

--- a/module/MarkMichaelis.ScoopBucket/Private/LiveOutputPane.ps1
+++ b/module/MarkMichaelis.ScoopBucket/Private/LiveOutputPane.ps1
@@ -1,0 +1,255 @@
+# Host-adaptive transient "live output" pane for the package commands (#354).
+#
+# Thrust A (#352) routed package ConfigScript output through Write-UpdateStatus,
+# which renders a single transient line via Write-Progress. This adds a multiline
+# pane that shows a rolling tail of the most recent live-output lines and clears on
+# completion -- on hosts that can repaint with ANSI cursor moves. Everywhere else it
+# degrades to the existing single-line Write-Progress region, or (when progress is
+# silenced) to a verbose-only mirror.
+#
+# All host-detection and frame-building logic is pure (returns a mode enum / strings)
+# so it is fully unit-testable without a live console. Only Write-LivePane performs
+# the imperative cursor writes, and it is gated by Resolve-LiveOutputMode -- when in
+# any doubt the mode resolves to Single, never Multiline.
+
+function Resolve-LiveOutputMode {
+    <#
+    .SYNOPSIS
+        Decide how the live-output pane should render on the current host.
+    .DESCRIPTION
+        Returns one of 'Multiline', 'Single', or 'Off' from host facts. Multiline is
+        chosen only for a genuinely interactive, VT-capable console that is not VS
+        Code, not CI, not redirected, and not the ISE. Any uncertainty resolves to
+        the safe single-line region; a silenced progress preference resolves to Off
+        (verbose-only). All facts are parameters (defaulted from the environment) so
+        every host signature can be unit-tested deterministically.
+    .PARAMETER TermProgram
+        Value of $env:TERM_PROGRAM (e.g. 'vscode').
+    .PARAMETER Ci
+        Value of $env:CI; any non-empty value forces Single.
+    .PARAMETER OutputRedirected
+        Whether stdout is redirected ([Console]::IsOutputRedirected). Resolved live
+        when not supplied.
+    .PARAMETER HostName
+        $Host.Name; an ISE host forces Single.
+    .PARAMETER SupportsVirtualTerminal
+        Whether the host UI supports virtual-terminal sequences. Resolved live when
+        not supplied.
+    .PARAMETER ProgressPreferenceValue
+        String form of $ProgressPreference; 'SilentlyContinue' forces Off.
+    .OUTPUTS
+        System.String -- 'Multiline' | 'Single' | 'Off'.
+    #>
+    [CmdletBinding()]
+    [OutputType([string])]
+    param(
+        [string]$TermProgram = $env:TERM_PROGRAM,
+        [string]$Ci = $env:CI,
+        [Nullable[bool]]$OutputRedirected,
+        [string]$HostName = $Host.Name,
+        [Nullable[bool]]$SupportsVirtualTerminal,
+        [string]$ProgressPreferenceValue = "$ProgressPreference"
+    )
+
+    if ($null -eq $OutputRedirected) {
+        try { $OutputRedirected = [Console]::IsOutputRedirected } catch { $OutputRedirected = $false }
+    }
+    if ($null -eq $SupportsVirtualTerminal) {
+        try { $SupportsVirtualTerminal = [bool]$Host.UI.SupportsVirtualTerminal } catch { $SupportsVirtualTerminal = $false }
+    }
+
+    if ($ProgressPreferenceValue -eq 'SilentlyContinue') { return 'Off' }
+    if (-not [string]::IsNullOrEmpty($Ci))                { return 'Single' }
+    if ($OutputRedirected)                                { return 'Single' }
+    if ($TermProgram -eq 'vscode')                        { return 'Single' }
+    if ($HostName -like '*ISE*')                          { return 'Single' }
+    if (-not $SupportsVirtualTerminal)                    { return 'Single' }
+    return 'Multiline'
+}
+
+function Get-LivePaneFrame {
+    <#
+    .SYNOPSIS
+        Build the ANSI repaint string for the multiline pane and report how many
+        lines it now occupies.
+    .DESCRIPTION
+        Shows the last MaxLines of the supplied buffer. When a previous frame is on
+        screen (PreviousLineCount > 0), the returned text first moves the cursor to
+        the top of that block and clears to the end of the display, then writes the
+        current tail (lines joined by newline, no trailing newline -- the cursor is
+        left on the last line so the next frame's PreviousLineCount is the tail
+        count). Pure: returns the text + line count, writes nothing.
+    .PARAMETER Lines
+        The full rolling buffer; only the last MaxLines are drawn.
+    .PARAMETER PreviousLineCount
+        Lines drawn by the previous frame (0 for the first paint).
+    .PARAMETER MaxLines
+        Maximum pane height.
+    .OUTPUTS
+        PSCustomObject with Text (string) and LineCount (int).
+    #>
+    [CmdletBinding()]
+    [OutputType([pscustomobject])]
+    param(
+        [string[]]$Lines = @(),
+        [int]$PreviousLineCount = 0,
+        [ValidateRange(1, 100)][int]$MaxLines = 5
+    )
+
+    $esc = [char]27
+    $tail = @($Lines | Where-Object { $null -ne $_ } | Select-Object -Last $MaxLines)
+
+    $reset = ''
+    if ($PreviousLineCount -gt 0) {
+        $up = [Math]::Max(0, $PreviousLineCount - 1)
+        $reset = "$esc[${up}F$esc[0J"
+    }
+
+    return [pscustomobject]@{
+        Text      = $reset + ($tail -join "`n")
+        LineCount = $tail.Count
+    }
+}
+
+function Get-LivePaneClear {
+    <#
+    .SYNOPSIS
+        Build the ANSI string that erases the multiline pane on completion.
+    .DESCRIPTION
+        Moves the cursor to the top of the drawn block and clears to the end of the
+        display, leaving the cursor where the pane began so the final table prints in
+        its place. Returns '' when nothing was drawn. Pure.
+    .PARAMETER PreviousLineCount
+        Lines currently drawn by the pane.
+    .OUTPUTS
+        System.String.
+    #>
+    [CmdletBinding()]
+    [OutputType([string])]
+    param([int]$PreviousLineCount = 0)
+
+    if ($PreviousLineCount -le 0) { return '' }
+    $esc = [char]27
+    $up = [Math]::Max(0, $PreviousLineCount - 1)
+    return "$esc[${up}F$esc[0J"
+}
+
+function Write-StatusProgress {
+    <#
+    .SYNOPSIS
+        Render a single transient status line via Write-Progress (the Single-mode
+        renderer extracted from the original #276 Write-UpdateStatus body).
+    .PARAMETER Status
+        Status text; omit with -Completed to tear the line down.
+    .PARAMETER Activity
+        Progress activity label.
+    .PARAMETER Id
+        Progress record id.
+    .PARAMETER ParentId
+        Parent progress record id (>= 0 to set).
+    .PARAMETER PercentComplete
+        0-100; omit (-1) when none applies.
+    .PARAMETER Completed
+        Clear the progress line.
+    #>
+    [CmdletBinding()]
+    param(
+        [Parameter(Position = 0)][string]$Status,
+        [string]$Activity = 'Update-Package',
+        [int]$Id = 1,
+        [int]$ParentId = -1,
+        [int]$PercentComplete = -1,
+        [switch]$Completed
+    )
+
+    if ($Completed) {
+        Write-Progress -Activity $Activity -Id $Id -Completed
+        return
+    }
+    if (-not $Status) { return }
+
+    $progressArgs = @{ Activity = $Activity; Status = $Status; Id = $Id }
+    if ($ParentId -ge 0)        { $progressArgs['ParentId']        = $ParentId }
+    if ($PercentComplete -ge 0) { $progressArgs['PercentComplete'] = [Math]::Min(100, [Math]::Max(0, $PercentComplete)) }
+    Write-Progress @progressArgs
+}
+
+function Write-LivePane {
+    <#
+    .SYNOPSIS
+        Render a live-output status line through the host-appropriate renderer and
+        keep the module-scoped multiline pane state.
+    .DESCRIPTION
+        Mirrors every status to Write-Verbose (recoverable in all modes), then:
+          * Multiline -- append to the rolling buffer and repaint the ANSI pane;
+          * Single    -- delegate to Write-StatusProgress (Write-Progress region);
+          * Off       -- verbose-only.
+        -Completed tears the renderer down (erase the multiline pane / clear the
+        progress line) and resets the pane state.
+    .PARAMETER Status
+        The status text.
+    .PARAMETER Activity
+        Progress / pane activity label.
+    .PARAMETER Id
+        Progress record id (Single mode).
+    .PARAMETER ParentId
+        Parent progress record id (Single mode).
+    .PARAMETER PercentComplete
+        0-100 (Single mode); omit (-1) when none applies.
+    .PARAMETER MaxLines
+        Multiline pane height.
+    .PARAMETER Completed
+        Tear the renderer down and reset pane state.
+    .PARAMETER Mode
+        Force a renderer mode (testing/override); defaults to Resolve-LiveOutputMode.
+    #>
+    [CmdletBinding()]
+    param(
+        [Parameter(Position = 0)][string]$Status,
+        [string]$Activity = 'Update-Package',
+        [int]$Id = 1,
+        [int]$ParentId = -1,
+        [int]$PercentComplete = -1,
+        [ValidateRange(1, 100)][int]$MaxLines = 5,
+        [switch]$Completed,
+        [ValidateSet('Multiline', 'Single', 'Off')][string]$Mode
+    )
+
+    if (-not $Mode) { $Mode = Resolve-LiveOutputMode }
+
+    if ($Completed) {
+        if ($Mode -eq 'Multiline') {
+            if ($script:LivePaneLineCount -gt 0) {
+                [Console]::Out.Write((Get-LivePaneClear -PreviousLineCount $script:LivePaneLineCount))
+            }
+        } else {
+            Write-StatusProgress -Activity $Activity -Id $Id -Completed
+        }
+        $script:LivePaneLineCount = 0
+        if ($script:LivePaneBuffer) { $script:LivePaneBuffer.Clear() }
+        return
+    }
+
+    if (-not $Status) { return }
+
+    Write-Verbose $Status
+
+    switch ($Mode) {
+        'Off' { return }
+        'Single' {
+            $progressArgs = @{ Status = $Status; Activity = $Activity; Id = $Id }
+            if ($ParentId -ge 0)        { $progressArgs['ParentId']        = $ParentId }
+            if ($PercentComplete -ge 0) { $progressArgs['PercentComplete'] = $PercentComplete }
+            Write-StatusProgress @progressArgs
+        }
+        'Multiline' {
+            if (-not $script:LivePaneBuffer) {
+                $script:LivePaneBuffer = New-Object System.Collections.Generic.List[string]
+            }
+            [void]$script:LivePaneBuffer.Add($Status)
+            $frame = Get-LivePaneFrame -Lines $script:LivePaneBuffer -PreviousLineCount $script:LivePaneLineCount -MaxLines $MaxLines
+            [Console]::Out.Write($frame.Text)
+            $script:LivePaneLineCount = $frame.LineCount
+        }
+    }
+}

--- a/module/MarkMichaelis.ScoopBucket/Private/Write-UpdateStatus.ps1
+++ b/module/MarkMichaelis.ScoopBucket/Private/Write-UpdateStatus.ps1
@@ -36,26 +36,19 @@ function Write-UpdateStatus {
         [switch]$Completed
     )
 
+    # Forward to the host-adaptive pane (#354). Write-LivePane owns the verbose
+    # mirror and, per Resolve-LiveOutputMode, renders either the multiline ANSI pane
+    # (interactive VT console) or the original single-line Write-Progress region
+    # (CI / redirected / VS Code / no-VT) or verbose-only (progress silenced). In CI
+    # and under redirection the mode is always Single, so the #276 behaviour --
+    # transient Write-Progress plus a -Verbose mirror -- is preserved exactly.
+    $forward = @{ Activity = $Activity; Id = $Id; ParentId = $ParentId; PercentComplete = $PercentComplete }
     if ($Completed) {
-        Write-Progress -Activity $Activity -Id $Id -Completed
+        Write-LivePane @forward -Completed
         return
     }
-
-    if (-not $Status) { return }
-
-    # Persistent-on-demand copy: hidden unless the caller passed -Verbose, in
-    # which case it shows inline and is captured by 4>. $VerbosePreference is
-    # inherited from the calling cmdlet's scope, so engines invoked without an
-    # explicit -Verbose still honour a -Verbose on Update-Package.
-    Write-Verbose $Status
-
-    # Transient live copy: never captured by redirection, auto-clears on
-    # completion. Safe (no-op) on non-interactive hosts and honours a caller
-    # who set $ProgressPreference = 'SilentlyContinue'.
-    $progressArgs = @{ Activity = $Activity; Status = $Status; Id = $Id }
-    if ($ParentId -ge 0)        { $progressArgs['ParentId']        = $ParentId }
-    if ($PercentComplete -ge 0) { $progressArgs['PercentComplete'] = [Math]::Min(100, [Math]::Max(0, $PercentComplete)) }
-    Write-Progress @progressArgs
+    if ($Status) { $forward['Status'] = $Status }
+    Write-LivePane @forward
 }
 
 function Get-CapturedOutputTail {


### PR DESCRIPTION
## Summary

Thrust B of the package live-output work (follows #352). Adds the host-adaptive
**multiline** transient pane the user asked for: a rolling tail of recent
underlying-tool output that clears on success, degrading cleanly to the existing
single-line region or to verbose-only where a repainting pane is unsafe.

## Changes

New `Private/LiveOutputPane.ps1`:

- `Resolve-LiveOutputMode` (pure) -> `Multiline | Single | Off` from host facts
  (`TERM_PROGRAM`, `CI`, `[Console]::IsOutputRedirected`, `Host.Name`,
  virtual-terminal support, `ProgressPreference`). Any uncertainty -> `Single`;
  silenced progress -> `Off`.
- `Get-LivePaneFrame` / `Get-LivePaneClear` (pure) -- exact cursor-up +
  clear-to-end ANSI sequences and drawn-line accounting.
- `Write-StatusProgress` -- the original #276 single-line `Write-Progress`
  renderer, extracted unchanged.
- `Write-LivePane` -- thin dispatcher (Multiline ANSI pane / Single progress /
  Off verbose-only); mirrors every status to `-Verbose` in all modes and keeps the
  pane line-count state.

`Write-UpdateStatus` becomes a thin forwarder to `Write-LivePane` so every
existing caller (engine steps + the #352 ConfigScript capture) shares one pane.

## Safety

Under CI and redirected output the mode is always `Single`, so the #276 behaviour
(transient `Write-Progress` + `-Verbose` mirror) is preserved exactly --
`Multiline` only ever engages on a genuinely interactive VT console.

## Tests

`Private/LiveOutputPane.Tests.ps1` -- each host signature -> mode; exact frame /
clear escape sequences and line counts; `Write-LivePane` verbose mirror in Off
mode and line-count state across Multiline calls + teardown.

Closes #354