### PR TITLE
fix(packages): make multiline live pane opt-in and wrap-safe

### DIFF
--- a/module/MarkMichaelis.ScoopBucket/Private/LiveOutputPane.Tests.ps1
+++ b/module/MarkMichaelis.ScoopBucket/Private/LiveOutputPane.Tests.ps1
@@ -7,11 +7,14 @@
     The multiline pane is the portability risk, so its decision logic and frame
     strings are pure and pinned here:
 
-      * Resolve-LiveOutputMode resolves Multiline only for a genuinely interactive,
-        VT-capable, non-VS-Code, non-CI, non-redirected, non-ISE console; every
-        other signature is Single, and a silenced progress preference is Off.
+      * Resolve-LiveOutputMode defaults to the safe single-line Write-Progress
+        region for every interactive console, and only resolves Multiline when
+        $env:SCOOPBUCKET_LIVE_PANE explicitly opts in AND the host is a capable,
+        VT-capable, non-VS-Code, non-CI, non-redirected, non-ISE console; a silenced
+        progress preference is Off.
       * Get-LivePaneFrame / Get-LivePaneClear emit the exact cursor-move + clear
-        sequences and account for the drawn line count.
+        sequences, split embedded newlines, truncate to a supplied width, and
+        account for the drawn line count.
       * Write-LivePane mirrors to verbose in every mode and maintains the pane's
         line-count state across calls / teardown.
 #>
@@ -67,12 +70,30 @@ Describe 'Resolve-LiveOutputMode' -Tag 'Light','Module' {
         $m | Should -Be 'Single'
     }
 
-    It 'returns Multiline only for a capable interactive console' {
+    It 'returns Single for a capable interactive console when the pane is not opted in' {
         $m = & $script:mod {
             Resolve-LiveOutputMode -TermProgram 'WindowsTerminal' -Ci '' -OutputRedirected $false `
-                -HostName 'ConsoleHost' -SupportsVirtualTerminal $true -ProgressPreferenceValue 'Continue'
+                -HostName 'ConsoleHost' -SupportsVirtualTerminal $true -ProgressPreferenceValue 'Continue' `
+                -LivePaneOptIn ''
+        }
+        $m | Should -Be 'Single'
+    }
+
+    It 'returns Multiline only for a capable interactive console that opts in' {
+        $m = & $script:mod {
+            Resolve-LiveOutputMode -TermProgram 'WindowsTerminal' -Ci '' -OutputRedirected $false `
+                -HostName 'ConsoleHost' -SupportsVirtualTerminal $true -ProgressPreferenceValue 'Continue' `
+                -LivePaneOptIn 'multiline'
         }
         $m | Should -Be 'Multiline'
+    }
+
+    It 'keeps Single even when opted in if the host is not capable (redirected)' {
+        $m = & $script:mod {
+            Resolve-LiveOutputMode -Ci '' -OutputRedirected $true -SupportsVirtualTerminal $true `
+                -ProgressPreferenceValue 'Continue' -LivePaneOptIn 'true'
+        }
+        $m | Should -Be 'Single'
     }
 }
 
@@ -95,6 +116,20 @@ Describe 'Get-LivePaneFrame' -Tag 'Light','Module' {
         $f = & $script:mod { Get-LivePaneFrame -Lines @('1', '2', '3', '4', '5', '6') -PreviousLineCount 0 -MaxLines 3 }
         $f.Text | Should -Be "4`n5`n6"
         $f.LineCount | Should -Be 3
+    }
+
+    It 'splits an embedded-newline record into separate physical rows' {
+        # A single captured record carrying its own newlines must count as the rows
+        # it actually occupies, or the next frame''s cursor-up math desyncs (#356).
+        $f = & $script:mod { Get-LivePaneFrame -Lines @("a`nb`nc") -PreviousLineCount 0 }
+        $f.Text | Should -Be "a`nb`nc"
+        $f.LineCount | Should -Be 3
+    }
+
+    It 'truncates each drawn row to Width so it cannot wrap' {
+        $f = & $script:mod { Get-LivePaneFrame -Lines @('abcdefghij') -PreviousLineCount 0 -Width 4 }
+        $f.Text | Should -Be 'abcd'
+        $f.LineCount | Should -Be 1
     }
 }
 

--- a/module/MarkMichaelis.ScoopBucket/Private/LiveOutputPane.ps1
+++ b/module/MarkMichaelis.ScoopBucket/Private/LiveOutputPane.ps1
@@ -3,9 +3,10 @@
 # Thrust A (#352) routed package ConfigScript output through Write-UpdateStatus,
 # which renders a single transient line via Write-Progress. This adds a multiline
 # pane that shows a rolling tail of the most recent live-output lines and clears on
-# completion -- on hosts that can repaint with ANSI cursor moves. Everywhere else it
-# degrades to the existing single-line Write-Progress region, or (when progress is
-# silenced) to a verbose-only mirror.
+# completion -- but only when explicitly opted in via $env:SCOOPBUCKET_LIVE_PANE
+# (#356). By default, and everywhere the host is not a capable interactive VT
+# console, it degrades to the robust single-line Write-Progress region (or, when
+# progress is silenced, to a verbose-only mirror).
 #
 # All host-detection and frame-building logic is pure (returns a mode enum / strings)
 # so it is fully unit-testable without a live console. Only Write-LivePane performs
@@ -17,12 +18,16 @@ function Resolve-LiveOutputMode {
     .SYNOPSIS
         Decide how the live-output pane should render on the current host.
     .DESCRIPTION
-        Returns one of 'Multiline', 'Single', or 'Off' from host facts. Multiline is
-        chosen only for a genuinely interactive, VT-capable console that is not VS
-        Code, not CI, not redirected, and not the ISE. Any uncertainty resolves to
-        the safe single-line region; a silenced progress preference resolves to Off
-        (verbose-only). All facts are parameters (defaulted from the environment) so
-        every host signature can be unit-tested deterministically.
+        Returns one of 'Multiline', 'Single', or 'Off' from host facts. The
+        single-line Write-Progress region is the DEFAULT for every interactive
+        console because it is robust everywhere. The multiline ANSI pane is a
+        portability risk (its cursor-repaint math is corrupted by line wrapping and
+        embedded newlines on real terminals -- see #356), so it is strictly OPT-IN:
+        chosen only when $env:SCOOPBUCKET_LIVE_PANE explicitly requests it AND the
+        host is a genuinely interactive, VT-capable, non-VS-Code, non-CI,
+        non-redirected, non-ISE console. A silenced progress preference resolves to
+        Off (verbose-only). All facts are parameters (defaulted from the environment)
+        so every host signature can be unit-tested deterministically.
     .PARAMETER TermProgram
         Value of $env:TERM_PROGRAM (e.g. 'vscode').
     .PARAMETER Ci
@@ -37,6 +42,10 @@ function Resolve-LiveOutputMode {
         not supplied.
     .PARAMETER ProgressPreferenceValue
         String form of $ProgressPreference; 'SilentlyContinue' forces Off.
+    .PARAMETER LivePaneOptIn
+        Value of $env:SCOOPBUCKET_LIVE_PANE. The multiline pane is only ever selected
+        when this opts in (1/true/yes/on/multi/multiline, case-insensitive); any
+        other value keeps the safe Single region.
     .OUTPUTS
         System.String -- 'Multiline' | 'Single' | 'Off'.
     #>
@@ -48,7 +57,8 @@ function Resolve-LiveOutputMode {
         [Nullable[bool]]$OutputRedirected,
         [string]$HostName = $Host.Name,
         [Nullable[bool]]$SupportsVirtualTerminal,
-        [string]$ProgressPreferenceValue = "$ProgressPreference"
+        [string]$ProgressPreferenceValue = "$ProgressPreference",
+        [string]$LivePaneOptIn = $env:SCOOPBUCKET_LIVE_PANE
     )
 
     if ($null -eq $OutputRedirected) {
@@ -59,6 +69,11 @@ function Resolve-LiveOutputMode {
     }
 
     if ($ProgressPreferenceValue -eq 'SilentlyContinue') { return 'Off' }
+
+    # Multiline is strictly opt-in (#356): without an explicit request, the robust
+    # single-line region is always used, even on a fully capable console.
+    if ($LivePaneOptIn -notmatch '^\s*(?i:1|true|yes|on|multi|multiline)\s*$') { return 'Single' }
+
     if (-not [string]::IsNullOrEmpty($Ci))                { return 'Single' }
     if ($OutputRedirected)                                { return 'Single' }
     if ($TermProgram -eq 'vscode')                        { return 'Single' }
@@ -73,18 +88,27 @@ function Get-LivePaneFrame {
         Build the ANSI repaint string for the multiline pane and report how many
         lines it now occupies.
     .DESCRIPTION
-        Shows the last MaxLines of the supplied buffer. When a previous frame is on
+        Shows the last MaxLines of the supplied buffer. Each incoming entry is first
+        split on embedded newlines so one physical row maps to exactly one drawn line
+        (npm/dotnet emit multi-line records), and -- when Width > 0 -- each row is
+        truncated to Width so it can never wrap. Both are required for the reported
+        LineCount to equal the physical rows drawn; otherwise the next frame's
+        cursor-up math overwrites the wrong rows (#356). When a previous frame is on
         screen (PreviousLineCount > 0), the returned text first moves the cursor to
         the top of that block and clears to the end of the display, then writes the
         current tail (lines joined by newline, no trailing newline -- the cursor is
         left on the last line so the next frame's PreviousLineCount is the tail
         count). Pure: returns the text + line count, writes nothing.
     .PARAMETER Lines
-        The full rolling buffer; only the last MaxLines are drawn.
+        The full rolling buffer; only the last MaxLines (after newline-splitting) are
+        drawn.
     .PARAMETER PreviousLineCount
         Lines drawn by the previous frame (0 for the first paint).
     .PARAMETER MaxLines
         Maximum pane height.
+    .PARAMETER Width
+        Maximum drawn width per line; 0 (default) disables truncation. Lines longer
+        than Width are clipped so they occupy a single physical row.
     .OUTPUTS
         PSCustomObject with Text (string) and LineCount (int).
     #>
@@ -93,11 +117,23 @@ function Get-LivePaneFrame {
     param(
         [string[]]$Lines = @(),
         [int]$PreviousLineCount = 0,
-        [ValidateRange(1, 100)][int]$MaxLines = 5
+        [ValidateRange(1, 100)][int]$MaxLines = 5,
+        [int]$Width = 0
     )
 
     $esc = [char]27
-    $tail = @($Lines | Where-Object { $null -ne $_ } | Select-Object -Last $MaxLines)
+
+    # Split embedded newlines so each entry is exactly one physical row, then keep
+    # the most recent MaxLines, then clip to Width so nothing wraps.
+    $physical = foreach ($line in @($Lines | Where-Object { $null -ne $_ })) {
+        $line -split "`r?`n"
+    }
+    $tail = @($physical | Select-Object -Last $MaxLines)
+    if ($Width -gt 0) {
+        $tail = @($tail | ForEach-Object {
+            if ($_.Length -gt $Width) { $_.Substring(0, $Width) } else { $_ }
+        })
+    }
 
     $reset = ''
     if ($PreviousLineCount -gt 0) {
@@ -247,7 +283,10 @@ function Write-LivePane {
                 $script:LivePaneBuffer = New-Object System.Collections.Generic.List[string]
             }
             [void]$script:LivePaneBuffer.Add($Status)
-            $frame = Get-LivePaneFrame -Lines $script:LivePaneBuffer -PreviousLineCount $script:LivePaneLineCount -MaxLines $MaxLines
+            $width = 0
+            try { $width = [Console]::WindowWidth - 1 } catch { $width = 0 }
+            if ($width -lt 10) { $width = 0 }
+            $frame = Get-LivePaneFrame -Lines $script:LivePaneBuffer -PreviousLineCount $script:LivePaneLineCount -MaxLines $MaxLines -Width $width
             [Console]::Out.Write($frame.Text)
             $script:LivePaneLineCount = $frame.LineCount
         }


### PR DESCRIPTION
## Summary

Fixes the garbled / duplicated scrollback from `Update-Package` / `Install-Package`
on normal interactive consoles (regression from #354).

### Root cause
`Resolve-LiveOutputMode` resolved to the multiline ANSI pane for any VT-capable
console. That pane repaints with cursor-up moves and tracks a logical line count
that desyncs from the actual physical rows whenever a captured record carries
embedded newlines (npm/dotnet output) or a line wraps wider than the console -- so
frames stacked into scrollback as duplicates instead of overwriting. The
previously-transient engine status lines (including the by-design `Node.js`
dependency of `MCP Server Configuration`) then leaked into scrollback too.

### Changes
- `Resolve-LiveOutputMode` defaults to the robust single-line `Write-Progress`
  region for every interactive console. The multiline pane is now strictly OPT-IN
  via `\` (1/true/yes/on/multi/multiline) and only on a
  capable interactive console.
- `Get-LivePaneFrame` splits embedded newlines into physical rows and truncates
  each drawn row to a supplied `Width` so it never wraps -- keeping `LineCount`
  equal to the rows actually drawn.
- `Write-LivePane` passes the live console width to the frame builder.

### Tests
Behavior-first Pester (all tagged `Light,Module`):
- capable console without opt-in -> Single; with opt-in -> Multiline; opted-in but
  redirected -> Single.
- `Get-LivePaneFrame` splits an embedded-newline record into separate rows and
  truncates to `Width`.

28 related Light tests pass locally (Pester 5.7.1).

Closes #356