### PR TITLE
feat(bucket): add PowerToys (Mouse Without Borders) to ClientBasePackages

### DIFF
--- a/bucket/ClientBasePackages.ps1
+++ b/bucket/ClientBasePackages.ps1
@@ -146,6 +146,8 @@ Register-ArgumentCompleter -Native -CommandName sox -ScriptBlock {
         }
     }
     [Package]@{ Name = 'Dropbox';          Installer = 'winget'; Id = 'Dropbox.Dropbox' }
+    [Package]@{ Name = 'PowerToys';        Installer = 'winget'; Id = 'Microsoft.PowerToys'
+                Notes = 'Microsoft PowerToys suite; installed for the maintained Mouse Without Borders module (mouse/keyboard/clipboard sharing across machines), which replaces the unmaintained standalone Microsoft.MouseWithoutBorders 2.2.1 build.' }
     [Package]@{ Name = 'Foxit PDF Reader'; Installer = 'winget'; Id = 'Foxit.FoxitReader'
                 Notes = 'choco foxitreader times out downloading upstream installer (#27). winget is preferred per README.' }
     [Package]@{

--- a/bucket/ClientBasePackagesPowerToys.Tests.ps1
+++ b/bucket/ClientBasePackagesPowerToys.Tests.ps1
@@ -1,0 +1,43 @@
+#requires -Version 7.0
+#requires -Modules @{ ModuleName = 'Pester'; ModuleVersion = '5.0.0' }
+
+<#
+.SYNOPSIS
+    Behavior-first pin for the ClientBasePackages PowerToys entry. PowerToys is
+    installed for its maintained Mouse Without Borders module (closes #358),
+    replacing the unmaintained standalone Microsoft.MouseWithoutBorders 2.2.1
+    build.
+
+.DESCRIPTION
+    A plain winget GUI app is otherwise only covered structurally by the
+    data-driven Bundles.Tests.ps1, which validates whatever packages exist but
+    does not pin any specific package's presence. This focused test fails with a
+    named diagnostic if the PowerToys entry is removed or its winget Id drifts,
+    so a revert breaks for a behavioral reason rather than silently dropping
+    Mouse Without Borders from the bucket.
+#>
+
+BeforeAll {
+    $scoopBucketPsd1 = Join-Path $PSScriptRoot '..\module\MarkMichaelis.ScoopBucket\MarkMichaelis.ScoopBucket.psd1'
+    if (Test-Path $scoopBucketPsd1) {
+        Import-Module $scoopBucketPsd1 -Force
+    } else {
+        Import-Module MarkMichaelis.ScoopBucket -Force
+    }
+    $script:powerToys = Get-Package -BucketPath $PSScriptRoot -Name 'PowerToys'
+}
+
+Describe 'ClientBasePackages: PowerToys (Mouse Without Borders)' -Tag 'Light', 'Bundle' {
+
+    It 'declares the PowerToys package exactly once' {
+        @($script:powerToys).Count | Should -Be 1
+    }
+
+    It 'installs via winget' {
+        $script:powerToys.Installer | Should -Be 'winget'
+    }
+
+    It 'targets the Microsoft.PowerToys winget id (ships the maintained Mouse Without Borders)' {
+        $script:powerToys.Id | Should -Be 'Microsoft.PowerToys'
+    }
+}


### PR DESCRIPTION
## Summary
Adds **Mouse Without Borders** to the bucket by installing `Microsoft.PowerToys`
(winget). The maintained Mouse Without Borders module now ships inside PowerToys;
the standalone `Microsoft.MouseWithoutBorders` winget package is the
unmaintained 2.2.1 (2021) build with a known clipboard crash-loop, so PowerToys
is installed instead.

## Changes
- `bucket/ClientBasePackages.ps1` -- new `Microsoft.PowerToys` [Package] entry
  in the **Client** group (plain winget GUI app, default machine scope). A
  `Notes` field records the Mouse Without Borders rationale.
- `bucket/ClientBasePackagesPowerToys.Tests.ps1` -- behavior-first pin test
  (`-Tag Light,Bundle`) asserting the entry exists once with
  `Id=Microsoft.PowerToys`. Fails for a behavioral reason if reverted.

## Verification
- `pwsh -NoProfile -File bucket/Invoke-Tests.ps1` (Light gate): 1517 passed,
  0 failed. The 3 new PowerToys tests run and pass.

## Notes
- Group placement (Client vs OS) was a deliberate call: PowerToys is treated as
  a client app.
- `.github/scripts/Test-Installs.ps1` auto-discovers the new winget package and
  attempts a real machine-scope install in CI. If the runner cannot validate it,
  the fallback is a `CISkipPackages` entry keyed `Microsoft.PowerToys`.

Closes #358