### PR TITLE
feat(onedrive): interactive kill/recheck for move blockers

### DIFF
--- a/bucket/os/MarkMichaelisOneDriveConfiguration.Tests.ps1
+++ b/bucket/os/MarkMichaelisOneDriveConfiguration.Tests.ps1
@@ -1969,49 +1969,130 @@ Describe 'Invoke-MarkMichaelisOneDriveConfiguration open-handle pre-flight' -Tag
         Mock -CommandName Get-Process -MockWith { $null }
     }
 
-    It 'aborts before any mutation when an open handle blocks a planned move' {
-        Mock -CommandName Get-OneDriveMoveBlocker -MockWith {
-            @([pscustomobject]@{ Process = 'SnagitEditor.exe'; Id = 999; Path = 'C:\Users\me\OneDrive - IntelliTect\x.snagx' })
+    It 'aborts before any mutation when the user aborts at the blocker prompt' {
+        Mock -CommandName Invoke-OneDriveMoveBlockerResolution -MockWith {
+            throw 'Open file handles still block the OneDrive folder move. Close the listed applications and re-run. No changes were made.'
         }
 
         {
             Invoke-MarkMichaelisOneDriveConfiguration -RootDir 'C:\OneDrive' -KfmOwner 'Michaelis' -FreshSync @() -Confirm:$false -WarningAction SilentlyContinue
-        } | Should -Throw -ExpectedMessage '*SnagitEditor.exe*'
+        } | Should -Throw -ExpectedMessage '*still block the OneDrive folder move*'
 
         Should -Invoke Stop-OneDriveExe -Times 0
         Should -Invoke Move-OneDriveFolder -Times 0
         Should -Invoke Export-OneDriveRegistryBackup -Times 0
     }
 
-    It 'proceeds with the migration when -SkipOpenHandleCheck is passed even if blockers exist' {
-        Mock -CommandName Get-OneDriveMoveBlocker -MockWith {
-            @([pscustomobject]@{ Process = 'SnagitEditor.exe'; Id = 999; Path = 'C:\Users\me\OneDrive - IntelliTect\x.snagx' })
-        }
-
-        Invoke-MarkMichaelisOneDriveConfiguration -RootDir 'C:\OneDrive' -KfmOwner 'Michaelis' -FreshSync @() -SkipOpenHandleCheck -Confirm:$false
-
-        Should -Invoke Get-OneDriveMoveBlocker -Times 0
-        Should -Invoke Move-OneDriveFolder -Times 1
-    }
-
-    It 'proceeds normally when no blockers are found' {
-        Mock -CommandName Get-OneDriveMoveBlocker -MockWith { @() }
+    It 'proceeds with the migration after the blocker resolution returns clear' {
+        Mock -CommandName Invoke-OneDriveMoveBlockerResolution
 
         Invoke-MarkMichaelisOneDriveConfiguration -RootDir 'C:\OneDrive' -KfmOwner 'Michaelis' -FreshSync @() -Confirm:$false
 
-        Should -Invoke Get-OneDriveMoveBlocker -Times 1
+        Should -Invoke Invoke-OneDriveMoveBlockerResolution -Times 1
         Should -Invoke Move-OneDriveFolder -Times 1
     }
 
-    It 'reports blockers informationally under -WhatIf without throwing' {
+    It 'reports blockers informationally under -WhatIf without prompting or throwing' {
         Mock -CommandName Get-OneDriveMoveBlocker -MockWith {
             @([pscustomobject]@{ Process = 'SnagitEditor.exe'; Id = 999; Path = 'C:\Users\me\OneDrive - IntelliTect\x.snagx' })
         }
+        Mock -CommandName Invoke-OneDriveMoveBlockerResolution
 
         {
             Invoke-MarkMichaelisOneDriveConfiguration -RootDir 'C:\OneDrive' -KfmOwner 'Michaelis' -FreshSync @() -WhatIf -WarningAction SilentlyContinue
         } | Should -Not -Throw
 
+        Should -Invoke Invoke-OneDriveMoveBlockerResolution -Times 0
         Should -Invoke Move-OneDriveFolder -Times 0
+    }
+}
+
+Describe 'Invoke-OneDriveMoveBlockerResolution' -Tag 'Light' {
+    BeforeEach {
+        Mock -CommandName Stop-Process
+        Mock -CommandName Start-Sleep
+        Mock -CommandName Read-OneDriveBlockerAction -MockWith { 'Recheck' }
+    }
+
+    It 'returns without prompting when the first scan is clear' {
+        Mock -CommandName Get-OneDriveMoveBlocker -MockWith { @() }
+
+        Invoke-OneDriveMoveBlockerResolution -Root @('C:\Users\me\OneDrive - Foo') -Confirm:$false
+
+        Should -Invoke Read-OneDriveBlockerAction -Times 0
+        Should -Invoke Stop-Process -Times 0
+    }
+
+    It 'stops each blocking process when the user chooses Kill, then returns once clear' {
+        $script:scanCount = 0
+        Mock -CommandName Get-OneDriveMoveBlocker -MockWith {
+            $script:scanCount++
+            if ($script:scanCount -eq 1) {
+                @([pscustomobject]@{ Process = 'SnagitEditor.exe'; Id = 999; Path = 'C:\Users\me\OneDrive - Foo\a.snagx' })
+            } else { @() }
+        }
+        Mock -CommandName Read-OneDriveBlockerAction -MockWith { 'Kill' }
+
+        Invoke-OneDriveMoveBlockerResolution -Root @('C:\Users\me\OneDrive - Foo') -Confirm:$false -WarningAction SilentlyContinue
+
+        Should -Invoke Stop-Process -Times 1 -ParameterFilter { $Id -eq 999 }
+    }
+
+    It 'rescans without killing when the user chooses Recheck' {
+        $script:scanCount = 0
+        Mock -CommandName Get-OneDriveMoveBlocker -MockWith {
+            $script:scanCount++
+            if ($script:scanCount -eq 1) {
+                @([pscustomobject]@{ Process = 'Code.exe'; Id = 222; Path = 'C:\Users\me\OneDrive - Foo\notes.md' })
+            } else { @() }
+        }
+        Mock -CommandName Read-OneDriveBlockerAction -MockWith { 'Recheck' }
+
+        Invoke-OneDriveMoveBlockerResolution -Root @('C:\Users\me\OneDrive - Foo') -Confirm:$false -WarningAction SilentlyContinue
+
+        Should -Invoke Read-OneDriveBlockerAction -Times 1
+        Should -Invoke Stop-Process -Times 0
+    }
+
+    It 'throws when the user chooses Abort' {
+        Mock -CommandName Get-OneDriveMoveBlocker -MockWith {
+            @([pscustomobject]@{ Process = 'WINWORD.EXE'; Id = 333; Path = 'C:\Users\me\OneDrive - Foo\report.docx' })
+        }
+        Mock -CommandName Read-OneDriveBlockerAction -MockWith { 'Abort' }
+
+        {
+            Invoke-OneDriveMoveBlockerResolution -Root @('C:\Users\me\OneDrive - Foo') -Confirm:$false -WarningAction SilentlyContinue
+        } | Should -Throw -ExpectedMessage '*still block the OneDrive folder move*'
+
+        Should -Invoke Stop-Process -Times 0
+    }
+
+    It 'does not stop processes under -WhatIf (ShouldProcess gate)' {
+        Mock -CommandName Get-OneDriveMoveBlocker -MockWith {
+            @([pscustomobject]@{ Process = 'SnagitEditor.exe'; Id = 999; Path = 'C:\Users\me\OneDrive - Foo\a.snagx' })
+        }
+        Mock -CommandName Read-OneDriveBlockerAction -MockWith { 'Kill' }
+
+        {
+            Invoke-OneDriveMoveBlockerResolution -Root @('C:\Users\me\OneDrive - Foo') -WhatIf -WarningAction SilentlyContinue
+        } | Should -Throw
+
+        Should -Invoke Stop-Process -Times 0
+    }
+}
+
+Describe 'Get-OneDriveBlockerProcess' -Tag 'Light' {
+    It 'collapses per-handle records into one record per process with a handle count' {
+        $blockers = @(
+            [pscustomobject]@{ Process = 'SnagitEditor.exe'; Id = 999; Path = 'C:\Users\me\OneDrive - Foo\a.snagx' }
+            [pscustomobject]@{ Process = 'SnagitEditor.exe'; Id = 999; Path = 'C:\Users\me\OneDrive - Foo\b.snagx' }
+            [pscustomobject]@{ Process = 'Code.exe'; Id = 222; Path = 'C:\Users\me\OneDrive - Foo\notes.md' }
+        )
+
+        $result = @(Get-OneDriveBlockerProcess -Blocker $blockers)
+
+        $result.Count | Should -Be 2
+        ($result | Where-Object Id -eq 999).HandleCount | Should -Be 2
+        ($result | Where-Object Id -eq 222).HandleCount | Should -Be 1
     }
 }

--- a/bucket/os/MarkMichaelisOneDriveConfiguration.ps1
+++ b/bucket/os/MarkMichaelisOneDriveConfiguration.ps1
@@ -142,17 +142,6 @@
     Policy) and you intentionally want to preview or run the remaining
     per-user work from a non-elevated shell.
 
-.PARAMETER SkipOpenHandleCheck
-    Bypass the open-file-handle pre-flight. By default, before executing
-    the plan the script scans each move-source folder (via Sysinternals
-    'handle') for files held open by other applications -- those open
-    handles would otherwise abort the same-volume rename with a sharing
-    violation mid-run. When blockers are found, a real run stops before
-    any mutation and lists the offending processes; under -WhatIf they
-    are reported as a warning only. Pass this switch to skip the scan
-    (for example when 'handle' is unavailable or you have already closed
-    the apps).
-
 .EXAMPLE
     .\MarkMichaelisOneDriveConfiguration.ps1 -WhatIf
 
@@ -228,8 +217,7 @@ param(
     [string[]] $FreshSync = @(),
     [switch] $DeleteSourceOnSuccess,
     [switch] $ForceHydrate,
-    [switch] $SkipElevationCheck,
-    [switch] $SkipOpenHandleCheck
+    [switch] $SkipElevationCheck
 )
 
 $ErrorActionPreference = 'Stop'
@@ -2172,7 +2160,7 @@ function Get-OneDriveMoveBlocker {
 
     $handleExe = Resolve-OneDriveHandleExe
     if (-not $handleExe) {
-        Write-Warning "Open-handle pre-flight skipped: Sysinternals 'handle' was not found on PATH (install with 'scoop install sysinternals'). A file left open under a move source could still abort the migration mid-run. Pass -SkipOpenHandleCheck to silence this warning."
+        Write-Warning "Open-handle pre-flight skipped: Sysinternals 'handle' was not found on PATH (install with 'scoop install sysinternals'). A file left open under a move source could still abort the migration mid-run."
         return
     }
 
@@ -2181,6 +2169,133 @@ function Get-OneDriveMoveBlocker {
             Where-Object { $_ -match 'pid:' })
 
     ConvertFrom-OneDriveHandleOutput -Line $rawLines -Root $roots -IncludeOneDriveProcesses:$IncludeOneDriveProcesses
+}
+
+function Get-OneDriveBlockerProcess {
+    <#
+    .SYNOPSIS
+        Collapse the per-handle blocker records into one record per process
+        instance (Process + Id), with the handle count and example paths.
+    .OUTPUTS
+        PSCustomObject (Process, Id, HandleCount, Paths) per blocking process.
+    #>
+    [CmdletBinding()]
+    [OutputType([pscustomobject])]
+    param(
+        [Parameter(Mandatory)][AllowEmptyCollection()][pscustomobject[]]$Blocker
+    )
+
+    $Blocker | Group-Object Id | ForEach-Object {
+        [pscustomobject]@{
+            Process     = $_.Group[0].Process
+            Id          = [int]$_.Name
+            HandleCount = $_.Count
+            Paths       = @($_.Group.Path)
+        }
+    } | Sort-Object Process, Id
+}
+
+function Write-OneDriveBlockerReport {
+    <#
+    .SYNOPSIS
+        Warn about the processes whose open handles would block a same-volume
+        OneDrive folder move, one line per process instance.
+    #>
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)][AllowEmptyCollection()][pscustomobject[]]$Process
+    )
+
+    Write-Warning 'Open file handles under the OneDrive move source(s) would block the same-volume folder rename:'
+    foreach ($p in $Process) {
+        $example = $p.Paths | Select-Object -First 1
+        Write-Warning ('  {0} (PID {1}) holds {2} open handle(s), e.g. {3}' -f $p.Process, $p.Id, $p.HandleCount, $example)
+    }
+}
+
+function Read-OneDriveBlockerAction {
+    <#
+    .SYNOPSIS
+        Prompt the user for how to handle the open-handle blockers: stop the
+        listed processes, recheck after closing apps manually, or abort.
+    .OUTPUTS
+        System.String -- one of 'Kill', 'Recheck', 'Abort'.
+    #>
+    [CmdletBinding()]
+    [OutputType([string])]
+    param(
+        [Parameter(Mandatory)][AllowEmptyCollection()][pscustomobject[]]$Process
+    )
+
+    $kill = [System.Management.Automation.Host.ChoiceDescription]::new(
+        '&Kill', 'Stop the listed process(es) now, then recheck.')
+    $recheck = [System.Management.Automation.Host.ChoiceDescription]::new(
+        '&Recheck', "Recheck after you've closed the apps yourself.")
+    $abort = [System.Management.Automation.Host.ChoiceDescription]::new(
+        '&Abort', 'Abort the migration without changing anything.')
+    $choices = [System.Management.Automation.Host.ChoiceDescription[]]@($kill, $recheck, $abort)
+
+    $caption = 'Open file handles block the OneDrive folder move'
+    $message = '{0} process(es) hold an open handle. Choose how to proceed:' -f @($Process).Count
+    $selection = $Host.UI.PromptForChoice($caption, $message, $choices, 1)
+
+    switch ($selection) {
+        0 { 'Kill' }
+        1 { 'Recheck' }
+        default { 'Abort' }
+    }
+}
+
+function Invoke-OneDriveMoveBlockerResolution {
+    <#
+    .SYNOPSIS
+        Pre-flight gate: loop until no process holds an open handle under a
+        OneDrive move source, prompting the user to stop the offending
+        processes or recheck, and aborting (throwing) on request.
+    .DESCRIPTION
+        On each pass the open handles are rescanned. When blockers remain the
+        user is prompted: Kill stops each process (guarded by ShouldProcess so
+        it honours -WhatIf / -Confirm), Recheck rescans after the user closes
+        apps manually, and Abort throws before any migration mutation. The loop
+        exits cleanly once the scan is clear.
+    #>
+    [CmdletBinding(SupportsShouldProcess)]
+    param(
+        [Parameter(Mandatory)][string[]]$Root
+    )
+
+    $abortMessage = 'Open file handles still block the OneDrive folder move. Close the listed applications and re-run. No changes were made.'
+
+    while ($true) {
+        $blockers = @(Get-OneDriveMoveBlocker -Root $Root)
+        if ($blockers.Count -eq 0) { return }
+
+        $processes = @(Get-OneDriveBlockerProcess -Blocker $blockers)
+        Write-OneDriveBlockerReport -Process $processes
+
+        $action = Read-OneDriveBlockerAction -Process $processes
+        if ($action -eq 'Abort') {
+            throw $abortMessage
+        }
+        if ($action -eq 'Kill') {
+            $stopped = 0
+            foreach ($p in $processes) {
+                $target = '{0} (PID {1})' -f $p.Process, $p.Id
+                if ($PSCmdlet.ShouldProcess($target, 'Stop process holding open handle(s) under a OneDrive move source')) {
+                    try {
+                        Stop-Process -Id $p.Id -Force -ErrorAction Stop
+                        $stopped++
+                    } catch {
+                        Write-Warning ('Failed to stop {0}: {1}' -f $target, $_.Exception.Message)
+                    }
+                }
+            }
+            if ($stopped -eq 0) {
+                throw $abortMessage
+            }
+            Start-Sleep -Milliseconds 500
+        }
+    }
 }
 
 function Invoke-MarkMichaelisOneDriveConfiguration {
@@ -2195,7 +2310,6 @@ function Invoke-MarkMichaelisOneDriveConfiguration {
         [switch]$DeleteSourceOnSuccess,
         [switch]$ForceHydrate,
         [switch]$SkipElevationCheck,
-        [switch]$SkipOpenHandleCheck,
         [bool]$IsElevated = $true
     )
 
@@ -2240,21 +2354,15 @@ function Invoke-MarkMichaelisOneDriveConfiguration {
             ForEach-Object { $_.CurrentValue }
     ) | Select-Object -Unique
 
-    if (-not $SkipOpenHandleCheck -and $moveSources.Count -gt 0) {
-        $blockers = @(Get-OneDriveMoveBlocker -Root $moveSources)
-        if ($blockers.Count -gt 0) {
-            $procSummary = ($blockers |
-                    Group-Object Process |
-                    Sort-Object Name |
-                    ForEach-Object { '{0} (PID {1})' -f $_.Name, (($_.Group.Id | Sort-Object -Unique) -join ', ') }) -join '; '
-            Write-Warning ('Open file handles under {0} OneDrive move source(s) would block the same-volume folder rename:' -f $moveSources.Count)
-            foreach ($b in ($blockers | Sort-Object Process, Id, Path)) {
-                Write-Warning ('  {0} (PID {1}) -> {2}' -f $b.Process, $b.Id, $b.Path)
+    if ($moveSources.Count -gt 0) {
+        if ($WhatIfPreference) {
+            $blockers = @(Get-OneDriveMoveBlocker -Root $moveSources)
+            if ($blockers.Count -gt 0) {
+                Write-OneDriveBlockerReport -Process (Get-OneDriveBlockerProcess -Blocker $blockers)
+                Write-Warning 'WhatIf: a real run would prompt to stop these processes or recheck before moving any folder.'
             }
-            Write-Warning 'Close the listed applications (save your work first), or re-run with -SkipOpenHandleCheck to override.'
-            if (-not $WhatIfPreference) {
-                throw "Open file handles block the OneDrive folder move ($($blockers.Count) handle(s) across $($moveSources.Count) source(s)): $procSummary. Close them and re-run, or pass -SkipOpenHandleCheck to override. No changes were made."
-            }
+        } else {
+            Invoke-OneDriveMoveBlockerResolution -Root $moveSources
         }
     }
 
@@ -2333,5 +2441,5 @@ if ($MyInvocation.InvocationName -ne '.') {
         -KfmOwnerContains:$KfmOwnerContains -NoKfmRebind:$NoKfmRebind `
         -NoFolderDescriptionsWrite:$NoFolderDescriptionsWrite -FreshSync $FreshSync `
         -DeleteSourceOnSuccess:$DeleteSourceOnSuccess -ForceHydrate:$ForceHydrate `
-        -SkipElevationCheck:$SkipElevationCheck -SkipOpenHandleCheck:$SkipOpenHandleCheck -IsElevated $__mmodIsElevated
+        -SkipElevationCheck:$SkipElevationCheck -IsElevated $__mmodIsElevated
 }


### PR DESCRIPTION
## Summary

Replaces the `-SkipOpenHandleCheck` bypass switch (added in #379) with an
interactive resolution prompt when open file handles block a OneDrive folder
move.

When blockers are detected on a real run, the user is prompted per the listed
processes:

- **Kill** -- stop each blocking process (gated by ShouldProcess, so it honours
  `-WhatIf` / `-Confirm`), then rescan.
- **Recheck** -- rescan after closing the apps manually (default).
- **Abort** -- stop without making any changes.

Under `-WhatIf` the orchestrator only reports blockers informationally -- it
never prompts and never throws.

## Changes

- Removed `-SkipOpenHandleCheck` from the script param block, the orchestrator
  function, the run-guard invocation, and help.
- Added `Get-OneDriveBlockerProcess`, `Write-OneDriveBlockerReport`,
  `Read-OneDriveBlockerAction`, and `Invoke-OneDriveMoveBlockerResolution`.
- `Invoke-OneDriveMoveBlockerResolution` is `SupportsShouldProcess` and
  wraps the destructive `Stop-Process -Force` in `ShouldProcess`; if nothing
  is stopped (all denied / `-WhatIf`) it throws a safe-abort message instead
  of looping.

## Tests

`pwsh -NoProfile -File bucket\Invoke-Tests.ps1 -Pattern MarkMichaelisOneDriveConfiguration`

- 91 passed, 0 failed.
- New coverage for the resolution loop (clear / Kill / Recheck / Abort /
  ShouldProcess gate) and `Get-OneDriveBlockerProcess`.
- No net-new PSScriptAnalyzer findings.

Closes #380