### PR TITLE
feat(powertoys): restore settings during the configuration phase

### DIFF
--- a/bucket/ClientBasePackages.ps1
+++ b/bucket/ClientBasePackages.ps1
@@ -148,7 +148,7 @@ Register-ArgumentCompleter -Native -CommandName sox -ScriptBlock {
     [Package]@{ Name = 'Dropbox';          Installer = 'winget'; Id = 'Dropbox.Dropbox' }
     [Package]@{ Name = 'PowerToys';        Installer = 'winget'; Id = 'Microsoft.PowerToys'
                 Notes = 'Microsoft PowerToys suite; installed for the maintained Mouse Without Borders module (mouse/keyboard/clipboard sharing across machines), which replaces the unmaintained standalone Microsoft.MouseWithoutBorders 2.2.1 build.'
-                PostInstallScript = { Import-PowerToysSettings -NoRestart } }
+                ConfigScript = { Import-PowerToysSettings -NoRestart } }
     [Package]@{ Name = 'Foxit PDF Reader'; Installer = 'winget'; Id = 'Foxit.FoxitReader'
                 Notes = 'choco foxitreader times out downloading upstream installer (#27). winget is preferred per README.' }
     [Package]@{

--- a/bucket/ClientBasePackagesPowerToys.Tests.ps1
+++ b/bucket/ClientBasePackagesPowerToys.Tests.ps1
@@ -41,10 +41,11 @@ Describe 'ClientBasePackages: PowerToys (Mouse Without Borders)' -Tag 'Light', '
         $script:powerToys.Id | Should -Be 'Microsoft.PowerToys'
     }
 
-    It 'restores the scrubbed PowerToys settings snapshot after install (PostInstallScript)' {
-        # Closes #366: the committed Data/PowerToysSettings.json is reapplied via
-        # Import-PowerToysSettings once PowerToys is installed. Get-Package strips
-        # scriptblocks, exposing only the HasPostInstallScript projection.
-        $script:powerToys.HasPostInstallScript | Should -BeTrue
+    It 'restores the scrubbed PowerToys settings snapshot during the configuration phase (ConfigScript)' {
+        # Closes #368: the committed Data/PowerToysSettings.json is reapplied via
+        # Import-PowerToysSettings on every install/update (idempotent desired-state
+        # configuration), not install-only. Get-Package strips scriptblocks,
+        # exposing only the HasConfigScript projection.
+        $script:powerToys.HasConfigScript | Should -BeTrue
     }
 }

--- a/module/MarkMichaelis.ScoopBucket/MarkMichaelis.ScoopBucket.psd1
+++ b/module/MarkMichaelis.ScoopBucket/MarkMichaelis.ScoopBucket.psd1
@@ -9,7 +9,7 @@
 #
 @{
     RootModule        = 'MarkMichaelis.ScoopBucket.psm1'
-    ModuleVersion     = '1.3.0'
+    ModuleVersion     = '1.4.0'
     GUID              = 'b7e8a4c2-9f3d-4b76-8e6a-1c5d2f7b9e10'
     Author            = 'Mark Michaelis'
     CompanyName       = 'IntelliTect'

--- a/module/MarkMichaelis.ScoopBucket/Private/Get-BundlePackages.ps1
+++ b/module/MarkMichaelis.ScoopBucket/Private/Get-BundlePackages.ps1
@@ -119,6 +119,7 @@ function global:Invoke-PackageInstall {
             HasCustomInstallScript = [bool]`$p.CustomInstallScript
             HasVerifyScript        = [bool]`$p.VerifyScript
             HasNativeCommandScript = [bool]`$p.NativeCommandScript
+            HasConfigScript        = [bool]`$p.ConfigScript
         }
     }
     Write-Output ('__SBPKG__' + (@{ Bundle = `$Bundle; Packages = @(`$exported) } | ConvertTo-Json -Depth 6 -Compress))

--- a/module/MarkMichaelis.ScoopBucket/Public/Get-Package.ps1
+++ b/module/MarkMichaelis.ScoopBucket/Public/Get-Package.ps1
@@ -112,6 +112,7 @@ function Get-Package {
                 HasCustomInstallScript = [bool]$p.HasCustomInstallScript
                 HasVerifyScript        = [bool]$p.HasVerifyScript
                 HasNativeCommandScript = [bool]$p.HasNativeCommandScript
+                HasConfigScript        = [bool]$p.HasConfigScript
             }
             $flat.Add($obj)
         }


### PR DESCRIPTION
## Summary

Restores the committed PowerToys settings snapshot (from #366 / #367) during
the **configuration phase** instead of install-only, so running the bucket
brings PowerToys to the version-controlled desired state on every install and
update.

## What changed

- PowerToys package in `ClientBasePackages.ps1` now declares
  `ConfigScript = { Import-PowerToysSettings -NoRestart }` instead of
  `PostInstallScript`. `ConfigScript` is re-applied on EVERY install and update
  (idempotent desired-state configuration); `Import-PowerToysSettings` is
  already idempotent.
- Added a `HasConfigScript` projection to both the bundle probe
  (`Get-BundlePackages`) and the `Get-Package` flattener, per the bundle-loader
  contract (a new `[Package]` field surfaced through Get-Package must be added
  to both or it round-trips as null).
- Behavior-first test now pins `HasConfigScript` on the PowerToys package
  (fails behaviorally if the hook is removed or downgraded to PostInstallScript).
- Module bumped 1.3.0 -> 1.4.0.

## Behavior note

Because `ConfigScript` re-applies on every install/update, the committed
snapshot is the source of truth: re-running the bucket reverts PowerToys to the
version-controlled settings. `-NoRestart` keeps the apply non-disruptive (the
settings take effect the next time PowerToys starts).

## Testing

```powershell
Invoke-Pester -Path bucket\ClientBasePackagesPowerToys.Tests.ps1 -Output Detailed
.\bucket\Invoke-Tests.ps1
```

Full Light gate: 1567 passed, 0 failed.

Closes #368