### PR TITLE
fix(dotnet): upgrade dotnet-sdk instead of deprecated dotnetcore-sdk

### DIFF
--- a/bucket/developer/dotnet.json
+++ b/bucket/developer/dotnet.json
@@ -1,10 +1,10 @@
 {
     "$schema": "https://raw.githubusercontent.com/lukesampson/scoop/master/schema.json",
-    "version": "1.02.000",
+    "version": "1.03.000",
     "url": ["https://raw.githubusercontent.com/MarkMichaelis/ScoopBucket/main/bucket/_placeholder"],
     "installer": {
         "script": [
-            "choco install dotnetcore-sdk -y;choco install dotnetcore-sdk -pre -y"
+            "choco upgrade dotnet-sdk -y --no-progress"
         ]
     }
 }


### PR DESCRIPTION
## Summary

The legacy `dotnetcore-sdk` Chocolatey package caps at .NET Core 3.x and is a no-op on re-run (`choco install` does nothing when the package is present). Switch `bucket/developer/dotnet.json` to the maintained `dotnet-sdk` package using the upgrade verb so the bucket installs and advances the current .NET SDK.

```diff
-      "choco install dotnetcore-sdk -y;choco install dotnetcore-sdk -pre -y"
+      "choco upgrade dotnet-sdk -y --no-progress"
```

Manifest version bumped `1.02.000` -> `1.03.000`.

## Test

```powershell
Invoke-Pester -Path bucket\BucketManifestVersion.Tests.ps1, bucket\ManifestUrlSelfReferences.Tests.ps1
```

123 passed, 0 failed.

Closes #360