### PR TITLE
fix(OSBasePackages): install Parsec via custom download to dodge winget hash mismatch

### DIFF
--- a/bucket/Bundles.Tests.ps1
+++ b/bucket/Bundles.Tests.ps1
@@ -389,6 +389,22 @@ Describe 'Specific cross-bundle placement contracts' -Tag 'Light','Bundle' {
         $bc.HasPostInstallScript | Should -BeTrue
     }
 
+    It 'Parsec uses a hash-resilient custom installer rather than the rolling-URL winget manifest (#388)' {
+        # The winget Parsec.Parsec manifest pins InstallerSha256 against the
+        # rolling https://builds.parsec.app/package/parsec-windows.exe URL, so
+        # an elevated machine-scope install fails "Installer hash does not
+        # match; this cannot be overridden when running as admin" the moment
+        # Parsec ships a newer build. OSBasePackages therefore installs Parsec
+        # via a custom download + silent-switch script (no hash check), gated
+        # by VerifyScript -- mirroring the Readwise Reader precedent.
+        $parsec = $script:byBundle.OSBasePackages | Where-Object Name -eq 'Parsec'
+        $parsec                        | Should -Not -BeNullOrEmpty
+        $parsec.Installer              | Should -Be 'custom'
+        $parsec.HasCustomInstallScript | Should -BeTrue
+        $parsec.HasVerifyScript        | Should -BeTrue
+        $parsec.Id                     | Should -BeNullOrEmpty -Because 'a custom installer carries no winget/scoop Id'
+    }
+
     It 'Get-Package surfaces WingetExtraArgs through the child-runspace bundle loader (#161)' {
         # Regression: PR #159 added WingetExtraArgs on the [Package] class
         # and to Test-Installs.ps1's CI wrapper, but the curated hashtable

--- a/bucket/OSBasePackages.json
+++ b/bucket/OSBasePackages.json
@@ -1,6 +1,6 @@
 {
     "$schema": "https://raw.githubusercontent.com/lukesampson/scoop/master/schema.json",
-    "version": "1.32.000",
+    "version": "1.33.000",
     "url": [
         "https://raw.githubusercontent.com/MarkMichaelis/ScoopBucket/main/bucket/OSBasePackages.ps1"
     ],

--- a/bucket/OSBasePackages.ps1
+++ b/bucket/OSBasePackages.ps1
@@ -86,7 +86,25 @@ Register-ArgumentCompleter -Native -CommandName es -ScriptBlock {
     [Package]@{ Name = 'WinDirStat';                    Installer = 'winget'; Id = 'WinDirStat.WinDirStat' }
     [Package]@{ Name = 'UniversalSilentSwitchFinder';   Installer = 'winget'; Id = 'WindowsPostInstallWizard.UniversalSilentSwitchFinder' }
     [Package]@{ Name = 'Tailscale';                     Installer = 'winget'; Id = 'Tailscale.Tailscale' }
-    [Package]@{ Name = 'Parsec';                        Installer = 'winget'; Id = 'Parsec.Parsec' }
+    [Package]@{
+        Name        = 'Parsec'
+        Installer   = 'custom'
+        Notes       = 'winget Parsec.Parsec pins a SHA256 against the rolling builds.parsec.app installer URL; once Parsec ships a newer build the hash mismatches and an elevated (machine-scope) winget install cannot override it ("Installer hash does not match; this cannot be overridden when running as admin", #388). Download the current parsec-windows.exe and run the documented silent switches instead.'
+        UpdateMode  = 'Reinstall'  # re-run the idempotent download-latest installer; VerifyScript gates it.
+        CustomInstallScript = {
+            $exe = Join-Path $env:ProgramFiles 'Parsec\parsecd.exe'
+            if (Test-Path $exe) { return }
+            $tmp = Join-Path $env:TEMP 'parsec-windows.exe'
+            Invoke-WebRequest -Uri 'https://builds.parsec.app/package/parsec-windows.exe' -OutFile $tmp
+            try {
+                $proc = Start-Process -FilePath $tmp -ArgumentList '/silent', '/norun', '/nocleanuser', '/allusers' -Wait -PassThru
+                if ($proc.ExitCode -ne 0) { throw "Parsec installer exited with code $($proc.ExitCode)." }
+            } finally {
+                Remove-Item $tmp -ErrorAction Ignore
+            }
+        }
+        VerifyScript = { Test-Path (Join-Path $env:ProgramFiles 'Parsec\parsecd.exe') }
+    }
     [Package]@{
         Name        = 'bat'
         Installer   = 'winget'


### PR DESCRIPTION
## Summary

Fixes a Parsec install failure in the OS set. Installing Parsec from `OSBasePackages` failed on an elevated machine-scope run:

```
Found Parsec [Parsec.Parsec] Version 150.101.0.0
Downloading https://builds.parsec.app/package/parsec-windows.exe
Installer hash does not match; this cannot be overridden when running as admin
```

### Root cause

The winget `Parsec.Parsec` manifest pins `InstallerSha256: 350DD7A6...` (release 2026-02-04) against the **rolling** installer URL `https://builds.parsec.app/package/parsec-windows.exe`, which always serves the latest build. Once Parsec ships a newer build the bytes no longer match the pinned hash. winget's `--ignore-security-hash` override is **rejected for machine-scope installs running as admin** -- exactly how OSBasePackages installs (`winget install --scope machine`).

### Fix

Switch Parsec to a `custom` installer that downloads the current `parsec-windows.exe` and runs the documented silent switches (from winget's own manifest), bypassing the hash check:

- `/silent /norun /nocleanuser /allusers` (machine-wide, no auto-launch)
- Idempotent: skips the download when `%ProgramFiles%\Parsec\parsecd.exe` already exists
- `VerifyScript` checks that same path; `UpdateMode = Reinstall`
- Mirrors the existing **Readwise Reader** custom-installer precedent in `ClientBasePackages`

This installs the full host-capable Parsec (service + virtual USB adapter driver), the right artifact for the OS/remote-access set. The scoop `extras/parsec` alternative ships only the portable client zip and carries the same rolling-URL hash fragility.

### Validation

- Behavior-first contract test added in `Bundles.Tests.ps1`; verified RED on revert ("Expected: 'custom' But was: 'winget'") and GREEN with the fix.
- Targeted Pester (Bundles, BucketStructure, ManifestUrlSelfReferences, BucketManifestVersion, Package): 1010 passed, 0 failed, 1 skipped.
- `Test-ManifestVersionBumps.ps1`: all manifests up to date.
- `OSBasePackages.json` 1.32.000 -> 1.33.000.

Closes #388