### PR TITLE
docs(aiagents): clarify Claude Design has no separate install

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,11 @@ scripts: base packages for client, developer, and AI workflows; an
 and a curated set of MCP servers; and miscellaneous one-shot system
 configurations.
 
+> **Claude Design** has no separate installer: use Claude Code's `/design`
+> (and `/design-sync`) to work on design projects in a local folder, or the web
+> canvas at [`claude.ai/design`](https://claude.ai/design). It also surfaces in
+> the Claude Desktop sidebar once Anthropic enables the rollout for your account.
+
 ## Bootstrap
 
 ```powershell

--- a/bucket/AIAgents.json
+++ b/bucket/AIAgents.json
@@ -1,6 +1,6 @@
 {
     "$schema": "https://raw.githubusercontent.com/lukesampson/scoop/master/schema.json",
-    "version": "1.23.000",
+    "version": "1.24.000",
     "url": [
         "https://raw.githubusercontent.com/MarkMichaelis/ScoopBucket/main/bucket/AIAgents.ps1"
     ],

--- a/bucket/AIAgents.ps1
+++ b/bucket/AIAgents.ps1
@@ -245,6 +245,14 @@ foreach (`$pair in @(
             }
         }
     }
+    # Claude Design (claude.ai/design) has NO separate installer -- it is a
+    # surface of the Claude ecosystem, not a package, so there is deliberately
+    # no ClaudeDesign manifest. Its local-project-directory workflow ships
+    # through THIS `claude` CLI: `/design` imports/edits/syncs a design project
+    # inside your codebase and `/design-sync` pulls a design system in. The
+    # visual canvas lives at claude.ai/design and appears in the Claude Desktop
+    # sidebar (Chat / Cowork / Code / Design) once Anthropic enables its gated
+    # rollout for your account. Nothing to install here beyond Claude Code.
     [Package]@{
         Name        = 'Claude Code CLI'
         Installer   = 'scoop'
@@ -252,7 +260,7 @@ foreach (`$pair in @(
         CliCommands = @('claude')
         DependsOn   = @('Node.js')
         Completion  = 'auto'
-        Notes       = 'claude has no completion subcommand and no PSCompletions entry. Hand-curated top-level command list.'
+        Notes       = 'claude has no completion subcommand and no PSCompletions entry. Hand-curated top-level command list. Also the install home for Claude Design''s local-project workflow (/design, /design-sync); claude.ai/design is the web canvas and there is no separate ClaudeDesign package.'
         ExpectedCompletions = @{ claude = @('--help','--version','mcp') }
         NativeCommandScript = {
             @"


### PR DESCRIPTION
## Summary

Documents that **Claude Design** has no separate installer -- it is a surface of
the Claude ecosystem, not a package. There is deliberately no `ClaudeDesign`
manifest.

- **Local project directories** -> the already-installed **Claude Code** CLI via
  `/design` and `/design-sync` (import/edit/sync a design project in a codebase).
- **Web canvas** -> `claude.ai/design` (and the Claude Desktop sidebar once
  Anthropic enables its gated rollout for the account).

## Changes

- `bucket/AIAgents.ps1` -- comment block above the Claude Code CLI package plus a
  `Notes` pointer explaining the Claude Design relationship.
- `bucket/AIAgents.json` -- version bump `1.23.000` -> `1.24.000` (required: the
  manifest references `AIAgents.ps1`).
- `README.md` -- one-line discoverability note in the intro.

## Validation

- `AIAgents.ps1` parses cleanly.
- `Test-ManifestVersionBumps.ps1` -> "All 4 manifest(s) have up-to-date version bumps."
- `Invoke-Pester bucket/Bundles.Tests.ps1` -> 806 passed, 0 failed, 1 skipped.

Documentation-only; the installed package set is unchanged, so no new tests.

Closes #384