### PR TITLE
fix(powertoys): restart collides with orphaned helper processes (Global mutex access-denied)

### DIFF
--- a/bucket/os/PowerToysSettingsBackup.Tests.ps1
+++ b/bucket/os/PowerToysSettingsBackup.Tests.ps1
@@ -164,10 +164,10 @@ Describe 'Stop-PowerToysProcess' -Tag 'Light' {
             [pscustomobject]@{ Id = 102; ProcessName = 'PowerToys.FancyZones' }
             [pscustomobject]@{ Id = 200; ProcessName = 'Notepad' }
         )
-        # Enumeration sees the whole family; the post-wait survivor re-query (by
-        # id) sees nothing -- the kill succeeded.
+        # Enumeration (by name) sees the whole family; the post-wait survivor
+        # re-query (by id) sees nothing -- the kill succeeded.
         Mock Get-Process { $script:fakeProcs } -ParameterFilter { $Name }
-        Mock Get-Process { @() }
+        Mock Get-Process { @() } -ParameterFilter { $Id }
         Mock Stop-Process { }
         Mock Wait-Process { }
     }

--- a/bucket/os/PowerToysSettingsBackup.Tests.ps1
+++ b/bucket/os/PowerToysSettingsBackup.Tests.ps1
@@ -153,3 +153,72 @@ Describe 'Restore-PowerToysSettings' -Tag 'Light' {
             Should -Throw '*No PowerToys backup*'
     }
 }
+
+Describe 'Stop-PowerToysProcess' -Tag 'Light' {
+    BeforeEach {
+        # Runner + two PowerToys.* helpers that hold the Global single-instance
+        # object, plus an unrelated process that must never be touched.
+        $script:fakeProcs = @(
+            [pscustomobject]@{ Id = 100; ProcessName = 'PowerToys' }
+            [pscustomobject]@{ Id = 101; ProcessName = 'PowerToys.Settings' }
+            [pscustomobject]@{ Id = 102; ProcessName = 'PowerToys.FancyZones' }
+            [pscustomobject]@{ Id = 200; ProcessName = 'Notepad' }
+        )
+        # Enumeration sees the whole family; the post-wait survivor re-query (by
+        # id) sees nothing -- the kill succeeded.
+        Mock Get-Process { $script:fakeProcs } -ParameterFilter { $Name }
+        Mock Get-Process { @() }
+        Mock Stop-Process { }
+        Mock Wait-Process { }
+    }
+
+    It 'stops the runner and its PowerToys.* helpers by id but leaves unrelated processes alone' {
+        Stop-PowerToysProcess
+
+        Should -Invoke Stop-Process -ParameterFilter { $Id -eq 100 } -Times 1 -Exactly
+        Should -Invoke Stop-Process -ParameterFilter { $Id -eq 101 } -Times 1 -Exactly
+        Should -Invoke Stop-Process -ParameterFilter { $Id -eq 102 } -Times 1 -Exactly
+        Should -Invoke Stop-Process -ParameterFilter { $Id -eq 200 } -Times 0 -Exactly
+    }
+
+    It 'waits for the killed PowerToys processes to exit before returning' {
+        Stop-PowerToysProcess
+
+        Should -Invoke Wait-Process -Times 1 -Exactly -ParameterFilter {
+            $Id -contains 100 -and $Id -contains 101 -and $Id -contains 102 -and $Id -notcontains 200
+        }
+    }
+
+    It 'warns when a PowerToys process survives the stop (an elevated kill refusal)' {
+        # The survivor re-query (by id) still finds the runner -- the kill was refused.
+        Mock Get-Process { @([pscustomobject]@{ Id = 100; ProcessName = 'PowerToys' }) } -ParameterFilter { $Id }
+        Mock Write-Warning { }
+
+        Stop-PowerToysProcess
+
+        Should -Invoke Write-Warning -ParameterFilter { $Message -like '*could not be fully stopped*' } -Times 1 -Exactly
+    }
+}
+
+Describe 'Start-PowerToysProcess' -Tag 'Light' {
+    BeforeEach {
+        Mock Start-Process { }
+        Mock Test-Path { $true }
+    }
+
+    It 'does not launch a second instance when PowerToys is already running' {
+        Mock Get-Process { @([pscustomobject]@{ Id = 100; ProcessName = 'PowerToys' }) }
+
+        Start-PowerToysProcess
+
+        Should -Invoke Start-Process -Times 0 -Exactly
+    }
+
+    It 'launches PowerToys once when none is running and the exe exists' {
+        Mock Get-Process { @() }
+
+        Start-PowerToysProcess
+
+        Should -Invoke Start-Process -Times 1 -Exactly
+    }
+}

--- a/bucket/os/PowerToysSettingsBackup.Tests.ps1
+++ b/bucket/os/PowerToysSettingsBackup.Tests.ps1
@@ -204,6 +204,7 @@ Describe 'Start-PowerToysProcess' -Tag 'Light' {
     BeforeEach {
         Mock Start-Process { }
         Mock Test-Path { $true }
+        Mock Write-Warning { }
     }
 
     It 'does not launch a second instance when PowerToys is already running' {
@@ -212,6 +213,7 @@ Describe 'Start-PowerToysProcess' -Tag 'Light' {
         Start-PowerToysProcess
 
         Should -Invoke Start-Process -Times 0 -Exactly
+        Should -Invoke Write-Warning -ParameterFilter { $Message -like '*already running*' } -Times 1 -Exactly
     }
 
     It 'launches PowerToys once when none is running and the exe exists' {

--- a/bucket/os/PowerToysSettingsBackup.Tests.ps1
+++ b/bucket/os/PowerToysSettingsBackup.Tests.ps1
@@ -223,4 +223,14 @@ Describe 'Start-PowerToysProcess' -Tag 'Light' {
 
         Should -Invoke Start-Process -Times 1 -Exactly
     }
+
+    It 'does not warn when PowerToys.exe is not found (best-effort, non-actionable)' {
+        Mock Get-Process { @() }
+        Mock Test-Path { $false }
+
+        Start-PowerToysProcess
+
+        Should -Invoke Start-Process -Times 0 -Exactly
+        Should -Invoke Write-Warning -Times 0 -Exactly
+    }
 }

--- a/bucket/os/PowerToysSettingsBackup.ps1
+++ b/bucket/os/PowerToysSettingsBackup.ps1
@@ -183,21 +183,40 @@ function Select-PowerToysBackupRelativePath {
 function Stop-PowerToysProcess {
     <#
     .SYNOPSIS
-        Stop any running PowerToys processes so settings can be replaced safely.
+        Stop the PowerToys runner and its helper processes so settings can be
+        replaced safely.
     .DESCRIPTION
-        Terminates each PowerToys process by id (never by name) so a settings
-        restore is not clobbered by the running app rewriting its files.
-        No-op when PowerToys is not running.
+        Terminates the runner ('PowerToys') AND every 'PowerToys.*' helper
+        (Settings, FancyZones, MouseWithoutBorders, KeyboardManagerEngine, ...)
+        by id (never by name) so a settings restore is not clobbered by the
+        running app and so the helpers release the
+        Global\PowerToys-<ver>-Default-1 single-instance object before any
+        restart. After issuing the stops it waits for the killed processes to
+        exit, and warns if any survive (for example when PowerToys runs elevated
+        and the kill is refused). No-op when PowerToys is not running.
     .OUTPUTS
         None.
     #>
     [CmdletBinding(SupportsShouldProcess)]
     param()
-    $procs = Get-Process -Name 'PowerToys' -ErrorAction SilentlyContinue
+    $procs = Get-Process -Name 'PowerToys*' -ErrorAction SilentlyContinue |
+        Where-Object { $_.ProcessName -like 'PowerToys*' }
+    $killed = [System.Collections.Generic.List[int]]::new()
     foreach ($proc in $procs) {
-        if ($PSCmdlet.ShouldProcess("PID $($proc.Id)", 'Stop PowerToys process')) {
+        if ($PSCmdlet.ShouldProcess("PID $($proc.Id) ($($proc.ProcessName))", 'Stop PowerToys process')) {
             Stop-Process -Id $proc.Id -Force -ErrorAction SilentlyContinue
+            $killed.Add($proc.Id)
         }
+    }
+    if ($killed.Count -eq 0) { return }
+    # Block until the killed processes exit so they release the Global
+    # single-instance/IPC object before any restart collides with it.
+    Wait-Process -Id $killed.ToArray() -Timeout 10 -ErrorAction SilentlyContinue
+    # Re-query exactly the ids we tried to kill; any that remain were refused
+    # (for example PowerToys running elevated while this session is not).
+    $survivors = @(Get-Process -Id $killed.ToArray() -ErrorAction SilentlyContinue)
+    if ($survivors.Count -gt 0) {
+        Write-Warning ("PowerToys could not be fully stopped; {0} process(es) still running. Close PowerToys manually or run elevated, then retry." -f $survivors.Count)
     }
 }
 
@@ -206,7 +225,10 @@ function Start-PowerToysProcess {
     .SYNOPSIS
         Relaunch PowerToys from a known install location, best-effort.
     .DESCRIPTION
-        Looks for PowerToys.exe under the per-user and machine install roots
+        No-ops with a warning when any PowerToys process is still running so a
+        second runner is never launched (a duplicate runner collides on the
+        Global single-instance object and crashes with access-denied). Otherwise
+        looks for PowerToys.exe under the per-user and machine install roots
         and starts the first match. Never throws -- restarting is a
         convenience, not a guarantee.
     .OUTPUTS
@@ -214,6 +236,12 @@ function Start-PowerToysProcess {
     #>
     [CmdletBinding(SupportsShouldProcess)]
     param()
+    $running = Get-Process -Name 'PowerToys*' -ErrorAction SilentlyContinue |
+        Where-Object { $_.ProcessName -like 'PowerToys*' }
+    if ($running) {
+        Write-Warning 'PowerToys is already running; not launching a second instance.'
+        return
+    }
     $candidates = @(
         (Join-Path $env:LOCALAPPDATA 'PowerToys\PowerToys.exe')
         (Join-Path $env:ProgramFiles 'PowerToys\PowerToys.exe')

--- a/bucket/os/PowerToysSettingsBackup.ps1
+++ b/bucket/os/PowerToysSettingsBackup.ps1
@@ -248,7 +248,7 @@ function Start-PowerToysProcess {
     )
     $exe = $candidates | Where-Object { $_ -and (Test-Path -LiteralPath $_) } | Select-Object -First 1
     if (-not $exe) {
-        Write-Warning 'PowerToys.exe not found in the known install locations; not restarting.'
+        Write-Verbose 'PowerToys.exe not found in the known install locations; not restarting.'
         return
     }
     if ($PSCmdlet.ShouldProcess($exe, 'Start PowerToys')) {

--- a/module/MarkMichaelis.ScoopBucket/Private/PowerToysSettings.ps1
+++ b/module/MarkMichaelis.ScoopBucket/Private/PowerToysSettings.ps1
@@ -352,21 +352,40 @@ function ConvertTo-PowerToysWriteSet {
 function Stop-PowerToysProcess {
     <#
     .SYNOPSIS
-        Stop any running PowerToys processes so settings can be replaced safely.
+        Stop the PowerToys runner and its helper processes so settings can be
+        replaced safely.
     .DESCRIPTION
-        Terminates each PowerToys process by id (never by name) so an apply is not
-        clobbered by the running app rewriting its files. No-op when PowerToys is
-        not running.
+        Terminates the runner ('PowerToys') AND every 'PowerToys.*' helper
+        (Settings, FancyZones, MouseWithoutBorders, KeyboardManagerEngine, ...)
+        by id (never by name) so an apply is not clobbered by the running app and
+        so the helpers release the Global\PowerToys-<ver>-Default-1
+        single-instance object before any restart. After issuing the stops it
+        waits for the killed processes to exit, and warns if any survive (for
+        example when PowerToys runs elevated and the kill is refused). No-op when
+        PowerToys is not running.
     .OUTPUTS
         None.
     #>
     [CmdletBinding(SupportsShouldProcess)]
     param()
-    $procs = Get-Process -Name 'PowerToys' -ErrorAction SilentlyContinue
+    $procs = Get-Process -Name 'PowerToys*' -ErrorAction SilentlyContinue |
+        Where-Object { $_.ProcessName -like 'PowerToys*' }
+    $killed = [System.Collections.Generic.List[int]]::new()
     foreach ($proc in $procs) {
-        if ($PSCmdlet.ShouldProcess("PID $($proc.Id)", 'Stop PowerToys process')) {
+        if ($PSCmdlet.ShouldProcess("PID $($proc.Id) ($($proc.ProcessName))", 'Stop PowerToys process')) {
             Stop-Process -Id $proc.Id -Force -ErrorAction SilentlyContinue
+            $killed.Add($proc.Id)
         }
+    }
+    if ($killed.Count -eq 0) { return }
+    # Block until the killed processes exit so they release the Global
+    # single-instance/IPC object before any restart collides with it.
+    Wait-Process -Id $killed.ToArray() -Timeout 10 -ErrorAction SilentlyContinue
+    # Re-query exactly the ids we tried to kill; any that remain were refused
+    # (for example PowerToys running elevated while this session is not).
+    $survivors = @(Get-Process -Id $killed.ToArray() -ErrorAction SilentlyContinue)
+    if ($survivors.Count -gt 0) {
+        Write-Warning ("PowerToys could not be fully stopped; {0} process(es) still running. Close PowerToys manually or run elevated, then retry." -f $survivors.Count)
     }
 }
 
@@ -375,13 +394,22 @@ function Start-PowerToysProcess {
     .SYNOPSIS
         Relaunch PowerToys from a known install location, best-effort.
     .DESCRIPTION
-        Looks for PowerToys.exe under the per-user and machine install roots and
+        No-ops with a warning when any PowerToys process is still running so a
+        second runner is never launched (a duplicate runner collides on the
+        Global single-instance object and crashes with access-denied). Otherwise
+        looks for PowerToys.exe under the per-user and machine install roots and
         starts the first match. Never throws -- restarting is a convenience.
     .OUTPUTS
         None.
     #>
     [CmdletBinding(SupportsShouldProcess)]
     param()
+    $running = Get-Process -Name 'PowerToys*' -ErrorAction SilentlyContinue |
+        Where-Object { $_.ProcessName -like 'PowerToys*' }
+    if ($running) {
+        Write-Warning 'PowerToys is already running; not launching a second instance.'
+        return
+    }
     $candidates = @(
         (Join-Path $env:LOCALAPPDATA 'PowerToys\PowerToys.exe')
         (Join-Path $env:ProgramFiles 'PowerToys\PowerToys.exe')

--- a/module/MarkMichaelis.ScoopBucket/Public/PowerToysSettings.Tests.ps1
+++ b/module/MarkMichaelis.ScoopBucket/Public/PowerToysSettings.Tests.ps1
@@ -194,10 +194,10 @@ Describe 'Stop-PowerToysProcess' -Tag 'Light', 'Module' {
             [pscustomobject]@{ Id = 102; ProcessName = 'PowerToys.FancyZones' }
             [pscustomobject]@{ Id = 200; ProcessName = 'Notepad' }
         )
-        # Enumeration sees the whole family; the post-wait survivor re-query (by
-        # id) sees nothing -- the kill succeeded.
+        # Enumeration (by name) sees the whole family; the post-wait survivor
+        # re-query (by id) sees nothing -- the kill succeeded.
         Mock -ModuleName MarkMichaelis.ScoopBucket Get-Process { $script:fakeProcs } -ParameterFilter { $Name }
-        Mock -ModuleName MarkMichaelis.ScoopBucket Get-Process { @() }
+        Mock -ModuleName MarkMichaelis.ScoopBucket Get-Process { @() } -ParameterFilter { $Id }
         Mock -ModuleName MarkMichaelis.ScoopBucket Stop-Process { }
         Mock -ModuleName MarkMichaelis.ScoopBucket Wait-Process { }
     }

--- a/module/MarkMichaelis.ScoopBucket/Public/PowerToysSettings.Tests.ps1
+++ b/module/MarkMichaelis.ScoopBucket/Public/PowerToysSettings.Tests.ps1
@@ -253,4 +253,14 @@ Describe 'Start-PowerToysProcess' -Tag 'Light', 'Module' {
 
         Should -Invoke -ModuleName MarkMichaelis.ScoopBucket Start-Process -Times 1 -Exactly
     }
+
+    It 'does not warn when PowerToys.exe is not found (best-effort, non-actionable)' {
+        Mock -ModuleName MarkMichaelis.ScoopBucket Get-Process { @() }
+        Mock -ModuleName MarkMichaelis.ScoopBucket Test-Path { $false }
+
+        & $script:mod { Start-PowerToysProcess }
+
+        Should -Invoke -ModuleName MarkMichaelis.ScoopBucket Start-Process -Times 0 -Exactly
+        Should -Invoke -ModuleName MarkMichaelis.ScoopBucket Write-Warning -Times 0 -Exactly
+    }
 }

--- a/module/MarkMichaelis.ScoopBucket/Public/PowerToysSettings.Tests.ps1
+++ b/module/MarkMichaelis.ScoopBucket/Public/PowerToysSettings.Tests.ps1
@@ -183,3 +183,72 @@ Describe 'Import-PowerToysSettings' -Tag 'Light', 'Module' {
             Should -Throw '*snapshot not found*'
     }
 }
+
+Describe 'Stop-PowerToysProcess' -Tag 'Light', 'Module' {
+    BeforeEach {
+        # Runner + two PowerToys.* helpers that hold the Global single-instance
+        # object, plus an unrelated process that must never be touched.
+        $script:fakeProcs = @(
+            [pscustomobject]@{ Id = 100; ProcessName = 'PowerToys' }
+            [pscustomobject]@{ Id = 101; ProcessName = 'PowerToys.Settings' }
+            [pscustomobject]@{ Id = 102; ProcessName = 'PowerToys.FancyZones' }
+            [pscustomobject]@{ Id = 200; ProcessName = 'Notepad' }
+        )
+        # Enumeration sees the whole family; the post-wait survivor re-query (by
+        # id) sees nothing -- the kill succeeded.
+        Mock -ModuleName MarkMichaelis.ScoopBucket Get-Process { $script:fakeProcs } -ParameterFilter { $Name }
+        Mock -ModuleName MarkMichaelis.ScoopBucket Get-Process { @() }
+        Mock -ModuleName MarkMichaelis.ScoopBucket Stop-Process { }
+        Mock -ModuleName MarkMichaelis.ScoopBucket Wait-Process { }
+    }
+
+    It 'stops the runner and its PowerToys.* helpers by id but leaves unrelated processes alone' {
+        & $script:mod { Stop-PowerToysProcess }
+
+        Should -Invoke -ModuleName MarkMichaelis.ScoopBucket Stop-Process -ParameterFilter { $Id -eq 100 } -Times 1 -Exactly
+        Should -Invoke -ModuleName MarkMichaelis.ScoopBucket Stop-Process -ParameterFilter { $Id -eq 101 } -Times 1 -Exactly
+        Should -Invoke -ModuleName MarkMichaelis.ScoopBucket Stop-Process -ParameterFilter { $Id -eq 102 } -Times 1 -Exactly
+        Should -Invoke -ModuleName MarkMichaelis.ScoopBucket Stop-Process -ParameterFilter { $Id -eq 200 } -Times 0 -Exactly
+    }
+
+    It 'waits for the killed PowerToys processes to exit before returning' {
+        & $script:mod { Stop-PowerToysProcess }
+
+        Should -Invoke -ModuleName MarkMichaelis.ScoopBucket Wait-Process -Times 1 -Exactly -ParameterFilter {
+            $Id -contains 100 -and $Id -contains 101 -and $Id -contains 102 -and $Id -notcontains 200
+        }
+    }
+
+    It 'warns when a PowerToys process survives the stop (an elevated kill refusal)' {
+        # The survivor re-query (by id) still finds the runner -- the kill was refused.
+        Mock -ModuleName MarkMichaelis.ScoopBucket Get-Process { @([pscustomobject]@{ Id = 100; ProcessName = 'PowerToys' }) } -ParameterFilter { $Id }
+        Mock -ModuleName MarkMichaelis.ScoopBucket Write-Warning { }
+
+        & $script:mod { Stop-PowerToysProcess }
+
+        Should -Invoke -ModuleName MarkMichaelis.ScoopBucket Write-Warning -ParameterFilter { $Message -like '*could not be fully stopped*' } -Times 1 -Exactly
+    }
+}
+
+Describe 'Start-PowerToysProcess' -Tag 'Light', 'Module' {
+    BeforeEach {
+        Mock -ModuleName MarkMichaelis.ScoopBucket Start-Process { }
+        Mock -ModuleName MarkMichaelis.ScoopBucket Test-Path { $true }
+    }
+
+    It 'does not launch a second instance when PowerToys is already running' {
+        Mock -ModuleName MarkMichaelis.ScoopBucket Get-Process { @([pscustomobject]@{ Id = 100; ProcessName = 'PowerToys' }) }
+
+        & $script:mod { Start-PowerToysProcess }
+
+        Should -Invoke -ModuleName MarkMichaelis.ScoopBucket Start-Process -Times 0 -Exactly
+    }
+
+    It 'launches PowerToys once when none is running and the exe exists' {
+        Mock -ModuleName MarkMichaelis.ScoopBucket Get-Process { @() }
+
+        & $script:mod { Start-PowerToysProcess }
+
+        Should -Invoke -ModuleName MarkMichaelis.ScoopBucket Start-Process -Times 1 -Exactly
+    }
+}

--- a/module/MarkMichaelis.ScoopBucket/Public/PowerToysSettings.Tests.ps1
+++ b/module/MarkMichaelis.ScoopBucket/Public/PowerToysSettings.Tests.ps1
@@ -234,6 +234,7 @@ Describe 'Start-PowerToysProcess' -Tag 'Light', 'Module' {
     BeforeEach {
         Mock -ModuleName MarkMichaelis.ScoopBucket Start-Process { }
         Mock -ModuleName MarkMichaelis.ScoopBucket Test-Path { $true }
+        Mock -ModuleName MarkMichaelis.ScoopBucket Write-Warning { }
     }
 
     It 'does not launch a second instance when PowerToys is already running' {
@@ -242,6 +243,7 @@ Describe 'Start-PowerToysProcess' -Tag 'Light', 'Module' {
         & $script:mod { Start-PowerToysProcess }
 
         Should -Invoke -ModuleName MarkMichaelis.ScoopBucket Start-Process -Times 0 -Exactly
+        Should -Invoke -ModuleName MarkMichaelis.ScoopBucket Write-Warning -ParameterFilter { $Message -like '*already running*' } -Times 1 -Exactly
     }
 
     It 'launches PowerToys once when none is running and the exe exists' {


### PR DESCRIPTION
## Summary

`Import-PowerToysSettings` (module) and `Restore-PowerToysSettings` (bucket bundle)
restart PowerToys after writing settings, and the restart crashed with:

```
Unhandled exception ... Access to the path 'Global\PowerToys-0.99.1.0-Default-1' is denied.
```

## Root cause

`Stop-PowerToysProcess` ran `Get-Process -Name 'PowerToys'` (EXACT name), matching only
the runner `PowerToys.exe`. The `PowerToys.*` helper processes (Settings, FancyZones,
MouseWithoutBorders, KeyboardManagerEngine, ...) were orphaned and kept holding the
`Global\PowerToys-<ver>-Default-1` single-instance/IPC object, so the immediate
`Start-PowerToysProcess` launched a fresh runner that collided -> access-denied crash.
A compounding factor: if a kill is refused (PowerToys running elevated while the cmdlet is
not), survivors remained and the restart still collided.

## Fix (applied identically in both duplicated copies)

- `module/MarkMichaelis.ScoopBucket/Private/PowerToysSettings.ps1`
- `bucket/os/PowerToysSettingsBackup.ps1`

`Stop-PowerToysProcess`:
- Selects the whole family -- `Get-Process -Name 'PowerToys*'` filtered to
  `ProcessName -like 'PowerToys*'` -- still terminating BY ID (`Stop-Process -Id`),
  preserving the "by id, never by name" convention.
- `Wait-Process -Id <killedIds> -Timeout 10` after the stops so the Global object is
  released before any restart.
- Re-queries the killed ids and `Write-Warning`s when any survive, so the caller does not
  crash-restart silently.

`Start-PowerToysProcess`:
- BEFORE launching, if any PowerToys process is still running it no-ops with a
  `Write-Warning` ("PowerToys is already running; not launching a second instance") and
  returns. Otherwise it launches `PowerToys.exe` from the known install locations exactly
  as before.
- The missing-exe path now logs at `Write-Verbose` in BOTH copies (the bucket copy used
  `Write-Warning`); missing PowerToys is a normal, non-actionable situation, and the two
  copies are meant to stay behaviorally identical.

## Tests (behavior-first)

New Describe blocks in BOTH test files, tagged for the Light gate
(`'Light','Module'` for the module file with `Mock -ModuleName`; `'Light'` for the
dot-sourced bucket file). 12 new tests (6 per file) pin:
- the family stop kills the runner + `PowerToys.*` helpers but never an unrelated process
  (Notepad);
- `Wait-Process` runs for the killed ids;
- a survivor triggers the "could not be fully stopped" warning;
- `Start` does not launch a second instance and emits the "already running" warning when
  PowerToys is already running;
- `Start` launches exactly once when none is running;
- `Start` does not warn (no noisy `Write-Warning`) when `PowerToys.exe` is not found.

RED was verified by reverting only the source code: the new assertions fail against the
original/un-aligned code (e.g. `Stop-Process` called for the unrelated Notepad id,
`Wait-Process` called 0 times, no second-instance guard, missing `already running`
warning, and the bucket missing-exe path emitting a `Write-Warning`); all pass after the
fix.

## Verification

- Light gate (new tests RUN and pass; whole suite green):
  ```
  pwsh -NoProfile -File bucket/Invoke-Tests.ps1
  ```
  Result: Tests Passed: 1582, Failed: 0, Skipped: 3, NotRun: 106 (the 12 new PowerToys
  tests run under the Light tag; PowerToys-only run: 43 passed, 0 failed).
- PSScriptAnalyzer: no new findings on the changed functions (pre-existing Write-Host /
  plural-noun findings are in untouched code).
- Dry run -- `Import-PowerToysSettings -WhatIf` on a machine with PowerToys actually
  running: no exception thrown, `FileCount = 0` (nothing written under `-WhatIf`), and the
  start guard fired ("PowerToys is already running; not launching a second instance").
  No crash path.
- Copilot review addressed across follow-up commits (constrain the survivor re-query mock
  to `-Id`; assert the user-facing "already running" warning; align the bucket missing-exe
  log to `Write-Verbose`). All review threads resolved; the latest review introduced zero
  new threads.

Closes #372