### PR TITLE
feat(bundles): add Lazygit, Tailscale, Parsec, and enable Remote Desktop

### DIFF
--- a/bucket/DeveloperBasePackages.json
+++ b/bucket/DeveloperBasePackages.json
@@ -1,6 +1,6 @@
 {
     "$schema": "https://raw.githubusercontent.com/lukesampson/scoop/master/schema.json",
-    "version": "1.25.000",
+    "version": "1.26.000",
     "url": [
         "https://raw.githubusercontent.com/MarkMichaelis/ScoopBucket/main/bucket/DeveloperBasePackages.ps1"
     ],

--- a/bucket/DeveloperBasePackages.ps1
+++ b/bucket/DeveloperBasePackages.ps1
@@ -97,6 +97,31 @@ Register-ArgumentCompleter -Native -CommandName devenv -ScriptBlock {
     }
 
     [Package]@{
+        Name        = 'Lazygit'
+        Installer   = 'winget'
+        Id          = 'JesseDuffield.lazygit'
+        CliCommands = @('lazygit')
+        Completion  = 'auto'
+        Notes       = 'lazygit is a terminal UI for git; its CLI surface is a small set of setup flags (no `lazygit completion powershell` subcommand and no PSCompletions catalog entry). Hand-curated flag list mirrors bat/fzf/code in the bucket.'
+        ExpectedCompletions = @{ lazygit = @('--help','--version','--config') }
+        NativeCommandScript = {
+            @"
+Register-ArgumentCompleter -Native -CommandName lazygit -ScriptBlock {
+    param(`$wordToComplete, `$commandAst, `$cursorPosition)
+    @(
+        '--help','-h','--version','-v','--debug','-d','--config','-c',
+        '--print-config-dir','-cd','--use-config-dir','-ucd','--path','-p',
+        '--filter','-f','--git-dir','-g','--work-tree','-w','--screen-mode','-sm',
+        '--profile','-pf','--tail','-t'
+    ) | Where-Object { `$_ -like "`$wordToComplete*" } | ForEach-Object {
+        [System.Management.Automation.CompletionResult]::new(`$_, `$_, 'ParameterValue', `$_)
+    }
+}
+"@
+        }
+    }
+
+    [Package]@{
         Name        = 'Visual Studio Code'
         Installer   = 'winget'
         Id          = 'Microsoft.VisualStudioCode'

--- a/bucket/OSBasePackages.json
+++ b/bucket/OSBasePackages.json
@@ -1,6 +1,6 @@
 {
     "$schema": "https://raw.githubusercontent.com/lukesampson/scoop/master/schema.json",
-    "version": "1.31.000",
+    "version": "1.32.000",
     "url": [
         "https://raw.githubusercontent.com/MarkMichaelis/ScoopBucket/main/bucket/OSBasePackages.ps1"
     ],

--- a/bucket/OSBasePackages.ps1
+++ b/bucket/OSBasePackages.ps1
@@ -85,6 +85,8 @@ Register-ArgumentCompleter -Native -CommandName es -ScriptBlock {
     [Package]@{ Name = 'Google Chrome';                 Installer = 'winget'; Id = 'Google.Chrome' }
     [Package]@{ Name = 'WinDirStat';                    Installer = 'winget'; Id = 'WinDirStat.WinDirStat' }
     [Package]@{ Name = 'UniversalSilentSwitchFinder';   Installer = 'winget'; Id = 'WindowsPostInstallWizard.UniversalSilentSwitchFinder' }
+    [Package]@{ Name = 'Tailscale';                     Installer = 'winget'; Id = 'Tailscale.Tailscale' }
+    [Package]@{ Name = 'Parsec';                        Installer = 'winget'; Id = 'Parsec.Parsec' }
     [Package]@{
         Name        = 'bat'
         Installer   = 'winget'

--- a/bucket/os/EnableRemoteDesktop.json
+++ b/bucket/os/EnableRemoteDesktop.json
@@ -1,0 +1,12 @@
+{
+    "$schema": "https://raw.githubusercontent.com/lukesampson/scoop/master/schema.json",
+    "version": "1.00.000",
+    "url": ["https://raw.githubusercontent.com/MarkMichaelis/ScoopBucket/main/bucket/_placeholder"],
+    "installer": {
+        "script": [
+            "Set-ItemProperty -Path 'HKLM:\\SYSTEM\\CurrentControlSet\\Control\\Terminal Server' -Name 'fDenyTSConnections' -Value 0 -Type DWord",
+            "Set-ItemProperty -Path 'HKLM:\\SYSTEM\\CurrentControlSet\\Control\\Terminal Server\\WinStations\\RDP-Tcp' -Name 'UserAuthentication' -Value 1 -Type DWord",
+            "Enable-NetFirewallRule -DisplayGroup 'Remote Desktop'"
+        ]
+    }
+}


### PR DESCRIPTION
## Summary

Adds four machine-setup items requested across the install bundles:

1. **Lazygit** -> `DeveloperBasePackages` (the developer/Git tooling set), via winget `JesseDuffield.lazygit`, with a hand-curated PowerShell tab-completer matching the other CLI entries in that bundle.
2. **Tailscale** -> `OSBasePackages` (winget `Tailscale.Tailscale`), as a GUI app entry (no completion, matching Google Chrome / WinDirStat / Everything).
3. **Parsec** -> `OSBasePackages` (winget `Parsec.Parsec`), as a GUI app entry.
4. **Enable Remote Desktop** -> new standalone `bucket/os/EnableRemoteDesktop.json` toggle: sets `fDenyTSConnections=0`, enforces NLA (`UserAuthentication=1`), and opens the "Remote Desktop" firewall group. Modeled on the existing `EnableHybernate` toggle.

## Interpretation note

There is no literal "OSPlus" bundle in the repo; the OS install set is `OSBasePackages`, so items 2-4 target the OS group. Remote Desktop is a system toggle (not a package), so it follows the repo's standalone `bucket/os/*` toggle convention (EnableHybernate, SetPowerConfiguration) rather than an `OSBasePackages` package entry.

## Version bumps

- `OSBasePackages.json` 1.31.000 -> 1.32.000
- `DeveloperBasePackages.json` 1.25.000 -> 1.26.000

## Validation

- Both bundle scripts parse; new manifest is valid JSON.
- Targeted Pester suite (Bundles, BucketStructure, ManifestUrlSelfReferences, BucketManifestVersion, CompletionEndToEnd, Package, GetPackageValidationError): 1014 passed, 0 failed, 1 skipped.
- `Test-ManifestVersionBumps.ps1` reports no violations; `ManifestVersionBumps.Tests.ps1` passes.
- All three winget IDs verified to resolve.

Closes #386