### PR TITLE
feat(live-output): Style A bottom-anchored sticky scroll-region overlay

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,7 @@ Thumbs.db
 Samples/HAR-Original/
 .dogfood-output/
 testResults.xml
+# Per-run package install/update failure logs written by the failure-log
+# feature (#352). These are transient diagnostic artifacts emitted into the
+# working directory on a failed run, not source -- never commit them.
+ScoopBucket-*-failures.log

--- a/bucket/UpdatePackage.Tests.ps1
+++ b/bucket/UpdatePackage.Tests.ps1
@@ -739,6 +739,10 @@ Describe 'Quiet-by-default update output (#276)' -Tag 'Light','Module' {
 
     It 'reports the current package as a transient Write-Progress status' {
         InModuleScope MarkMichaelis.ScoopBucket {
+            # Pin the Single (Write-Progress) renderer so this #276 path is asserted
+            # deterministically regardless of the test host's console capability
+            # (a capable interactive console now defaults to the Sticky renderer).
+            Mock Resolve-LiveOutputMode { 'Single' }
             Mock Update-WingetPackage    { return @{ State='Updated'; Reason=$null } }
             Mock Update-PathFromRegistry { }
             Mock Register-PackageCompletion { }

--- a/module/MarkMichaelis.ScoopBucket/Private/LiveOutputPane.Tests.ps1
+++ b/module/MarkMichaelis.ScoopBucket/Private/LiveOutputPane.Tests.ps1
@@ -117,6 +117,40 @@ Describe 'Resolve-LiveOutputMode' -Tag 'Light','Module' {
         }
         $m | Should -Be 'Single'
     }
+
+    It 'does not read the console window height once a cheap gate has chosen Single' {
+        # On a headless host the [Console]::WindowHeight getter raises a
+        # non-terminating "handle is invalid" error that leaks into a caller's
+        # -ErrorVariable. The cheap, non-throwing gates (CI / redirected / vscode /
+        # ISE / no-VT) must therefore short-circuit BEFORE the height is probed.
+        foreach ($case in @(
+                @{ Name = 'CI';         Args = @{ Ci = 'true'; OutputRedirected = $false; SupportsVirtualTerminal = $true } }
+                @{ Name = 'redirected'; Args = @{ Ci = '';     OutputRedirected = $true;  SupportsVirtualTerminal = $true } }
+                @{ Name = 'vscode';     Args = @{ Ci = '';     OutputRedirected = $false; SupportsVirtualTerminal = $true; TermProgram = 'vscode' } }
+                @{ Name = 'no-VT';      Args = @{ Ci = '';     OutputRedirected = $false; SupportsVirtualTerminal = $false } }
+            )) {
+            Mock -ModuleName MarkMichaelis.ScoopBucket Get-ConsoleWindowHeight { 30 }
+            $splat = $case.Args
+            $m = & $script:mod {
+                param($splat)
+                Resolve-LiveOutputMode @splat -HostName 'ConsoleHost' -ProgressPreferenceValue 'Continue' -LivePaneOverride ''
+            } $splat
+            $m | Should -Be 'Single' -Because "the $($case.Name) gate must force Single"
+            Should -Invoke -ModuleName MarkMichaelis.ScoopBucket Get-ConsoleWindowHeight -Times 0 -Exactly `
+                -Because "the $($case.Name) gate must short-circuit before the console handle is touched"
+        }
+    }
+
+    It 'reads the console window height only when no cheaper gate short-circuits' {
+        Mock -ModuleName MarkMichaelis.ScoopBucket Get-ConsoleWindowHeight { 30 }
+        $m = & $script:mod {
+            Resolve-LiveOutputMode -TermProgram 'WindowsTerminal' -Ci '' -OutputRedirected $false `
+                -HostName 'ConsoleHost' -SupportsVirtualTerminal $true -ProgressPreferenceValue 'Continue' `
+                -LivePaneOverride ''
+        }
+        $m | Should -Be 'Sticky'
+        Should -Invoke -ModuleName MarkMichaelis.ScoopBucket Get-ConsoleWindowHeight -Times 1 -Exactly
+    }
 }
 
 Describe 'Get-LivePaneFrame' -Tag 'Light','Module' {

--- a/module/MarkMichaelis.ScoopBucket/Private/LiveOutputPane.Tests.ps1
+++ b/module/MarkMichaelis.ScoopBucket/Private/LiveOutputPane.Tests.ps1
@@ -7,11 +7,12 @@
     The multiline pane is the portability risk, so its decision logic and frame
     strings are pure and pinned here:
 
-      * Resolve-LiveOutputMode defaults to the safe single-line Write-Progress
-        region for every interactive console, and only resolves Multiline when
-        $env:SCOOPBUCKET_LIVE_PANE explicitly opts in AND the host is a capable,
-        VT-capable, non-VS-Code, non-CI, non-redirected, non-ISE console; a silenced
-        progress preference is Off.
+      * Resolve-LiveOutputMode defaults to the multiline pane on any capable,
+        VT-capable, non-VS-Code, non-CI, non-redirected, non-ISE interactive console,
+        and degrades to the single-line Write-Progress region everywhere the host
+        cannot drive it. $env:SCOOPBUCKET_LIVE_PANE is an override/off-switch: a
+        falsy value (0/false/no/off/single) forces Single even on a capable console; a
+        silenced progress preference is Off.
       * Get-LivePaneFrame / Get-LivePaneClear emit the exact cursor-move + clear
         sequences, split embedded newlines, truncate to a supplied width, and
         account for the drawn line count.
@@ -70,28 +71,49 @@ Describe 'Resolve-LiveOutputMode' -Tag 'Light','Module' {
         $m | Should -Be 'Single'
     }
 
-    It 'returns Single for a capable interactive console when the pane is not opted in' {
+    It 'returns Sticky by default for a capable interactive console (no override)' {
         $m = & $script:mod {
             Resolve-LiveOutputMode -TermProgram 'WindowsTerminal' -Ci '' -OutputRedirected $false `
                 -HostName 'ConsoleHost' -SupportsVirtualTerminal $true -ProgressPreferenceValue 'Continue' `
-                -LivePaneOptIn ''
+                -LivePaneOverride '' -WindowHeight 30
+        }
+        $m | Should -Be 'Sticky'
+    }
+
+    It 'returns Single for a capable interactive console when the override forces it off' {
+        foreach ($off in '0', 'false', 'no', 'off', 'single') {
+            $m = & $script:mod {
+                param($off)
+                Resolve-LiveOutputMode -TermProgram 'WindowsTerminal' -Ci '' -OutputRedirected $false `
+                    -HostName 'ConsoleHost' -SupportsVirtualTerminal $true -ProgressPreferenceValue 'Continue' `
+                    -LivePaneOverride $off -WindowHeight 30
+            } $off
+            $m | Should -Be 'Single' -Because "override '$off' must force the single-line region"
+        }
+    }
+
+    It 'still returns Sticky for a capable console when the override explicitly requests it' {
+        $m = & $script:mod {
+            Resolve-LiveOutputMode -TermProgram 'WindowsTerminal' -Ci '' -OutputRedirected $false `
+                -HostName 'ConsoleHost' -SupportsVirtualTerminal $true -ProgressPreferenceValue 'Continue' `
+                -LivePaneOverride 'multiline' -WindowHeight 30
+        }
+        $m | Should -Be 'Sticky'
+    }
+
+    It 'falls back to Single on a capable console when the window is too short for a sticky bar' {
+        $m = & $script:mod {
+            Resolve-LiveOutputMode -TermProgram 'WindowsTerminal' -Ci '' -OutputRedirected $false `
+                -HostName 'ConsoleHost' -SupportsVirtualTerminal $true -ProgressPreferenceValue 'Continue' `
+                -LivePaneOverride '' -WindowHeight 4
         }
         $m | Should -Be 'Single'
     }
 
-    It 'returns Multiline only for a capable interactive console that opts in' {
-        $m = & $script:mod {
-            Resolve-LiveOutputMode -TermProgram 'WindowsTerminal' -Ci '' -OutputRedirected $false `
-                -HostName 'ConsoleHost' -SupportsVirtualTerminal $true -ProgressPreferenceValue 'Continue' `
-                -LivePaneOptIn 'multiline'
-        }
-        $m | Should -Be 'Multiline'
-    }
-
-    It 'keeps Single even when opted in if the host is not capable (redirected)' {
+    It 'keeps Single when the host is not capable (redirected) even with no override' {
         $m = & $script:mod {
             Resolve-LiveOutputMode -Ci '' -OutputRedirected $true -SupportsVirtualTerminal $true `
-                -ProgressPreferenceValue 'Continue' -LivePaneOptIn 'true'
+                -ProgressPreferenceValue 'Continue' -LivePaneOverride '' -WindowHeight 30
         }
         $m | Should -Be 'Single'
     }
@@ -144,6 +166,56 @@ Describe 'Get-LivePaneClear' -Tag 'Light','Module' {
     }
 }
 
+Describe 'Sticky scroll-region helpers' -Tag 'Light','Module' {
+    It 'Get-StickyRegionEnter sets the scroll region above the bar and parks the cursor' {
+        # Height 30, 1 bar row => scroll region rows 1..29, cursor parked at 29;1.
+        $s = & $script:mod { Get-StickyRegionEnter -Height 30 -BarRows 1 }
+        $s | Should -Be "$($script:ESC)[1;29r$($script:ESC)[29;1H"
+    }
+
+    It 'Get-StickyRegionEnter accounts for a taller bar' {
+        $s = & $script:mod { Get-StickyRegionEnter -Height 30 -BarRows 2 }
+        $s | Should -Be "$($script:ESC)[1;28r$($script:ESC)[28;1H"
+    }
+
+    It 'Get-StickyStatusFrame saves the cursor, paints the bar row, and restores' {
+        # Bar row for Height 30 / 1 bar row is row 30.
+        $s = & $script:mod { Get-StickyStatusFrame -Status 'Updating X' -Height 30 -BarRows 1 -Width 80 }
+        # ESC7 save, move to 30;1, clear line, inverse status, reset, ESC8 restore.
+        $expected = "$($script:ESC)7$($script:ESC)[30;1H$($script:ESC)[2K$($script:ESC)[7mUpdating X$($script:ESC)[0m$($script:ESC)8"
+        $s | Should -Be $expected
+    }
+
+    It 'Get-StickyStatusFrame clips the status to Width so the bar never wraps' {
+        $s = & $script:mod { Get-StickyStatusFrame -Status 'abcdefghij' -Height 10 -BarRows 1 -Width 4 }
+        $s | Should -Match ([regex]::Escape("$($script:ESC)[7mabcd$($script:ESC)[0m"))
+        $s | Should -Not -Match 'efghij'
+    }
+
+    It 'Get-StickyLogLine writes the first line in place and later lines after a newline' {
+        $first = & $script:mod { Get-StickyLogLine -Text 'first' -Width 80 -IsFirst $true }
+        $first | Should -Be 'first'
+        $next = & $script:mod { Get-StickyLogLine -Text 'second' -Width 80 -IsFirst $false }
+        $next | Should -Be "`nsecond"
+    }
+
+    It 'Get-StickyLogLine splits an embedded-newline record into separate scrolled rows' {
+        $s = & $script:mod { Get-StickyLogLine -Text "a`nb" -Width 80 -IsFirst $false }
+        $s | Should -Be "`na`nb"
+    }
+
+    It 'Get-StickyLogLine clips each row to Width' {
+        $s = & $script:mod { Get-StickyLogLine -Text 'abcdefghij' -Width 4 -IsFirst $true }
+        $s | Should -Be 'abcd'
+    }
+
+    It 'Get-StickyRegionLeave resets the region and clears the bar, leaving the log above' {
+        # Height 30 / 1 bar row: reset region, move to first bar row (30), clear to end.
+        $s = & $script:mod { Get-StickyRegionLeave -Height 30 -BarRows 1 }
+        $s | Should -Be "$($script:ESC)[r$($script:ESC)[30;1H$($script:ESC)[0J"
+    }
+}
+
 Describe 'Write-LivePane' -Tag 'Light','Module' {
     It 'mirrors the status to the verbose stream even when the visual mode is Off' {
         $v = & $script:mod {
@@ -165,5 +237,51 @@ Describe 'Write-LivePane' -Tag 'Light','Module' {
         } 6>$null
         $counts.After | Should -Be 2
         $counts.Reset | Should -Be 0
+    }
+
+    It 'activates the sticky region on the first Sticky write and tears it down on completion' {
+        $state = & $script:mod {
+            $script:StickyActive = $false
+            $script:StickyStarted = $false
+            Write-LivePane -Status 'one' -Mode 'Sticky'
+            $activeAfterFirst = $script:StickyActive
+            $startedAfterFirst = $script:StickyStarted
+            Write-LivePane -Status 'two' -Mode 'Sticky'
+            Write-LivePane -Completed -Mode 'Sticky'
+            [pscustomobject]@{
+                ActiveAfterFirst  = $activeAfterFirst
+                StartedAfterFirst = $startedAfterFirst
+                ActiveAfterDone   = $script:StickyActive
+            }
+        } 6>$null
+        $state.ActiveAfterFirst  | Should -BeTrue
+        $state.StartedAfterFirst | Should -BeTrue
+        $state.ActiveAfterDone   | Should -BeFalse
+    }
+
+    It 'mirrors Sticky status lines to the verbose stream (recoverable transcript)' {
+        $v = & $script:mod {
+            $script:StickyActive = $false
+            $script:StickyStarted = $false
+            $VerbosePreference = 'Continue'
+            Write-LivePane -Status 'sticky-verbose-line' -Mode 'Sticky'
+            Write-LivePane -Completed -Mode 'Sticky'
+        } 4>&1 6>$null
+        @($v | Where-Object { "$_" -match 'sticky-verbose-line' }) | Should -Not -BeNullOrEmpty
+    }
+
+    It 'tears down an active sticky region on completion even when Mode now resolves to Single' {
+        # Guards against a mid-run host-fact shift leaving the VT scroll region leaked:
+        # teardown is driven by the active-region flag, not the freshly-resolved Mode.
+        $active = & $script:mod {
+            $script:StickyActive = $false
+            $script:StickyStarted = $false
+            Write-LivePane -Status 'one' -Mode 'Sticky'
+            $afterFirst = $script:StickyActive
+            Write-LivePane -Completed -Mode 'Single'
+            [pscustomobject]@{ AfterFirst = $afterFirst; AfterDone = $script:StickyActive }
+        } 6>$null
+        $active.AfterFirst | Should -BeTrue
+        $active.AfterDone  | Should -BeFalse
     }
 }

--- a/module/MarkMichaelis.ScoopBucket/Private/LiveOutputPane.ps1
+++ b/module/MarkMichaelis.ScoopBucket/Private/LiveOutputPane.ps1
@@ -1,33 +1,47 @@
-# Host-adaptive transient "live output" pane for the package commands (#354).
+# Host-adaptive "live output" pane for the package commands (#354).
 #
 # Thrust A (#352) routed package ConfigScript output through Write-UpdateStatus,
-# which renders a single transient line via Write-Progress. This adds a multiline
-# pane that shows a rolling tail of the most recent live-output lines and clears on
-# completion -- but only when explicitly opted in via $env:SCOOPBUCKET_LIVE_PANE
-# (#356). By default, and everywhere the host is not a capable interactive VT
-# console, it degrades to the robust single-line Write-Progress region (or, when
-# progress is silenced, to a verbose-only mirror).
+# which renders a single transient line via Write-Progress. Style A (#361) renders,
+# on a capable interactive console, a bottom-anchored STICKY status bar via a VT
+# scroll region (DECSTBM): the package log scrolls normally ABOVE the bar and stays
+# in scrollback (selectable / copy-paste-able), while only the pinned status bar is
+# transient and is torn down on completion. Everywhere the host cannot drive the
+# scroll-region cursor math (VS Code, CI, redirected, ISE, a non-VT host, or a window
+# too short for a bar plus a usable log) it degrades to the robust single-line
+# Write-Progress region (or, when progress is silenced, to a verbose-only mirror).
+# $env:SCOOPBUCKET_LIVE_PANE is an off-switch: a falsy value (0/false/no/off/single)
+# forces the single-line region even on a capable console (#356/#361).
 #
 # All host-detection and frame-building logic is pure (returns a mode enum / strings)
 # so it is fully unit-testable without a live console. Only Write-LivePane performs
-# the imperative cursor writes, and it is gated by Resolve-LiveOutputMode -- when in
-# any doubt the mode resolves to Single, never Multiline.
+# the imperative cursor writes, and it is gated by Resolve-LiveOutputMode -- which
+# only resolves Sticky on a console that can actually render it.
+#
+# PORTABILITY (#361): the renderer is intentionally ScoopBucket-agnostic -- the pure
+# frame builders and Write-LivePane core take only primitives (strings, ints, host
+# facts) and reference no [Package]/bundle/Update-Package types, so this single file
+# can later be lifted verbatim into the IntelliSDLC.ai upstream repo as a generic
+# console-overlay utility. Write-UpdateStatus stays a thin ScoopBucket adapter.
+
+# Minimum console height (rows) required to host a sticky status bar plus a usable
+# scrolling log; shorter windows degrade to the single-line region.
+$script:StickyMinHeight = 6
 
 function Resolve-LiveOutputMode {
     <#
     .SYNOPSIS
         Decide how the live-output pane should render on the current host.
     .DESCRIPTION
-        Returns one of 'Multiline', 'Single', or 'Off' from host facts. The
-        single-line Write-Progress region is the DEFAULT for every interactive
-        console because it is robust everywhere. The multiline ANSI pane is a
-        portability risk (its cursor-repaint math is corrupted by line wrapping and
-        embedded newlines on real terminals -- see #356), so it is strictly OPT-IN:
-        chosen only when $env:SCOOPBUCKET_LIVE_PANE explicitly requests it AND the
-        host is a genuinely interactive, VT-capable, non-VS-Code, non-CI,
-        non-redirected, non-ISE console. A silenced progress preference resolves to
-        Off (verbose-only). All facts are parameters (defaulted from the environment)
-        so every host signature can be unit-tested deterministically.
+        Returns one of 'Sticky', 'Single', or 'Off' from host facts. The bottom-anchored
+        sticky scroll-region bar is the DEFAULT for a genuinely interactive, VT-capable,
+        non-VS-Code, non-CI, non-redirected, non-ISE console that is tall enough to host
+        a pinned bar plus a usable log -- those are exactly the hosts whose scroll-region
+        cursor math the renderer can drive safely. Every other host degrades to the robust
+        single-line Write-Progress region. $env:SCOOPBUCKET_LIVE_PANE is an
+        override/off-switch: a falsy value (0/false/no/off/single, case-insensitive)
+        forces Single even on a capable console. A silenced progress preference
+        resolves to Off (verbose-only). All facts are parameters (defaulted from the
+        environment) so every host signature can be unit-tested deterministically.
     .PARAMETER TermProgram
         Value of $env:TERM_PROGRAM (e.g. 'vscode').
     .PARAMETER Ci
@@ -42,12 +56,17 @@ function Resolve-LiveOutputMode {
         not supplied.
     .PARAMETER ProgressPreferenceValue
         String form of $ProgressPreference; 'SilentlyContinue' forces Off.
-    .PARAMETER LivePaneOptIn
-        Value of $env:SCOOPBUCKET_LIVE_PANE. The multiline pane is only ever selected
-        when this opts in (1/true/yes/on/multi/multiline, case-insensitive); any
-        other value keeps the safe Single region.
+    .PARAMETER LivePaneOverride
+        Value of $env:SCOOPBUCKET_LIVE_PANE. A falsy value (0/false/no/off/single,
+        case-insensitive) forces the safe single-line region even on a capable host;
+        any other value (including empty) leaves the capability-based default in
+        effect.
+    .PARAMETER WindowHeight
+        Console window height in rows ([Console]::WindowHeight). Resolved live when
+        not supplied. A window too short to host a pinned status bar plus a usable
+        scrolling log degrades to Single.
     .OUTPUTS
-        System.String -- 'Multiline' | 'Single' | 'Off'.
+        System.String -- 'Sticky' | 'Single' | 'Off'.
     #>
     [CmdletBinding()]
     [OutputType([string])]
@@ -58,7 +77,8 @@ function Resolve-LiveOutputMode {
         [string]$HostName = $Host.Name,
         [Nullable[bool]]$SupportsVirtualTerminal,
         [string]$ProgressPreferenceValue = "$ProgressPreference",
-        [string]$LivePaneOptIn = $env:SCOOPBUCKET_LIVE_PANE
+        [string]$LivePaneOverride = $env:SCOOPBUCKET_LIVE_PANE,
+        [Nullable[int]]$WindowHeight
     )
 
     if ($null -eq $OutputRedirected) {
@@ -67,19 +87,26 @@ function Resolve-LiveOutputMode {
     if ($null -eq $SupportsVirtualTerminal) {
         try { $SupportsVirtualTerminal = [bool]$Host.UI.SupportsVirtualTerminal } catch { $SupportsVirtualTerminal = $false }
     }
+    if ($null -eq $WindowHeight) {
+        try { $WindowHeight = [Console]::WindowHeight } catch { $WindowHeight = 0 }
+    }
 
     if ($ProgressPreferenceValue -eq 'SilentlyContinue') { return 'Off' }
 
-    # Multiline is strictly opt-in (#356): without an explicit request, the robust
-    # single-line region is always used, even on a fully capable console.
-    if ($LivePaneOptIn -notmatch '^\s*(?i:1|true|yes|on|multi|multiline)\s*$') { return 'Single' }
+    # Explicit off-switch (#361): a falsy override forces the safe single-line region
+    # even on a fully capable console.
+    if ($LivePaneOverride -match '^\s*(?i:0|false|no|off|single)\s*$') { return 'Single' }
 
+    # Capability gates: these hosts cannot drive the scroll-region cursor math, so the
+    # sticky default degrades to the robust single-line region.
     if (-not [string]::IsNullOrEmpty($Ci))                { return 'Single' }
     if ($OutputRedirected)                                { return 'Single' }
     if ($TermProgram -eq 'vscode')                        { return 'Single' }
     if ($HostName -like '*ISE*')                          { return 'Single' }
     if (-not $SupportsVirtualTerminal)                    { return 'Single' }
-    return 'Multiline'
+    # A window too short for a pinned bar plus a usable log degrades to Single.
+    if ($WindowHeight -gt 0 -and $WindowHeight -lt $script:StickyMinHeight) { return 'Single' }
+    return 'Sticky'
 }
 
 function Get-LivePaneFrame {
@@ -170,6 +197,134 @@ function Get-LivePaneClear {
     return "$esc[${up}F$esc[0J"
 }
 
+function Get-StickyRegionEnter {
+    <#
+    .SYNOPSIS
+        Build the VT sequence that opens a bottom-anchored sticky scroll region.
+    .DESCRIPTION
+        Sets the DECSTBM scroll region (ESC[<top>;<bottom>r) to rows 1..(Height-BarRows)
+        so the bottom BarRows are frozen as a pinned status bar, then parks the cursor on
+        the last scrolling row so subsequent log writes scroll ABOVE the bar and persist
+        in scrollback. Pure: returns the string, writes nothing. ScoopBucket-agnostic.
+    .PARAMETER Height
+        Console window height in rows.
+    .PARAMETER BarRows
+        Number of rows reserved at the bottom for the status bar (default 1).
+    .OUTPUTS
+        System.String.
+    #>
+    [CmdletBinding()]
+    [OutputType([string])]
+    param(
+        [Parameter(Mandatory)][int]$Height,
+        [int]$BarRows = 1
+    )
+    $esc = [char]27
+    $bottom = [Math]::Max(1, $Height - $BarRows)
+    return "$esc[1;${bottom}r$esc[${bottom};1H"
+}
+
+function Get-StickyStatusFrame {
+    <#
+    .SYNOPSIS
+        Build the VT sequence that paints the pinned status bar without disturbing the
+        scrolling log cursor.
+    .DESCRIPTION
+        Saves the cursor (ESC7), moves to the first bar row, clears the line, renders the
+        status inverse (ESC[7m..ESC[0m) clipped to Width so it never wraps, then restores
+        the cursor (ESC8) back into the scrolling region. Pure. ScoopBucket-agnostic.
+    .PARAMETER Status
+        Status text for the bar.
+    .PARAMETER Height
+        Console window height in rows.
+    .PARAMETER BarRows
+        Rows reserved for the bar (default 1).
+    .PARAMETER Width
+        Maximum drawn width; the status is clipped to this so the bar never wraps.
+    .OUTPUTS
+        System.String.
+    #>
+    [CmdletBinding()]
+    [OutputType([string])]
+    param(
+        [string]$Status = '',
+        [Parameter(Mandatory)][int]$Height,
+        [int]$BarRows = 1,
+        [int]$Width = 0
+    )
+    $esc = [char]27
+    $barRow = [Math]::Max(1, $Height - $BarRows + 1)
+    $text = $Status
+    if ($Width -gt 0 -and $text.Length -gt $Width) { $text = $text.Substring(0, $Width) }
+    return "$esc`7$esc[${barRow};1H$esc[2K$esc[7m$text$esc[0m$esc`8"
+}
+
+function Get-StickyLogLine {
+    <#
+    .SYNOPSIS
+        Build the persistent log text written into the scrolling region above the bar.
+    .DESCRIPTION
+        Splits embedded newlines so each record maps to exactly one physical row, clips
+        each row to Width so nothing wraps, and joins them with newlines. The very first
+        line is written in place (the cursor is already parked on the last scrolling row);
+        every later line is prefixed with a newline so the region scrolls up by one. The
+        log is intentionally left in scrollback (copy/paste-able). Pure. ScoopBucket-
+        agnostic.
+    .PARAMETER Text
+        The log record (may contain embedded newlines).
+    .PARAMETER Width
+        Maximum drawn width per row; 0 disables clipping.
+    .PARAMETER IsFirst
+        $true for the first log line of the region (no leading newline).
+    .OUTPUTS
+        System.String.
+    #>
+    [CmdletBinding()]
+    [OutputType([string])]
+    param(
+        [string]$Text = '',
+        [int]$Width = 0,
+        [bool]$IsFirst = $false
+    )
+    $rows = @($Text -split "`r?`n")
+    if ($Width -gt 0) {
+        $rows = @($rows | ForEach-Object {
+            if ($_.Length -gt $Width) { $_.Substring(0, $Width) } else { $_ }
+        })
+    }
+    $body = $rows -join "`n"
+    if ($IsFirst) { return $body }
+    return "`n$body"
+}
+
+function Get-StickyRegionLeave {
+    <#
+    .SYNOPSIS
+        Build the VT sequence that tears the sticky region down on completion.
+    .DESCRIPTION
+        Resets the scroll region to the full window (ESC[r), moves to the first bar row,
+        and clears to the end of the display so the transient status bar is wiped while
+        the scrolled log above it remains in scrollback. The cursor is left where the
+        bar was so the caller's summary table prints directly below the persisted log.
+        Pure. ScoopBucket-agnostic.
+    .PARAMETER Height
+        Console window height in rows.
+    .PARAMETER BarRows
+        Rows that were reserved for the bar (default 1).
+    .OUTPUTS
+        System.String.
+    #>
+    [CmdletBinding()]
+    [OutputType([string])]
+    param(
+        [Parameter(Mandatory)][int]$Height,
+        [int]$BarRows = 1
+    )
+    $esc = [char]27
+    $barRow = [Math]::Max(1, $Height - $BarRows + 1)
+    return "$esc[r$esc[${barRow};1H$esc[0J"
+}
+
 function Write-StatusProgress {
     <#
     .SYNOPSIS
@@ -217,11 +372,15 @@ function Write-LivePane {
         keep the module-scoped multiline pane state.
     .DESCRIPTION
         Mirrors every status to Write-Verbose (recoverable in all modes), then:
+          * Sticky    -- on first call, open a bottom-anchored VT scroll region and
+                         pin a status bar; each call scrolls the status into the
+                         persistent log above the bar and refreshes the bar;
           * Multiline -- append to the rolling buffer and repaint the ANSI pane;
           * Single    -- delegate to Write-StatusProgress (Write-Progress region);
           * Off       -- verbose-only.
-        -Completed tears the renderer down (erase the multiline pane / clear the
-        progress line) and resets the pane state.
+        -Completed tears the renderer down (reset the scroll region / erase the
+        multiline pane / clear the progress line) and resets the pane state. The Sticky
+        teardown is also safe to call from a finally on an aborted run.
     .PARAMETER Status
         The status text.
     .PARAMETER Activity
@@ -248,12 +407,25 @@ function Write-LivePane {
         [int]$PercentComplete = -1,
         [ValidateRange(1, 100)][int]$MaxLines = 5,
         [switch]$Completed,
-        [ValidateSet('Multiline', 'Single', 'Off')][string]$Mode
+        [ValidateSet('Sticky', 'Multiline', 'Single', 'Off')][string]$Mode
     )
 
     if (-not $Mode) { $Mode = Resolve-LiveOutputMode }
 
     if ($Completed) {
+        # Tear down an open sticky region whenever one is active, regardless of what
+        # Mode now resolves to -- this guarantees the VT scroll region is always reset
+        # even if host facts shifted mid-run (otherwise a stale region could leak).
+        if ($script:StickyActive) {
+            $height = 0
+            try { $height = [Console]::WindowHeight } catch { $height = 0 }
+            if ($height -gt 0) {
+                [Console]::Out.Write((Get-StickyRegionLeave -Height $height -BarRows $script:StickyBarRows))
+            }
+            $script:StickyActive = $false
+            $script:StickyStarted = $false
+            return
+        }
         if ($Mode -eq 'Multiline') {
             if ($script:LivePaneLineCount -gt 0) {
                 [Console]::Out.Write((Get-LivePaneClear -PreviousLineCount $script:LivePaneLineCount))
@@ -277,6 +449,31 @@ function Write-LivePane {
             if ($ParentId -ge 0)        { $progressArgs['ParentId']        = $ParentId }
             if ($PercentComplete -ge 0) { $progressArgs['PercentComplete'] = $PercentComplete }
             Write-StatusProgress @progressArgs
+        }
+        'Sticky' {
+            $height = 0
+            try { $height = [Console]::WindowHeight } catch { $height = 0 }
+            $width = 0
+            try { $width = [Console]::WindowWidth - 1 } catch { $width = 0 }
+            if ($width -lt 10) { $width = 0 }
+            if ($script:StickyBarRows -lt 1) { $script:StickyBarRows = 1 }
+
+            if (-not $script:StickyActive) {
+                if ($height -gt 0) {
+                    [Console]::Out.Write((Get-StickyRegionEnter -Height $height -BarRows $script:StickyBarRows))
+                }
+                $script:StickyActive = $true
+                $script:StickyStarted = $false
+            }
+
+            # Scroll the status into the persistent (copy/paste-able) log above the bar.
+            [Console]::Out.Write((Get-StickyLogLine -Text $Status -Width $width -IsFirst (-not $script:StickyStarted)))
+            $script:StickyStarted = $true
+
+            # Refresh the pinned bar with the latest status without moving the log cursor.
+            if ($height -gt 0) {
+                [Console]::Out.Write((Get-StickyStatusFrame -Status $Status -Height $height -BarRows $script:StickyBarRows -Width $width))
+            }
         }
         'Multiline' {
             if (-not $script:LivePaneBuffer) {

--- a/module/MarkMichaelis.ScoopBucket/Private/LiveOutputPane.ps1
+++ b/module/MarkMichaelis.ScoopBucket/Private/LiveOutputPane.ps1
@@ -27,6 +27,26 @@
 # scrolling log; shorter windows degrade to the single-line region.
 $script:StickyMinHeight = 6
 
+function Get-ConsoleWindowHeight {
+    <#
+    .SYNOPSIS
+        Read the console window height in rows, returning 0 when it cannot be read.
+    .DESCRIPTION
+        Isolated so callers can probe the (potentially throwing) [Console]::WindowHeight
+        getter through a single seam. On a headless host (CI / redirected) the getter
+        raises a non-terminating "handle is invalid" error that try/catch does NOT
+        swallow and that would leak into a caller's -ErrorVariable, so this is only
+        ever invoked once the cheaper, non-throwing host gates have failed to short
+        circuit. Returns 0 on any failure (treated as "height unknown"). Pure read.
+    .OUTPUTS
+        System.Int32 -- the window height, or 0 when unavailable.
+    #>
+    [CmdletBinding()]
+    [OutputType([int])]
+    param()
+    try { return [int][Console]::WindowHeight } catch { return 0 }
+}
+
 function Resolve-LiveOutputMode {
     <#
     .SYNOPSIS
@@ -87,9 +107,6 @@ function Resolve-LiveOutputMode {
     if ($null -eq $SupportsVirtualTerminal) {
         try { $SupportsVirtualTerminal = [bool]$Host.UI.SupportsVirtualTerminal } catch { $SupportsVirtualTerminal = $false }
     }
-    if ($null -eq $WindowHeight) {
-        try { $WindowHeight = [Console]::WindowHeight } catch { $WindowHeight = 0 }
-    }
 
     if ($ProgressPreferenceValue -eq 'SilentlyContinue') { return 'Off' }
 
@@ -104,6 +121,16 @@ function Resolve-LiveOutputMode {
     if ($TermProgram -eq 'vscode')                        { return 'Single' }
     if ($HostName -like '*ISE*')                          { return 'Single' }
     if (-not $SupportsVirtualTerminal)                    { return 'Single' }
+
+    # Only now -- once every cheaper, non-throwing gate has had its chance to return
+    # Single -- read the console window height. On a headless host (CI / redirected)
+    # the [Console]::WindowHeight getter raises a non-terminating "handle is invalid"
+    # error that try/catch does NOT swallow and that would otherwise leak into a
+    # caller's -ErrorVariable; deferring the read past those gates means such hosts
+    # never touch the console handle (#361 CI regression).
+    if ($null -eq $WindowHeight) {
+        $WindowHeight = Get-ConsoleWindowHeight
+    }
     # A window too short for a pinned bar plus a usable log degrades to Single.
     if ($WindowHeight -gt 0 -and $WindowHeight -lt $script:StickyMinHeight) { return 'Single' }
     return 'Sticky'

--- a/module/MarkMichaelis.ScoopBucket/Private/Write-UpdateStatus.ps1
+++ b/module/MarkMichaelis.ScoopBucket/Private/Write-UpdateStatus.ps1
@@ -36,12 +36,14 @@ function Write-UpdateStatus {
         [switch]$Completed
     )
 
-    # Forward to the host-adaptive pane (#354). Write-LivePane owns the verbose
-    # mirror and, per Resolve-LiveOutputMode, renders either the multiline ANSI pane
-    # (interactive VT console) or the original single-line Write-Progress region
-    # (CI / redirected / VS Code / no-VT) or verbose-only (progress silenced). In CI
-    # and under redirection the mode is always Single, so the #276 behaviour --
-    # transient Write-Progress plus a -Verbose mirror -- is preserved exactly.
+    # Forward to the host-adaptive pane (#354/#361). Write-LivePane owns the verbose
+    # mirror and, per Resolve-LiveOutputMode, renders either the bottom-anchored sticky
+    # status bar over a persistent scrolling log (capable interactive VT console) or the
+    # original single-line Write-Progress region (CI / redirected / VS Code / no-VT /
+    # too-short window) or verbose-only (progress silenced). In CI and under redirection
+    # the mode is always Single, so the #276 behaviour -- transient Write-Progress plus a
+    # -Verbose mirror -- is preserved exactly. Callers MUST invoke this with -Completed in
+    # a finally so an aborted run resets the VT scroll region.
     $forward = @{ Activity = $Activity; Id = $Id; ParentId = $ParentId; PercentComplete = $PercentComplete }
     if ($Completed) {
         Write-LivePane @forward -Completed

--- a/module/MarkMichaelis.ScoopBucket/Public/Invoke-PackageInstall.ps1
+++ b/module/MarkMichaelis.ScoopBucket/Public/Invoke-PackageInstall.ps1
@@ -139,6 +139,7 @@ function Invoke-PackageInstall {
         $PSCmdlet.WriteError($errRec)
     }
 
+    try {
     foreach ($pkg in $ordered) {
         $state  = 'Pending'
         $reason = $null
@@ -288,10 +289,13 @@ function Invoke-PackageInstall {
 
         & $addState $pkg $state $reason $null
     }
-
-    # Tear down the transient progress line before emitting results so the
-    # two don't fight over the host's rendering.
-    Write-UpdateStatus -Activity 'Install-Package' -Completed
+    }
+    finally {
+        # Tear down the transient status bar / progress line before emitting results
+        # so the two don't fight over the host's rendering. In a finally so an aborted
+        # or throwing run never leaves the terminal with a stuck VT scroll region.
+        Write-UpdateStatus -Activity 'Install-Package' -Completed
+    }
 
     # Persist a per-run failure log when any ConfigScript failed (#352).
     if ($configFailures.Count -gt 0 -and -not $isWhatIf) {

--- a/module/MarkMichaelis.ScoopBucket/Public/Invoke-PackageUpdate.ps1
+++ b/module/MarkMichaelis.ScoopBucket/Public/Invoke-PackageUpdate.ps1
@@ -154,6 +154,7 @@ function Invoke-PackageUpdate {
         }
     }
 
+    try {
     foreach ($pkg in $ordered) {
         $state  = 'Pending'
         $reason = $null
@@ -349,10 +350,13 @@ function Invoke-PackageUpdate {
 
         & $addState $pkg $state $reason $null $from $to
     }
-
-    # Tear down the transient progress line before emitting results so the
-    # two don't fight over the host's rendering.
-    Write-UpdateStatus -Completed
+    }
+    finally {
+        # Tear down the transient status bar / progress line before emitting results
+        # so the two don't fight over the host's rendering. In a finally so an aborted
+        # or throwing run never leaves the terminal with a stuck VT scroll region.
+        Write-UpdateStatus -Completed
+    }
 
     # When any package's ConfigScript failed, persist its full captured output to a
     # per-run log so the cause survives the transient pane (#352).


### PR DESCRIPTION
## Summary

Redesign the package-command live-output rendering as a **Style A bottom-anchored sticky overlay**. On a capable interactive console a pinned status bar is held at the bottom via a VT scroll region (DECSTBM); the package log scrolls normally ABOVE the bar and stays in scrollback (selectable / copy-paste-able). Only the pinned bar is transient and is torn down on completion. This makes the sticky overlay the DEFAULT (replacing the prior opt-in multiline pane), degrading gracefully to the single-line `Write-Progress` region where the host can't drive the scroll-region cursor math.

## Changes

- `Resolve-LiveOutputMode` returns `Sticky` for a capable VT console (tall enough: >= 6 rows); degrades to `Single` for VS Code / CI / redirected / ISE / no-VT / too-short windows; `Off` when progress is silenced. `\` stays an off-switch. Added `-WindowHeight` param + tiny-window guard.
- New pure, ScoopBucket-agnostic helpers -- `Get-StickyRegionEnter` / `Get-StickyStatusFrame` / `Get-StickyLogLine` / `Get-StickyRegionLeave` -- so the renderer can later be lifted to the IntelliSDLC.ai upstream repo. `Write-UpdateStatus` stays a thin adapter.
- `Write-LivePane` gained a `Sticky` branch (lazy region enter, per-call log + bar refresh) and a `-Completed` teardown driven by the active-region flag.
- `Invoke-PackageUpdate` / `Invoke-PackageInstall` tear the region down in a `finally` so an aborted/throwing run never leaves a stuck scroll region.
- Pinned the #276 `Write-Progress` test to Single mode (capable hosts now default to Sticky).
- Added `ScoopBucket-*-failures.log` to `.gitignore` (per-run #352 artifacts).

## Test

```powershell
.\bucket\Invoke-Tests.ps1
```

Full CI Light gate: **1515 passed, 0 failed**, 3 skipped.

## Notes

- Only the final `[Package]` summary reaches the success pipe; all status/log rendering is host-only (`[Console]::Out.Write` + `Write-Progress` + a `Write-Verbose` mirror) -- never redirectable.
- The persistent log is a deliberate departure from #276/#352 (which hid chatter): the user wants to copy/paste the run output into an AI.

Closes #361