### PR TITLE
fix: scoop install/update of MarkMichaelis bundles under -NoProfile + opt-in Register-BucketModule (#390)

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,8 +83,16 @@ parsing only for legacy ones).
 Each migrated bundle now looks like:
 
 ```powershell
-$scoopBucketPsd1 = Join-Path $PSScriptRoot '..\module\MarkMichaelis.ScoopBucket\MarkMichaelis.ScoopBucket.psd1'
-if (Test-Path $scoopBucketPsd1) { Import-Module $scoopBucketPsd1 -Force } else { Import-Module MarkMichaelis.ScoopBucket -Force }
+#region MarkMichaelis.ScoopBucket bundle module import (scoop-portable; see README)
+$scoopBucketModule = 'MarkMichaelis.ScoopBucket'
+$scoopBucketPsd1 = Join-Path $PSScriptRoot "..\module\$scoopBucketModule\$scoopBucketModule.psd1"
+if (-not (Test-Path $scoopBucketPsd1)) {
+    $scoopBucketRoot = if ($env:SCOOP) { $env:SCOOP } else { Join-Path $PSScriptRoot '..\..\..' }
+    $scoopBucketFound = Get-ChildItem -Path (Join-Path $scoopBucketRoot "buckets\*\module\$scoopBucketModule\$scoopBucketModule.psd1") -ErrorAction SilentlyContinue | Select-Object -First 1
+    if ($scoopBucketFound) { $scoopBucketPsd1 = $scoopBucketFound.FullName }
+}
+if (Test-Path $scoopBucketPsd1) { Import-Module $scoopBucketPsd1 -Force } else { Import-Module $scoopBucketModule -Force }
+#endregion MarkMichaelis.ScoopBucket bundle module import
 
 $Packages = [Package[]]@(
     [Package]@{
@@ -97,6 +105,19 @@ $Packages = [Package[]]@(
 
 Invoke-PackageInstall -Packages $Packages -Bundle 'OSBasePackages'
 ```
+
+The import block is deliberately portable across three run contexts, in
+priority order: (1) a repo checkout, where the module lives at
+`..\module\...` next to the bundle; (2) a `scoop install`/`update`, where
+scoop downloads only the single bundle `.ps1` into
+`~\scoop\apps\<bundle>\<version>\` and runs it under `-NoProfile` -- so the
+block searches the bucket clone scoop always keeps on disk at
+`<scoopRoot>\buckets\*\module\MarkMichaelis.ScoopBucket\...` (preferring
+`$env:SCOOP`, else walking up from the app dir); and (3) a by-name
+`Import-Module` fallback for machines where the module is already on the
+`PSModulePath`. Because a manifest `url` points at its bundle `.ps1`, any
+edit to this block requires a minor version bump in the referencing
+manifest(s) (see Manifest versioning below).
 
 The `[Package]` class enforces enums on `Installer` / `Source` / `Scope` /
 `Completion` and rejects misspelled property names at load time. See
@@ -119,6 +140,25 @@ To use the module locally:
 Import-Module MarkMichaelis.ScoopBucket -Force
 Get-Command -Module MarkMichaelis.ScoopBucket
 ```
+
+#### Make the module available on any machine (opt-in)
+
+The bare `Install-Package <name>` wrapper only wins the name clash with
+`PackageManagement\Install-Package` when this module is imported by your
+profile. To register it on a machine -- a junction at
+`<scoopRoot>\modules\MarkMichaelis.ScoopBucket` plus one idempotent
+`Import-Module MarkMichaelis.ScoopBucket` line appended to your
+`CurrentUserAllHosts` profile -- run either:
+
+```powershell
+scoop install MarkMichaelis/RegisterBucketModule    # uses the bucket clone
+.\Register-BucketModule.ps1 -FromLocalRepo -WhatIf  # dev machine: preview first
+```
+
+This is strictly opt-in (no bundle `depends` on it), idempotent, and
+`SupportsShouldProcess` (`-WhatIf`/`-Confirm`). Reverse it with
+`scoop uninstall RegisterBucketModule` or
+`.\Register-BucketModule.ps1 -Remove`.
 
 Top-level helpers for cross-bundle queries:
 

--- a/Register-BucketModule.ps1
+++ b/Register-BucketModule.ps1
@@ -137,7 +137,17 @@ function Install-BucketModuleJunction {
         throw "Refusing to replace a real directory (not a junction): $Link"
     }
     if (-not $PSCmdlet.ShouldProcess($Link, "Junction to $Source")) { return }
-    if ($exists) { (Get-Item -LiteralPath $Link -Force).Delete() }
+    if ($exists) {
+        # New-Item -ItemType Junction sets the ReadOnly attribute on some hosts,
+        # which makes a plain delete fail with Access denied. Strip ReadOnly, then
+        # delete ONLY the link (non-recursive) so we never follow the reparse point
+        # into the target. Mirrors module\Install-Module.ps1 (#391 review).
+        $stale = Get-Item -LiteralPath $Link -Force
+        if (($stale.Attributes -band [System.IO.FileAttributes]::ReadOnly) -ne 0) {
+            $stale.Attributes = $stale.Attributes -band (-bnot [System.IO.FileAttributes]::ReadOnly)
+        }
+        [System.IO.Directory]::Delete($Link, $false)
+    }
     $parent = Split-Path -Parent $Link
     if ($parent -and -not (Test-Path -LiteralPath $parent)) { New-Item -ItemType Directory -Force -Path $parent | Out-Null }
     New-Item -ItemType Junction -Path $Link -Value $Source | Out-Null
@@ -150,7 +160,14 @@ function Uninstall-BucketModuleJunction {
     if (-not (Test-Path -LiteralPath $Link)) { Write-Verbose "No junction at $Link."; return }
     if (-not (Test-IsReparsePoint -Path $Link)) { Write-Warning "Not a junction; leaving as-is: $Link"; return }
     if ($PSCmdlet.ShouldProcess($Link, 'Remove junction')) {
-        (Get-Item -LiteralPath $Link -Force).Delete()
+        # Strip ReadOnly (New-Item -ItemType Junction sets it on some hosts) then
+        # delete only the link (non-recursive) so we never follow the reparse point
+        # into the target. Mirrors module\Install-Module.ps1 (#391 review).
+        $existing = Get-Item -LiteralPath $Link -Force
+        if (($existing.Attributes -band [System.IO.FileAttributes]::ReadOnly) -ne 0) {
+            $existing.Attributes = $existing.Attributes -band (-bnot [System.IO.FileAttributes]::ReadOnly)
+        }
+        [System.IO.Directory]::Delete($Link, $false)
         Write-Verbose "Removed junction $Link"
     }
 }

--- a/Register-BucketModule.ps1
+++ b/Register-BucketModule.ps1
@@ -1,0 +1,196 @@
+#requires -Version 7.0
+<#
+.SYNOPSIS
+    Opt-in, per-machine helper that "installs" MarkMichaelis.ScoopBucket so the
+    bare `Install-Package <x>` wrapper resolves to this bucket's module.
+
+.DESCRIPTION
+    scoop keeps a full clone of this bucket on disk under
+    <scoopRoot>\buckets\<name>\, which includes the module at
+    module\MarkMichaelis.ScoopBucket. Bundles load that module directly under
+    -NoProfile (see #390 Part B), but the convenience wrapper `Install-Package
+    <x>` only wins the name clash with PackageManagement\Install-Package when
+    OUR module is imported in the shell. This script performs the two
+    deliberate, idempotent steps that constitute "installing the module":
+
+      1. Create a directory junction
+             <scoopRoot>\modules\MarkMichaelis.ScoopBucket
+         pointing at the module source. Because <scoopRoot>\modules is on
+         PSModulePath, the module becomes discoverable by name.
+      2. Append exactly one `Import-Module MarkMichaelis.ScoopBucket` line to
+         the CurrentUserAllHosts profile (inside a distinctly-marked sentinel
+         block) so an interactive shell eagerly imports the module and our
+         Install-Package shadows PackageManagement's.
+
+    Both steps are idempotent (safe to re-run) and honor -WhatIf / -Confirm.
+    This helper is intentionally NOT wired as a `depends` of any bundle, so
+    third-party consumers of individual bundles are never forced to alter their
+    machine. It is offered only via `scoop install MarkMichaelis/RegisterBucketModule`
+    or by running this script directly.
+
+    NOTE (deliberate tradeoff): this is the EAGER "the bare command must resolve
+    to ours" option. It differs from module/Install-Module.ps1's default lazy v3
+    profile block (which prepends PSModulePath and defers the import). It uses a
+    distinct sentinel so the two never collide; run only one of them.
+
+.PARAMETER ModulePath
+    Explicit path to the MarkMichaelis.ScoopBucket module directory to junction
+    to. Overrides discovery. Useful for pointing at a local repo checkout
+    (e.g. D:\Git\ScoopBucket\module\MarkMichaelis.ScoopBucket).
+
+.PARAMETER FromLocalRepo
+    Junction to the module directory that sits beside this script
+    (<scriptDir>\module\MarkMichaelis.ScoopBucket) -- i.e. this repo checkout --
+    instead of the scoop bucket clone. Intended for a dev machine.
+
+.PARAMETER ScoopRoot
+    Root of the scoop installation. Defaults to $env:SCOOP, else ~\scoop. The
+    junction is created under <ScoopRoot>\modules and, absent -ModulePath /
+    -FromLocalRepo, the module is discovered under <ScoopRoot>\buckets\*\module.
+
+.PARAMETER ProfilePath
+    Profile file to edit. Defaults to $PROFILE.CurrentUserAllHosts. Tests pass a
+    temp path so the host profile is never touched.
+
+.PARAMETER Remove
+    Reverse both steps: delete the junction (never the module source) and strip
+    the sentinel block from the profile.
+
+.EXAMPLE
+    ./Register-BucketModule.ps1
+    # Junction to the scoop bucket clone + add the profile import. Idempotent.
+
+.EXAMPLE
+    ./Register-BucketModule.ps1 -FromLocalRepo
+    # Dev machine: junction to this repo's module\ instead of the bucket clone.
+
+.EXAMPLE
+    ./Register-BucketModule.ps1 -WhatIf
+    # Show what would change without touching the machine.
+
+.EXAMPLE
+    ./Register-BucketModule.ps1 -Remove
+    # Uninstall: remove the junction and the profile import block.
+#>
+[CmdletBinding(SupportsShouldProcess)]
+param(
+    [string]$ModulePath,
+    [switch]$FromLocalRepo,
+    [string]$ScoopRoot,
+    [string]$ProfilePath = $PROFILE.CurrentUserAllHosts,
+    [switch]$Remove
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+$script:ModuleName  = 'MarkMichaelis.ScoopBucket'
+$script:BeginMarker = "# $($script:ModuleName):RegisterBucketModule:BEGIN"
+$script:EndMarker   = "# $($script:ModuleName):RegisterBucketModule:END"
+
+function Resolve-ScoopRoot {
+    param([string]$ScoopRoot)
+    if ($ScoopRoot) { return $ScoopRoot }
+    if ($env:SCOOP) { return $env:SCOOP }
+    return (Join-Path $HOME 'scoop')
+}
+
+function Resolve-ModuleSource {
+    param([string]$ModulePath, [switch]$FromLocalRepo, [string]$ScoopRoot, [string]$ScriptRoot)
+    if ($ModulePath) {
+        if (-not (Test-Path -LiteralPath $ModulePath)) { throw "ModulePath not found: $ModulePath" }
+        return (Resolve-Path -LiteralPath $ModulePath).Path
+    }
+    if ($FromLocalRepo) {
+        $local = Join-Path $ScriptRoot "module\$($script:ModuleName)"
+        if (-not (Test-Path -LiteralPath $local)) { throw "Local repo module not found beside the script: $local" }
+        return (Resolve-Path -LiteralPath $local).Path
+    }
+    $pattern = Join-Path $ScoopRoot "buckets\*\module\$($script:ModuleName)"
+    $found = Get-ChildItem -Path $pattern -Directory -ErrorAction SilentlyContinue | Select-Object -First 1
+    if (-not $found) {
+        throw "Could not find $($script:ModuleName) under $ScoopRoot\buckets\*\module. Pass -ModulePath or -FromLocalRepo."
+    }
+    return $found.FullName
+}
+
+function Test-IsReparsePoint {
+    param([string]$Path)
+    $item = Get-Item -LiteralPath $Path -Force -ErrorAction SilentlyContinue
+    return [bool]($item -and $item.Attributes.HasFlag([System.IO.FileAttributes]::ReparsePoint))
+}
+
+function Test-JunctionTarget {
+    param([string]$Link, [string]$Target)
+    if (-not (Test-IsReparsePoint -Path $Link)) { return $false }
+    $current = @((Get-Item -LiteralPath $Link -Force).Target)[0]
+    if (-not $current) { return $false }
+    return ([System.IO.Path]::GetFullPath($current).TrimEnd('\')) -ieq ([System.IO.Path]::GetFullPath($Target).TrimEnd('\'))
+}
+
+function Install-BucketModuleJunction {
+    param([string]$Link, [string]$Source, $Cmdlet)
+    if (Test-JunctionTarget -Link $Link -Target $Source) { Write-Verbose "Junction already current: $Link"; return }
+    $exists = Test-Path -LiteralPath $Link
+    if ($exists -and -not (Test-IsReparsePoint -Path $Link)) {
+        throw "Refusing to replace a real directory (not a junction): $Link"
+    }
+    if (-not $Cmdlet.ShouldProcess($Link, "Junction to $Source")) { return }
+    if ($exists) { (Get-Item -LiteralPath $Link -Force).Delete() }
+    $parent = Split-Path -Parent $Link
+    if ($parent -and -not (Test-Path -LiteralPath $parent)) { New-Item -ItemType Directory -Force -Path $parent | Out-Null }
+    New-Item -ItemType Junction -Path $Link -Value $Source | Out-Null
+    Write-Verbose "Created junction $Link -> $Source"
+}
+
+function Uninstall-BucketModuleJunction {
+    param([string]$Link, $Cmdlet)
+    if (-not (Test-Path -LiteralPath $Link)) { Write-Verbose "No junction at $Link."; return }
+    if (-not (Test-IsReparsePoint -Path $Link)) { Write-Warning "Not a junction; leaving as-is: $Link"; return }
+    if ($Cmdlet.ShouldProcess($Link, 'Remove junction')) {
+        (Get-Item -LiteralPath $Link -Force).Delete()
+        Write-Verbose "Removed junction $Link"
+    }
+}
+
+function Add-BucketModuleImport {
+    param([string]$ProfilePath, $Cmdlet)
+    $current = if (Test-Path -LiteralPath $ProfilePath) { Get-Content -Raw -LiteralPath $ProfilePath } else { '' }
+    if ($null -eq $current) { $current = '' }
+    if ($current -match [regex]::Escape($script:BeginMarker)) { Write-Verbose "Import block already present."; return }
+    if (-not $Cmdlet.ShouldProcess($ProfilePath, "Add $($script:ModuleName) import")) { return }
+    $parent = Split-Path -Parent $ProfilePath
+    if ($parent -and -not (Test-Path -LiteralPath $parent)) { New-Item -ItemType Directory -Force -Path $parent | Out-Null }
+    $block = $script:BeginMarker + "`n" + "Import-Module $($script:ModuleName)" + "`n" + $script:EndMarker
+    $prefix = if ($current -and -not $current.EndsWith("`n")) { "`n" } else { '' }
+    Add-Content -LiteralPath $ProfilePath -Value ($prefix + $block) -Encoding utf8
+    Write-Verbose "Added $($script:ModuleName) import block to $ProfilePath"
+}
+
+function Remove-BucketModuleImport {
+    param([string]$ProfilePath, $Cmdlet)
+    if (-not (Test-Path -LiteralPath $ProfilePath)) { Write-Verbose "No profile at $ProfilePath."; return }
+    $current = Get-Content -Raw -LiteralPath $ProfilePath
+    if ($null -eq $current) { return }
+    $pattern = '(?s)\r?\n?' + [regex]::Escape($script:BeginMarker) + '.*?' + [regex]::Escape($script:EndMarker) + '\r?\n?'
+    if ($current -notmatch $pattern) { Write-Verbose "No import block found in $ProfilePath."; return }
+    if ($Cmdlet.ShouldProcess($ProfilePath, "Remove $($script:ModuleName) import")) {
+        $updated = [regex]::Replace($current, $pattern, "`n")
+        Set-Content -LiteralPath $ProfilePath -Value $updated -Encoding utf8
+        Write-Verbose "Removed import block from $ProfilePath"
+    }
+}
+
+# --- main -----------------------------------------------------------------
+$resolvedScoop = Resolve-ScoopRoot -ScoopRoot $ScoopRoot
+$link = Join-Path (Join-Path $resolvedScoop 'modules') $script:ModuleName
+
+if ($Remove) {
+    Uninstall-BucketModuleJunction -Link $link -Cmdlet $PSCmdlet
+    Remove-BucketModuleImport -ProfilePath $ProfilePath -Cmdlet $PSCmdlet
+    return
+}
+
+$source = Resolve-ModuleSource -ModulePath $ModulePath -FromLocalRepo:$FromLocalRepo -ScoopRoot $resolvedScoop -ScriptRoot $PSScriptRoot
+Install-BucketModuleJunction -Link $link -Source $source -Cmdlet $PSCmdlet
+Add-BucketModuleImport -ProfilePath $ProfilePath -Cmdlet $PSCmdlet

--- a/Register-BucketModule.ps1
+++ b/Register-BucketModule.ps1
@@ -98,12 +98,12 @@ function Resolve-ScoopRoot {
 function Resolve-ModuleSource {
     param([string]$ModulePath, [switch]$FromLocalRepo, [string]$ScoopRoot, [string]$ScriptRoot)
     if ($ModulePath) {
-        if (-not (Test-Path -LiteralPath $ModulePath)) { throw "ModulePath not found: $ModulePath" }
+        if (-not (Test-Path -LiteralPath $ModulePath -PathType Container)) { throw "ModulePath not found or not a directory: $ModulePath" }
         return (Resolve-Path -LiteralPath $ModulePath).Path
     }
     if ($FromLocalRepo) {
         $local = Join-Path $ScriptRoot "module\$($script:ModuleName)"
-        if (-not (Test-Path -LiteralPath $local)) { throw "Local repo module not found beside the script: $local" }
+        if (-not (Test-Path -LiteralPath $local -PathType Container)) { throw "Local repo module not found (or not a directory) beside the script: $local" }
         return (Resolve-Path -LiteralPath $local).Path
     }
     $pattern = Join-Path $ScoopRoot "buckets\*\module\$($script:ModuleName)"

--- a/Register-BucketModule.ps1
+++ b/Register-BucketModule.ps1
@@ -129,13 +129,14 @@ function Test-JunctionTarget {
 }
 
 function Install-BucketModuleJunction {
-    param([string]$Link, [string]$Source, $Cmdlet)
+    [CmdletBinding(SupportsShouldProcess)]
+    param([string]$Link, [string]$Source)
     if (Test-JunctionTarget -Link $Link -Target $Source) { Write-Verbose "Junction already current: $Link"; return }
     $exists = Test-Path -LiteralPath $Link
     if ($exists -and -not (Test-IsReparsePoint -Path $Link)) {
         throw "Refusing to replace a real directory (not a junction): $Link"
     }
-    if (-not $Cmdlet.ShouldProcess($Link, "Junction to $Source")) { return }
+    if (-not $PSCmdlet.ShouldProcess($Link, "Junction to $Source")) { return }
     if ($exists) { (Get-Item -LiteralPath $Link -Force).Delete() }
     $parent = Split-Path -Parent $Link
     if ($parent -and -not (Test-Path -LiteralPath $parent)) { New-Item -ItemType Directory -Force -Path $parent | Out-Null }
@@ -144,21 +145,23 @@ function Install-BucketModuleJunction {
 }
 
 function Uninstall-BucketModuleJunction {
-    param([string]$Link, $Cmdlet)
+    [CmdletBinding(SupportsShouldProcess)]
+    param([string]$Link)
     if (-not (Test-Path -LiteralPath $Link)) { Write-Verbose "No junction at $Link."; return }
     if (-not (Test-IsReparsePoint -Path $Link)) { Write-Warning "Not a junction; leaving as-is: $Link"; return }
-    if ($Cmdlet.ShouldProcess($Link, 'Remove junction')) {
+    if ($PSCmdlet.ShouldProcess($Link, 'Remove junction')) {
         (Get-Item -LiteralPath $Link -Force).Delete()
         Write-Verbose "Removed junction $Link"
     }
 }
 
 function Add-BucketModuleImport {
-    param([string]$ProfilePath, $Cmdlet)
+    [CmdletBinding(SupportsShouldProcess)]
+    param([string]$ProfilePath)
     $current = if (Test-Path -LiteralPath $ProfilePath) { Get-Content -Raw -LiteralPath $ProfilePath } else { '' }
     if ($null -eq $current) { $current = '' }
     if ($current -match [regex]::Escape($script:BeginMarker)) { Write-Verbose "Import block already present."; return }
-    if (-not $Cmdlet.ShouldProcess($ProfilePath, "Add $($script:ModuleName) import")) { return }
+    if (-not $PSCmdlet.ShouldProcess($ProfilePath, "Add $($script:ModuleName) import")) { return }
     $parent = Split-Path -Parent $ProfilePath
     if ($parent -and -not (Test-Path -LiteralPath $parent)) { New-Item -ItemType Directory -Force -Path $parent | Out-Null }
     $block = $script:BeginMarker + "`n" + "Import-Module $($script:ModuleName)" + "`n" + $script:EndMarker
@@ -168,13 +171,14 @@ function Add-BucketModuleImport {
 }
 
 function Remove-BucketModuleImport {
-    param([string]$ProfilePath, $Cmdlet)
+    [CmdletBinding(SupportsShouldProcess)]
+    param([string]$ProfilePath)
     if (-not (Test-Path -LiteralPath $ProfilePath)) { Write-Verbose "No profile at $ProfilePath."; return }
     $current = Get-Content -Raw -LiteralPath $ProfilePath
     if ($null -eq $current) { return }
     $pattern = '(?s)\r?\n?' + [regex]::Escape($script:BeginMarker) + '.*?' + [regex]::Escape($script:EndMarker) + '\r?\n?'
     if ($current -notmatch $pattern) { Write-Verbose "No import block found in $ProfilePath."; return }
-    if ($Cmdlet.ShouldProcess($ProfilePath, "Remove $($script:ModuleName) import")) {
+    if ($PSCmdlet.ShouldProcess($ProfilePath, "Remove $($script:ModuleName) import")) {
         $updated = [regex]::Replace($current, $pattern, "`n")
         Set-Content -LiteralPath $ProfilePath -Value $updated -Encoding utf8
         Write-Verbose "Removed import block from $ProfilePath"
@@ -186,11 +190,11 @@ $resolvedScoop = Resolve-ScoopRoot -ScoopRoot $ScoopRoot
 $link = Join-Path (Join-Path $resolvedScoop 'modules') $script:ModuleName
 
 if ($Remove) {
-    Uninstall-BucketModuleJunction -Link $link -Cmdlet $PSCmdlet
-    Remove-BucketModuleImport -ProfilePath $ProfilePath -Cmdlet $PSCmdlet
+    Uninstall-BucketModuleJunction -Link $link
+    Remove-BucketModuleImport -ProfilePath $ProfilePath
     return
 }
 
 $source = Resolve-ModuleSource -ModulePath $ModulePath -FromLocalRepo:$FromLocalRepo -ScoopRoot $resolvedScoop -ScriptRoot $PSScriptRoot
-Install-BucketModuleJunction -Link $link -Source $source -Cmdlet $PSCmdlet
-Add-BucketModuleImport -ProfilePath $ProfilePath -Cmdlet $PSCmdlet
+Install-BucketModuleJunction -Link $link -Source $source
+Add-BucketModuleImport -ProfilePath $ProfilePath

--- a/Register-BucketModule.ps1
+++ b/Register-BucketModule.ps1
@@ -134,7 +134,7 @@ function Install-BucketModuleJunction {
     if (Test-JunctionTarget -Link $Link -Target $Source) { Write-Verbose "Junction already current: $Link"; return }
     $exists = Test-Path -LiteralPath $Link
     if ($exists -and -not (Test-IsReparsePoint -Path $Link)) {
-        throw "Refusing to replace a real directory (not a junction): $Link"
+        throw "Refusing to replace an existing path that is not a junction (reparse point): $Link"
     }
     if (-not $PSCmdlet.ShouldProcess($Link, "Junction to $Source")) { return }
     if ($exists) {
@@ -158,7 +158,7 @@ function Uninstall-BucketModuleJunction {
     [CmdletBinding(SupportsShouldProcess)]
     param([string]$Link)
     if (-not (Test-Path -LiteralPath $Link)) { Write-Verbose "No junction at $Link."; return }
-    if (-not (Test-IsReparsePoint -Path $Link)) { Write-Warning "Not a junction; leaving as-is: $Link"; return }
+    if (-not (Test-IsReparsePoint -Path $Link)) { Write-Warning "Path exists but is not a junction (reparse point); leaving as-is: $Link"; return }
     if ($PSCmdlet.ShouldProcess($Link, 'Remove junction')) {
         # Strip ReadOnly (New-Item -ItemType Junction sets it on some hosts) then
         # delete only the link (non-recursive) so we never follow the reparse point

--- a/Register-BucketModule.ps1
+++ b/Register-BucketModule.ps1
@@ -183,7 +183,10 @@ function Add-BucketModuleImport {
     if ($parent -and -not (Test-Path -LiteralPath $parent)) { New-Item -ItemType Directory -Force -Path $parent | Out-Null }
     $block = $script:BeginMarker + "`n" + "Import-Module $($script:ModuleName)" + "`n" + $script:EndMarker
     $prefix = if ($current -and -not $current.EndsWith("`n")) { "`n" } else { '' }
-    Add-Content -LiteralPath $ProfilePath -Value ($prefix + $block) -Encoding utf8
+    # Rewrite the whole profile in one pass (mirrors Remove-BucketModuleImport) so a file
+    # previously saved with a different encoding (e.g. UTF-16) is not corrupted by appending
+    # UTF-8 bytes; the result is a single, consistent UTF-8 encoding. (#391 review)
+    Set-Content -LiteralPath $ProfilePath -Value ($current + $prefix + $block) -Encoding utf8
     Write-Verbose "Added $($script:ModuleName) import block to $ProfilePath"
 }
 

--- a/bucket/AIAgents.json
+++ b/bucket/AIAgents.json
@@ -1,6 +1,6 @@
 {
     "$schema": "https://raw.githubusercontent.com/lukesampson/scoop/master/schema.json",
-    "version": "1.24.000",
+    "version": "1.25.000",
     "url": [
         "https://raw.githubusercontent.com/MarkMichaelis/ScoopBucket/main/bucket/AIAgents.ps1"
     ],

--- a/bucket/AIAgents.ps1
+++ b/bucket/AIAgents.ps1
@@ -9,8 +9,16 @@ param(
 )
 
 Write-Verbose 'Installing and configuring AIAgents...'
-$scoopBucketPsd1 = Join-Path $PSScriptRoot '..\module\MarkMichaelis.ScoopBucket\MarkMichaelis.ScoopBucket.psd1'
-if (Test-Path $scoopBucketPsd1) { Import-Module $scoopBucketPsd1 -Force } else { Import-Module MarkMichaelis.ScoopBucket -Force }
+#region MarkMichaelis.ScoopBucket bundle module import (scoop-portable; see README)
+$scoopBucketModule = 'MarkMichaelis.ScoopBucket'
+$scoopBucketPsd1 = Join-Path $PSScriptRoot "..\module\$scoopBucketModule\$scoopBucketModule.psd1"
+if (-not (Test-Path $scoopBucketPsd1)) {
+    $scoopBucketRoot = if ($env:SCOOP) { $env:SCOOP } else { Join-Path $PSScriptRoot '..\..\..' }
+    $scoopBucketFound = Get-ChildItem -Path (Join-Path $scoopBucketRoot "buckets\*\module\$scoopBucketModule\$scoopBucketModule.psd1") -ErrorAction SilentlyContinue | Select-Object -First 1
+    if ($scoopBucketFound) { $scoopBucketPsd1 = $scoopBucketFound.FullName }
+}
+if (Test-Path $scoopBucketPsd1) { Import-Module $scoopBucketPsd1 -Force } else { Import-Module $scoopBucketModule -Force }
+#endregion MarkMichaelis.ScoopBucket bundle module import
 
 # ---------------------------------------------------------------------------
 # Package list.

--- a/bucket/BundleModuleImportDrift.Tests.ps1
+++ b/bucket/BundleModuleImportDrift.Tests.ps1
@@ -1,0 +1,106 @@
+#requires -Version 7.0
+# ----------------------------------------------------------------------------
+# Drift guard (Pester v5, Light/Meta): every shipped bundle .ps1 that imports
+# MarkMichaelis.ScoopBucket in its header MUST use the single canonical
+# "scoop-portable" region block (see README / #390). The only permitted
+# variation is the branch-1 repo-checkout depth (..\module for a bundle that
+# sits directly in bucket\, ..\..\module for one under a bucket\<group>\ folder).
+#
+# Reverting a bundle to the legacy 2-line header, hand-editing one header out of
+# sync, or adding a new bundle that copies the old header all fail here.
+# ----------------------------------------------------------------------------
+
+Set-StrictMode -Version Latest
+
+Describe 'All bundle headers use the canonical scoop-portable module import' -Tag 'Light', 'Meta' {
+
+    BeforeDiscovery {
+        $script:BucketRoot = $PSScriptRoot
+        # A "bundle header" is any non-test .ps1 under bucket\ that resolves the
+        # module for import -- detected by the $scoopBucketPsd1 variable (present
+        # in both the legacy and canonical headers) or a by-name Import-Module of
+        # the module (the legacy fallback). Helper scripts that never import the
+        # module are intentionally excluded.
+        $script:BundleCases = @(
+            Get-ChildItem -Path $script:BucketRoot -Recurse -Filter '*.ps1' -File |
+                Where-Object { $_.Name -notlike '*.Tests.ps1' } |
+                Where-Object {
+                    $t = Get-Content -Raw -LiteralPath $_.FullName
+                    ($t -match '\$scoopBucketPsd1') -or ($t -match 'Import-Module\s+MarkMichaelis\.ScoopBucket\b')
+                } |
+                ForEach-Object {
+                    [pscustomobject]@{
+                        Name = $_.FullName.Substring($script:BucketRoot.Length + 1)
+                        Path = $_.FullName
+                    }
+                }
+        )
+    }
+
+    BeforeAll {
+        $script:BucketRoot = $PSScriptRoot
+
+        # The one true header, with {DEPTH} standing in for the branch-1 repo
+        # checkout depth. Compared line-for-line (LF-normalized) against every
+        # bundle's region block after its depth token is masked.
+        $script:Canonical = @(
+            '#region MarkMichaelis.ScoopBucket bundle module import (scoop-portable; see README)'
+            '$scoopBucketModule = ''MarkMichaelis.ScoopBucket'''
+            '$scoopBucketPsd1 = Join-Path $PSScriptRoot "{DEPTH}\$scoopBucketModule\$scoopBucketModule.psd1"'
+            'if (-not (Test-Path $scoopBucketPsd1)) {'
+            '    $scoopBucketRoot = if ($env:SCOOP) { $env:SCOOP } else { Join-Path $PSScriptRoot ''..\..\..'' }'
+            '    $scoopBucketFound = Get-ChildItem -Path (Join-Path $scoopBucketRoot "buckets\*\module\$scoopBucketModule\$scoopBucketModule.psd1") -ErrorAction SilentlyContinue | Select-Object -First 1'
+            '    if ($scoopBucketFound) { $scoopBucketPsd1 = $scoopBucketFound.FullName }'
+            '}'
+            'if (Test-Path $scoopBucketPsd1) { Import-Module $scoopBucketPsd1 -Force } else { Import-Module $scoopBucketModule -Force }'
+            '#endregion MarkMichaelis.ScoopBucket bundle module import'
+        ) -join "`n"
+
+        # Runtime recompute of the discovery set, so the "finds the shipped set"
+        # guard below cannot vacuously pass on a bad glob.
+        $script:BundleFiles = @(
+            Get-ChildItem -Path $script:BucketRoot -Recurse -Filter '*.ps1' -File |
+                Where-Object { $_.Name -notlike '*.Tests.ps1' } |
+                Where-Object {
+                    $t = Get-Content -Raw -LiteralPath $_.FullName
+                    ($t -match '\$scoopBucketPsd1') -or ($t -match 'Import-Module\s+MarkMichaelis\.ScoopBucket\b')
+                }
+        )
+
+        function Get-Region {
+            param([string]$Text)
+            $m = [regex]::Match($Text, '(?ms)^#region MarkMichaelis\.ScoopBucket bundle module import.*?^#endregion[^\r\n]*')
+            if ($m.Success) { return ($m.Value -replace "`r`n", "`n") }
+            return ''
+        }
+
+        function Get-ExpectedDepth {
+            param([string]$RelPath)
+            $sep = [System.IO.Path]::DirectorySeparatorChar
+            $subdirs = $RelPath.Split($sep).Count - 1
+            $dotdots = $subdirs + 1
+            return (('..' + [System.IO.Path]::DirectorySeparatorChar) * $dotdots) + 'module'
+        }
+    }
+
+    It 'finds the full shipped bundle set (guards the discovery predicate)' {
+        $script:BundleFiles.Count | Should -BeGreaterOrEqual 16 -Because 'the 16 production bundles must all be discovered'
+    }
+
+    It '<_.Name> uses the canonical region block (only branch-1 depth may differ)' -ForEach $script:BundleCases {
+        $text = Get-Content -Raw -LiteralPath $_.Path
+        $region = Get-Region -Text $text
+        $region | Should -Not -BeNullOrEmpty -Because "$($_.Name) must carry the canonical #region..#endregion header (legacy 2-line headers are forbidden)"
+        $masked = [regex]::Replace($region, '(\.\.\\){1,2}module', '{DEPTH}')
+        $masked | Should -BeExactly $script:Canonical -Because "$($_.Name) header drifted from the canonical scoop-portable block"
+    }
+
+    It '<_.Name> branch-1 depth matches its folder location' -ForEach $script:BundleCases {
+        $text = Get-Content -Raw -LiteralPath $_.Path
+        $region = Get-Region -Text $text
+        $depthMatch = [regex]::Match($region, 'Join-Path \$PSScriptRoot "((?:\.\.\\){1,2}module)\\')
+        $depthMatch.Success | Should -BeTrue -Because "$($_.Name) must have a branch-1 Join-Path depth"
+        $expected = Get-ExpectedDepth -RelPath $_.Name
+        $depthMatch.Groups[1].Value | Should -BeExactly $expected -Because "$($_.Name): a bundle in a group folder uses ..\..\module; a top-level bundle uses ..\module"
+    }
+}

--- a/bucket/BundleModuleImportDrift.Tests.ps1
+++ b/bucket/BundleModuleImportDrift.Tests.ps1
@@ -84,7 +84,7 @@ Describe 'All bundle headers use the canonical scoop-portable module import' -Ta
     }
 
     It 'finds the full shipped bundle set (guards the discovery predicate)' {
-        $script:BundleFiles.Count | Should -BeGreaterOrEqual 16 -Because 'the 16 production bundles must all be discovered'
+        $script:BundleFiles.Count | Should -Be 16 -Because 'the discovery predicate must match exactly the 16 production bundles -- update this count deliberately when adding or removing a bundle'
     }
 
     It '<_.Name> uses the canonical region block (only branch-1 depth may differ)' -ForEach $script:BundleCases {

--- a/bucket/ClientBasePackages.json
+++ b/bucket/ClientBasePackages.json
@@ -1,6 +1,6 @@
 {
     "$schema": "https://raw.githubusercontent.com/lukesampson/scoop/master/schema.json",
-    "version": "1.20.000",
+    "version": "1.21.000",
     "url": [
         "https://raw.githubusercontent.com/MarkMichaelis/ScoopBucket/main/bucket/ClientBasePackages.ps1"
     ],

--- a/bucket/ClientBasePackages.ps1
+++ b/bucket/ClientBasePackages.ps1
@@ -1,5 +1,13 @@
-$scoopBucketPsd1 = Join-Path $PSScriptRoot '..\module\MarkMichaelis.ScoopBucket\MarkMichaelis.ScoopBucket.psd1'
-if (Test-Path $scoopBucketPsd1) { Import-Module $scoopBucketPsd1 -Force } else { Import-Module MarkMichaelis.ScoopBucket -Force }
+#region MarkMichaelis.ScoopBucket bundle module import (scoop-portable; see README)
+$scoopBucketModule = 'MarkMichaelis.ScoopBucket'
+$scoopBucketPsd1 = Join-Path $PSScriptRoot "..\module\$scoopBucketModule\$scoopBucketModule.psd1"
+if (-not (Test-Path $scoopBucketPsd1)) {
+    $scoopBucketRoot = if ($env:SCOOP) { $env:SCOOP } else { Join-Path $PSScriptRoot '..\..\..' }
+    $scoopBucketFound = Get-ChildItem -Path (Join-Path $scoopBucketRoot "buckets\*\module\$scoopBucketModule\$scoopBucketModule.psd1") -ErrorAction SilentlyContinue | Select-Object -First 1
+    if ($scoopBucketFound) { $scoopBucketPsd1 = $scoopBucketFound.FullName }
+}
+if (Test-Path $scoopBucketPsd1) { Import-Module $scoopBucketPsd1 -Force } else { Import-Module $scoopBucketModule -Force }
+#endregion MarkMichaelis.ScoopBucket bundle module import
 
 # Refs:
 #   #5/#6/#7/#10/#12  scoop extras for apps with no machine-scope winget installer

--- a/bucket/DeveloperBasePackages.json
+++ b/bucket/DeveloperBasePackages.json
@@ -1,6 +1,6 @@
 {
     "$schema": "https://raw.githubusercontent.com/lukesampson/scoop/master/schema.json",
-    "version": "1.26.000",
+    "version": "1.27.000",
     "url": [
         "https://raw.githubusercontent.com/MarkMichaelis/ScoopBucket/main/bucket/DeveloperBasePackages.ps1"
     ],

--- a/bucket/DeveloperBasePackages.ps1
+++ b/bucket/DeveloperBasePackages.ps1
@@ -1,5 +1,13 @@
-$scoopBucketPsd1 = Join-Path $PSScriptRoot '..\module\MarkMichaelis.ScoopBucket\MarkMichaelis.ScoopBucket.psd1'
-if (Test-Path $scoopBucketPsd1) { Import-Module $scoopBucketPsd1 -Force } else { Import-Module MarkMichaelis.ScoopBucket -Force }
+#region MarkMichaelis.ScoopBucket bundle module import (scoop-portable; see README)
+$scoopBucketModule = 'MarkMichaelis.ScoopBucket'
+$scoopBucketPsd1 = Join-Path $PSScriptRoot "..\module\$scoopBucketModule\$scoopBucketModule.psd1"
+if (-not (Test-Path $scoopBucketPsd1)) {
+    $scoopBucketRoot = if ($env:SCOOP) { $env:SCOOP } else { Join-Path $PSScriptRoot '..\..\..' }
+    $scoopBucketFound = Get-ChildItem -Path (Join-Path $scoopBucketRoot "buckets\*\module\$scoopBucketModule\$scoopBucketModule.psd1") -ErrorAction SilentlyContinue | Select-Object -First 1
+    if ($scoopBucketFound) { $scoopBucketPsd1 = $scoopBucketFound.FullName }
+}
+if (Test-Path $scoopBucketPsd1) { Import-Module $scoopBucketPsd1 -Force } else { Import-Module $scoopBucketModule -Force }
+#endregion MarkMichaelis.ScoopBucket bundle module import
 
 # Refs:
 #   #14/#46  BeyondCompare: winget MSIX is user-scope only -> scoop extras

--- a/bucket/OSBasePackages.json
+++ b/bucket/OSBasePackages.json
@@ -1,6 +1,6 @@
 {
     "$schema": "https://raw.githubusercontent.com/lukesampson/scoop/master/schema.json",
-    "version": "1.33.000",
+    "version": "1.34.000",
     "url": [
         "https://raw.githubusercontent.com/MarkMichaelis/ScoopBucket/main/bucket/OSBasePackages.ps1"
     ],

--- a/bucket/OSBasePackages.ps1
+++ b/bucket/OSBasePackages.ps1
@@ -1,5 +1,13 @@
-$scoopBucketPsd1 = Join-Path $PSScriptRoot '..\module\MarkMichaelis.ScoopBucket\MarkMichaelis.ScoopBucket.psd1'
-if (Test-Path $scoopBucketPsd1) { Import-Module $scoopBucketPsd1 -Force } else { Import-Module MarkMichaelis.ScoopBucket -Force }
+#region MarkMichaelis.ScoopBucket bundle module import (scoop-portable; see README)
+$scoopBucketModule = 'MarkMichaelis.ScoopBucket'
+$scoopBucketPsd1 = Join-Path $PSScriptRoot "..\module\$scoopBucketModule\$scoopBucketModule.psd1"
+if (-not (Test-Path $scoopBucketPsd1)) {
+    $scoopBucketRoot = if ($env:SCOOP) { $env:SCOOP } else { Join-Path $PSScriptRoot '..\..\..' }
+    $scoopBucketFound = Get-ChildItem -Path (Join-Path $scoopBucketRoot "buckets\*\module\$scoopBucketModule\$scoopBucketModule.psd1") -ErrorAction SilentlyContinue | Select-Object -First 1
+    if ($scoopBucketFound) { $scoopBucketPsd1 = $scoopBucketFound.FullName }
+}
+if (Test-Path $scoopBucketPsd1) { Import-Module $scoopBucketPsd1 -Force } else { Import-Module $scoopBucketModule -Force }
+#endregion MarkMichaelis.ScoopBucket bundle module import
 
 # Refs:
 #   #29  ffmpeg via scoop main rather than winget Gyan.FFmpeg (nested-installer drift)

--- a/bucket/ScoopAppDirModuleImport.Tests.ps1
+++ b/bucket/ScoopAppDirModuleImport.Tests.ps1
@@ -1,0 +1,127 @@
+#requires -Version 7.0
+# ----------------------------------------------------------------------------
+# Part B behavior test (Pester v5, Light): a bundle .ps1 that scoop dropped
+# into ~\scoop\apps\<bundle>\<ver>\ (with NO sibling module\) must still load
+# MarkMichaelis.ScoopBucket -- by finding it in the bucket CLONE at
+# <scoopRoot>\buckets\*\module\... -- when run under -NoProfile.
+#
+# The header text is extracted from a REAL production bundle via its region
+# markers, so reverting the bucket-clone branch (branch 2) there makes the
+# positive cases below fail (behavioral fail-on-revert). See #390.
+# ----------------------------------------------------------------------------
+
+Set-StrictMode -Version Latest
+
+Describe 'Bundle loads MarkMichaelis.ScoopBucket from the scoop bucket clone under -NoProfile' -Tag 'Light', 'Bundle' {
+
+    BeforeAll {
+        $script:repoRoot  = Split-Path -Parent $PSScriptRoot
+        $script:moduleSrc = Join-Path $script:repoRoot 'module\MarkMichaelis.ScoopBucket'
+        $script:pwshPath  = (Get-Process -Id $PID).Path
+
+        # Pull the region-delimited "#region MarkMichaelis.ScoopBucket bundle
+        # module import ... #endregion" block out of a shipped bundle. Returns
+        # '' if absent (which makes the composed probe bundle fail to resolve
+        # [Package] -> the positive It below fails, exactly as it should before
+        # the fix lands).
+        function Get-BundleImportHeader {
+            param([Parameter(Mandatory)][string]$BundlePath)
+            $text = Get-Content -Raw -LiteralPath $BundlePath
+            $m = [regex]::Match($text, '(?ms)^#region MarkMichaelis\.ScoopBucket bundle module import.*?^#endregion[^\r\n]*')
+            if ($m.Success) { return $m.Value }
+            return ''
+        }
+
+        # Stage a fake scoop root: apps\BootstrapProbe\1.0.0\BootstrapProbe.ps1
+        # holding ONLY the header + a trivial declarative install, and
+        # (optionally) a sibling bucket clone that actually contains the module.
+        # NO module\ sibling is created in the app dir, so branch 1 (repo
+        # checkout) cannot resolve.
+        function New-FakeScoopBundle {
+            param(
+                [Parameter(Mandatory)][string]$Root,
+                [Parameter(Mandatory)][AllowEmptyString()][string]$Header,
+                [switch]$WithBucketClone
+            )
+            $appDir = Join-Path $Root 'apps\BootstrapProbe\1.0.0'
+            New-Item -ItemType Directory -Force -Path $appDir | Out-Null
+            if ($WithBucketClone) {
+                $cloneModule = Join-Path $Root 'buckets\TestBucket\module\MarkMichaelis.ScoopBucket'
+                New-Item -ItemType Directory -Force -Path $cloneModule | Out-Null
+                Copy-Item -Path (Join-Path $script:moduleSrc '*') -Destination $cloneModule -Recurse -Force
+            }
+            $body = @"
+$Header
+
+`$Packages = [Package[]]@(
+    [Package]@{ Name = 'BootstrapProbe'; CustomInstallScript = { } }
+)
+Invoke-PackageInstall -Packages `$Packages -Bundle 'BootstrapProbe' -DryRun |
+    ForEach-Object { "RESULT:`$(`$_.Name)=`$(`$_.Status)" }
+"@
+            $bundlePath = Join-Path $appDir 'BootstrapProbe.ps1'
+            Set-Content -LiteralPath $bundlePath -Value $body -Encoding utf8
+            return $bundlePath
+        }
+
+        # Run the probe bundle in a fresh -NoProfile child (mirrors scoop) so
+        # the imported module + [Package] type never leak into the test runner.
+        #
+        # The child's PSModulePath is pinned to just the built-in pwsh module
+        # dir. That is faithful to scoop's real launch -- under -NoProfile the
+        # module is NOT on PSModulePath (that is the bug; Part C is what puts it
+        # there deliberately) -- and it makes the negative control hermetic: a
+        # suite peer that prepends the repo module dir to the parent's
+        # PSModulePath cannot leak in and let branch 3 (by-name Import-Module)
+        # mask the branch-2 bucket-clone load path. See #390.
+        function Invoke-ProbeBundle {
+            param([Parameter(Mandatory)][string]$BundlePath, [string]$ScoopEnv = '')
+            $prevScoop = $env:SCOOP
+            $prevPsmp = $env:PSModulePath
+            try {
+                $env:SCOOP = $ScoopEnv
+                $env:PSModulePath = Join-Path $PSHOME 'Modules'
+                return (& $script:pwshPath -NoProfile -ExecutionPolicy Bypass -File $BundlePath 2>&1 | Out-String)
+            } finally {
+                $env:SCOOP = $prevScoop
+                $env:PSModulePath = $prevPsmp
+            }
+        }
+    }
+
+    Context 'top-level bundle header (OSBasePackages, branch-1 depth ..\module)' {
+        BeforeAll {
+            $script:header = Get-BundleImportHeader -BundlePath (Join-Path $script:repoRoot 'bucket\OSBasePackages.ps1')
+        }
+
+        It 'loads via the ..\..\..\ scoop-root derivation when $env:SCOOP is unset' {
+            $root = Join-Path $TestDrive ([guid]::NewGuid().ToString('N'))
+            $bundle = New-FakeScoopBundle -Root $root -Header $script:header -WithBucketClone
+            (Invoke-ProbeBundle -BundlePath $bundle) | Should -Match 'RESULT:BootstrapProbe=Installed'
+        }
+
+        It 'loads via $env:SCOOP when it points at the scoop root' {
+            $root = Join-Path $TestDrive ([guid]::NewGuid().ToString('N'))
+            $bundle = New-FakeScoopBundle -Root $root -Header $script:header -WithBucketClone
+            (Invoke-ProbeBundle -BundlePath $bundle -ScoopEnv $root) | Should -Match 'RESULT:BootstrapProbe=Installed'
+        }
+
+        It 'does NOT load when the bucket clone is absent (negative control: branch 2 is the load path)' {
+            $root = Join-Path $TestDrive ([guid]::NewGuid().ToString('N'))
+            $bundle = New-FakeScoopBundle -Root $root -Header $script:header
+            (Invoke-ProbeBundle -BundlePath $bundle) | Should -Not -Match 'RESULT:BootstrapProbe=Installed'
+        }
+    }
+
+    Context 'subdir bundle header (developer/PowerShell, branch-1 depth ..\..\module)' {
+        BeforeAll {
+            $script:header = Get-BundleImportHeader -BundlePath (Join-Path $script:repoRoot 'bucket\developer\PowerShell.ps1')
+        }
+
+        It 'loads from the bucket clone (identical branch 2 despite deeper branch 1)' {
+            $root = Join-Path $TestDrive ([guid]::NewGuid().ToString('N'))
+            $bundle = New-FakeScoopBundle -Root $root -Header $script:header -WithBucketClone
+            (Invoke-ProbeBundle -BundlePath $bundle) | Should -Match 'RESULT:BootstrapProbe=Installed'
+        }
+    }
+}

--- a/bucket/Test-Template.Tests.ps1.txt
+++ b/bucket/Test-Template.Tests.ps1.txt
@@ -15,8 +15,16 @@
 #        pwsh -NoProfile -File .\Invoke-Tests.ps1 -Pattern <Name> -Tag All
 # ----------------------------------------------------------------------------
 
-$scoopBucketPsd1 = Join-Path $PSScriptRoot '..\module\MarkMichaelis.ScoopBucket\MarkMichaelis.ScoopBucket.psd1'
-if (Test-Path $scoopBucketPsd1) { Import-Module $scoopBucketPsd1 -Force } else { Import-Module MarkMichaelis.ScoopBucket -Force }
+#region MarkMichaelis.ScoopBucket bundle module import (scoop-portable; see README)
+$scoopBucketModule = 'MarkMichaelis.ScoopBucket'
+$scoopBucketPsd1 = Join-Path $PSScriptRoot "..\module\$scoopBucketModule\$scoopBucketModule.psd1"
+if (-not (Test-Path $scoopBucketPsd1)) {
+    $scoopBucketRoot = if ($env:SCOOP) { $env:SCOOP } else { Join-Path $PSScriptRoot '..\..\..' }
+    $scoopBucketFound = Get-ChildItem -Path (Join-Path $scoopBucketRoot "buckets\*\module\$scoopBucketModule\$scoopBucketModule.psd1") -ErrorAction SilentlyContinue | Select-Object -First 1
+    if ($scoopBucketFound) { $scoopBucketPsd1 = $scoopBucketFound.FullName }
+}
+if (Test-Path $scoopBucketPsd1) { Import-Module $scoopBucketPsd1 -Force } else { Import-Module $scoopBucketModule -Force }
+#endregion MarkMichaelis.ScoopBucket bundle module import
 
 # Derive the package/script name from this file's name. e.g.,
 #   "Claude.Tests.ps1" -> "Claude"

--- a/bucket/admin/RegisterBucketModule.Tests.ps1
+++ b/bucket/admin/RegisterBucketModule.Tests.ps1
@@ -109,6 +109,39 @@ Describe 'Register-BucketModule' -Tag 'Light', 'Admin' {
         }
     }
 
+    Context 'when a non-junction path already occupies the link location' {
+        BeforeEach {
+            $script:Root = Join-Path $TestDrive ([guid]::NewGuid().ToString('N'))
+            $script:Scoop = Join-Path $script:Root 'scoop'
+            $script:Src = New-FakeModuleSource -Path (Join-Path $script:Root 'src\MarkMichaelis.ScoopBucket')
+            $script:Prof = Join-Path $script:Root 'profile\Microsoft.PowerShell_profile.ps1'
+            $script:Link = Join-Path $script:Scoop 'modules\MarkMichaelis.ScoopBucket'
+            New-Item -ItemType Directory -Force -Path (Split-Path -Parent $script:Link) | Out-Null
+        }
+
+        It 'refuses to replace a real directory at the link path and leaves it intact' {
+            New-Item -ItemType Directory -Force -Path $script:Link | Out-Null
+            Set-Content -LiteralPath (Join-Path $script:Link 'keep.txt') -Value 'precious' -Encoding utf8
+            { & $script:Script -ModulePath $script:Src.Path -ScoopRoot $script:Scoop -ProfilePath $script:Prof } | Should -Throw
+            Test-IsJunction -Path $script:Link | Should -BeFalse
+            Test-Path -LiteralPath (Join-Path $script:Link 'keep.txt') | Should -BeTrue
+        }
+
+        It 'refuses to replace a plain file at the link path (the guard is not directory-specific)' {
+            Set-Content -LiteralPath $script:Link -Value 'not a junction' -Encoding utf8
+            { & $script:Script -ModulePath $script:Src.Path -ScoopRoot $script:Scoop -ProfilePath $script:Prof } | Should -Throw
+            (Get-Item -LiteralPath $script:Link -Force).PSIsContainer | Should -BeFalse
+            (Get-Content -Raw -LiteralPath $script:Link).Trim() | Should -Be 'not a junction'
+        }
+
+        It '-Remove leaves a non-junction directory in place and does not throw' {
+            New-Item -ItemType Directory -Force -Path $script:Link | Out-Null
+            Set-Content -LiteralPath (Join-Path $script:Link 'keep.txt') -Value 'precious' -Encoding utf8
+            { & $script:Script -ScoopRoot $script:Scoop -ProfilePath $script:Prof -Remove -WarningAction SilentlyContinue } | Should -Not -Throw
+            Test-Path -LiteralPath (Join-Path $script:Link 'keep.txt') | Should -BeTrue
+        }
+    }
+
     Context 'discovering the module in the scoop bucket clone' {
         It 'junctions to <scoopRoot>\buckets\*\module\MarkMichaelis.ScoopBucket when no source is given' {
             $root = Join-Path $TestDrive ([guid]::NewGuid().ToString('N'))

--- a/bucket/admin/RegisterBucketModule.Tests.ps1
+++ b/bucket/admin/RegisterBucketModule.Tests.ps1
@@ -1,0 +1,130 @@
+#requires -Version 7.0
+# ----------------------------------------------------------------------------
+# Part C behavior tests (Pester v5, Light): Register-BucketModule.ps1 is the
+# opt-in, per-machine helper that makes the bare `Install-Package <x>` wrapper
+# resolve to OUR module. "Installing the module" is two idempotent steps:
+#   1. a junction <scoopRoot>\modules\MarkMichaelis.ScoopBucket -> the module
+#      source (bucket clone, an explicit path, or the local repo checkout);
+#   2. exactly one `Import-Module MarkMichaelis.ScoopBucket` line in $PROFILE.
+# Every case runs against TestDrive via the -ScoopRoot/-ProfilePath/-ModulePath
+# seams, so the host machine is never touched. See #390 (Part C).
+# ----------------------------------------------------------------------------
+
+Set-StrictMode -Version Latest
+
+Describe 'Register-BucketModule' -Tag 'Light', 'Admin' {
+
+    BeforeAll {
+        # bucket\admin -> bucket -> repo root
+        $script:Script = Join-Path (Split-Path -Parent (Split-Path -Parent $PSScriptRoot)) 'Register-BucketModule.ps1'
+
+        function New-FakeModuleSource {
+            param([Parameter(Mandatory)][string]$Path, [string]$Marker = ([guid]::NewGuid().ToString('N')))
+            New-Item -ItemType Directory -Force -Path $Path | Out-Null
+            Set-Content -LiteralPath (Join-Path $Path 'MarkMichaelis.ScoopBucket.psd1') -Value "@{ ModuleVersion = '9.9.9' }" -Encoding utf8
+            Set-Content -LiteralPath (Join-Path $Path 'marker.txt') -Value $Marker -Encoding utf8
+            return [pscustomobject]@{ Path = $Path; Marker = $Marker }
+        }
+        function Get-ImportLineCount {
+            param([string]$ProfilePath)
+            if (-not (Test-Path -LiteralPath $ProfilePath)) { return 0 }
+            @(Get-Content -LiteralPath $ProfilePath | Where-Object { $_ -match '^\s*Import-Module\s+MarkMichaelis\.ScoopBucket\s*$' }).Count
+        }
+        function Test-IsJunction {
+            param([string]$Path)
+            $item = Get-Item -LiteralPath $Path -Force -ErrorAction SilentlyContinue
+            return [bool]($item -and $item.Attributes.HasFlag([System.IO.FileAttributes]::ReparsePoint))
+        }
+        function Read-ThroughLink {
+            param([string]$LinkDir)
+            $p = Join-Path $LinkDir 'marker.txt'
+            if (Test-Path -LiteralPath $p) { return (Get-Content -Raw -LiteralPath $p).Trim() }
+            return ''
+        }
+    }
+
+    Context 'installing from an explicit -ModulePath' {
+        BeforeEach {
+            $script:Root = Join-Path $TestDrive ([guid]::NewGuid().ToString('N'))
+            $script:Scoop = Join-Path $script:Root 'scoop'
+            $script:Src = New-FakeModuleSource -Path (Join-Path $script:Root 'src\MarkMichaelis.ScoopBucket')
+            $script:Prof = Join-Path $script:Root 'profile\Microsoft.PowerShell_profile.ps1'
+            $script:Link = Join-Path $script:Scoop 'modules\MarkMichaelis.ScoopBucket'
+        }
+
+        It 'creates a junction under <scoopRoot>\modules pointing at the module source' {
+            & $script:Script -ModulePath $script:Src.Path -ScoopRoot $script:Scoop -ProfilePath $script:Prof
+            Test-IsJunction -Path $script:Link | Should -BeTrue
+            Read-ThroughLink -LinkDir $script:Link | Should -Be $script:Src.Marker
+        }
+
+        It 'adds exactly one Import-Module line to the profile' {
+            & $script:Script -ModulePath $script:Src.Path -ScoopRoot $script:Scoop -ProfilePath $script:Prof
+            Get-ImportLineCount -ProfilePath $script:Prof | Should -Be 1
+        }
+
+        It 'is idempotent: a second run keeps one junction and one Import-Module line' {
+            & $script:Script -ModulePath $script:Src.Path -ScoopRoot $script:Scoop -ProfilePath $script:Prof
+            & $script:Script -ModulePath $script:Src.Path -ScoopRoot $script:Scoop -ProfilePath $script:Prof
+            Test-IsJunction -Path $script:Link | Should -BeTrue
+            Get-ImportLineCount -ProfilePath $script:Prof | Should -Be 1
+        }
+
+        It '-WhatIf makes no changes' {
+            & $script:Script -ModulePath $script:Src.Path -ScoopRoot $script:Scoop -ProfilePath $script:Prof -WhatIf
+            Test-Path -LiteralPath $script:Link | Should -BeFalse
+            Get-ImportLineCount -ProfilePath $script:Prof | Should -Be 0
+        }
+
+        It '-Remove deletes the junction and strips the Import-Module line (leaving the source intact)' {
+            & $script:Script -ModulePath $script:Src.Path -ScoopRoot $script:Scoop -ProfilePath $script:Prof
+            & $script:Script -ScoopRoot $script:Scoop -ProfilePath $script:Prof -Remove
+            Test-Path -LiteralPath $script:Link | Should -BeFalse
+            Get-ImportLineCount -ProfilePath $script:Prof | Should -Be 0
+            # -Remove must delete only the link, never the real module source.
+            Test-Path -LiteralPath (Join-Path $script:Src.Path 'MarkMichaelis.ScoopBucket.psd1') | Should -BeTrue
+        }
+    }
+
+    Context 'discovering the module in the scoop bucket clone' {
+        It 'junctions to <scoopRoot>\buckets\*\module\MarkMichaelis.ScoopBucket when no source is given' {
+            $root = Join-Path $TestDrive ([guid]::NewGuid().ToString('N'))
+            $scoop = Join-Path $root 'scoop'
+            $clone = New-FakeModuleSource -Path (Join-Path $scoop 'buckets\MarkMichaelis\module\MarkMichaelis.ScoopBucket')
+            $prof = Join-Path $root 'profile.ps1'
+            $link = Join-Path $scoop 'modules\MarkMichaelis.ScoopBucket'
+            & $script:Script -ScoopRoot $scoop -ProfilePath $prof
+            Test-IsJunction -Path $link | Should -BeTrue
+            Read-ThroughLink -LinkDir $link | Should -Be $clone.Marker
+        }
+    }
+
+    Context 'targeting the local repo checkout' {
+        It '-FromLocalRepo junctions to the module dir beside the script' {
+            $root = Join-Path $TestDrive ([guid]::NewGuid().ToString('N'))
+            $scoop = Join-Path $root 'scoop'   # no bucket clone here
+            $prof = Join-Path $root 'profile.ps1'
+            $link = Join-Path $scoop 'modules\MarkMichaelis.ScoopBucket'
+            & $script:Script -FromLocalRepo -ScoopRoot $scoop -ProfilePath $prof
+            Test-IsJunction -Path $link | Should -BeTrue
+            # With no clone and no -ModulePath, the module can only be reached
+            # via the repo checkout beside the script.
+            Test-Path -LiteralPath (Join-Path $link 'MarkMichaelis.ScoopBucket.psd1') | Should -BeTrue
+        }
+    }
+
+    Context 'the RegisterBucketModule manifest wires the script' {
+        BeforeAll {
+            $script:Manifest = Get-Content -Raw -LiteralPath (Join-Path $PSScriptRoot 'RegisterBucketModule.json') | ConvertFrom-Json
+        }
+        It 'url points at the repo-root Register-BucketModule.ps1' {
+            $script:Manifest.url | Should -Be 'https://raw.githubusercontent.com/MarkMichaelis/ScoopBucket/main/Register-BucketModule.ps1'
+        }
+        It 'installer runs the downloaded script' {
+            ($script:Manifest.installer.script -join "`n") | Should -Match 'Register-BucketModule\.ps1'
+        }
+        It 'uninstaller reverses with -Remove' {
+            ($script:Manifest.uninstaller.script -join "`n") | Should -Match '-Remove'
+        }
+    }
+}

--- a/bucket/admin/RegisterBucketModule.Tests.ps1
+++ b/bucket/admin/RegisterBucketModule.Tests.ps1
@@ -107,6 +107,14 @@ Describe 'Register-BucketModule' -Tag 'Light', 'Admin' {
             # The old source must remain intact -- the delete must not follow the link.
             Test-Path -LiteralPath (Join-Path $script:Src.Path 'MarkMichaelis.ScoopBucket.psd1') | Should -BeTrue
         }
+
+        It 'rejects a -ModulePath that points at a file rather than a directory' {
+            $filePath = Join-Path $script:Root 'notadir.txt'
+            New-Item -ItemType Directory -Force -Path $script:Root | Out-Null
+            Set-Content -LiteralPath $filePath -Value 'x' -Encoding utf8
+            { & $script:Script -ModulePath $filePath -ScoopRoot $script:Scoop -ProfilePath $script:Prof } | Should -Throw -ExpectedMessage '*ModulePath not found or not a directory*'
+            Test-Path -LiteralPath $script:Link | Should -BeFalse
+        }
     }
 
     Context 'when a non-junction path already occupies the link location' {

--- a/bucket/admin/RegisterBucketModule.Tests.ps1
+++ b/bucket/admin/RegisterBucketModule.Tests.ps1
@@ -63,6 +63,19 @@ Describe 'Register-BucketModule' -Tag 'Light', 'Admin' {
             Get-ImportLineCount -ProfilePath $script:Prof | Should -Be 1
         }
 
+        It 'rewrites a profile saved as UTF-16 to a single consistent UTF-8 encoding' {
+            New-Item -ItemType Directory -Force -Path (Split-Path -Parent $script:Prof) | Out-Null
+            Set-Content -LiteralPath $script:Prof -Value '# pre-existing profile line' -Encoding unicode
+            & $script:Script -ModulePath $script:Src.Path -ScoopRoot $script:Scoop -ProfilePath $script:Prof
+            Get-ImportLineCount -ProfilePath $script:Prof | Should -Be 1
+            # The original line must survive intact (not mojibake from a mixed-encoding append).
+            (Get-Content -Raw -LiteralPath $script:Prof) | Should -Match 'pre-existing profile line'
+            # The whole file must be rewritten as UTF-8, never left as UTF-16 (BOM 0xFF 0xFE),
+            # so the profile never ends up with a mixed/inconsistent encoding.
+            $bytes = [System.IO.File]::ReadAllBytes($script:Prof)
+            ($bytes[0] -eq 0xFF -and $bytes[1] -eq 0xFE) | Should -BeFalse -Because 'the profile should be normalized to UTF-8, not left as UTF-16'
+        }
+
         It 'is idempotent: a second run keeps one junction and one Import-Module line' {
             & $script:Script -ModulePath $script:Src.Path -ScoopRoot $script:Scoop -ProfilePath $script:Prof
             & $script:Script -ModulePath $script:Src.Path -ScoopRoot $script:Scoop -ProfilePath $script:Prof

--- a/bucket/admin/RegisterBucketModule.Tests.ps1
+++ b/bucket/admin/RegisterBucketModule.Tests.ps1
@@ -84,6 +84,29 @@ Describe 'Register-BucketModule' -Tag 'Light', 'Admin' {
             # -Remove must delete only the link, never the real module source.
             Test-Path -LiteralPath (Join-Path $script:Src.Path 'MarkMichaelis.ScoopBucket.psd1') | Should -BeTrue
         }
+
+        It '-Remove deletes a junction that carries the ReadOnly attribute (some hosts set it)' {
+            & $script:Script -ModulePath $script:Src.Path -ScoopRoot $script:Scoop -ProfilePath $script:Prof
+            # New-Item -ItemType Junction sets ReadOnly on some hosts; simulate that so a
+            # plain (Get-Item).Delete() would fail with Access denied. See PR #391 review.
+            $item = Get-Item -LiteralPath $script:Link -Force
+            $item.Attributes = $item.Attributes -bor [System.IO.FileAttributes]::ReadOnly
+            & $script:Script -ScoopRoot $script:Scoop -ProfilePath $script:Prof -Remove
+            Test-Path -LiteralPath $script:Link | Should -BeFalse
+            Test-Path -LiteralPath (Join-Path $script:Src.Path 'MarkMichaelis.ScoopBucket.psd1') | Should -BeTrue
+        }
+
+        It 're-points a stale ReadOnly junction to a new source without following the reparse point' {
+            & $script:Script -ModulePath $script:Src.Path -ScoopRoot $script:Scoop -ProfilePath $script:Prof
+            $item = Get-Item -LiteralPath $script:Link -Force
+            $item.Attributes = $item.Attributes -bor [System.IO.FileAttributes]::ReadOnly
+            $src2 = New-FakeModuleSource -Path (Join-Path $script:Root 'src2\MarkMichaelis.ScoopBucket')
+            & $script:Script -ModulePath $src2.Path -ScoopRoot $script:Scoop -ProfilePath $script:Prof
+            Test-IsJunction -Path $script:Link | Should -BeTrue
+            Read-ThroughLink -LinkDir $script:Link | Should -Be $src2.Marker
+            # The old source must remain intact -- the delete must not follow the link.
+            Test-Path -LiteralPath (Join-Path $script:Src.Path 'MarkMichaelis.ScoopBucket.psd1') | Should -BeTrue
+        }
     }
 
     Context 'discovering the module in the scoop bucket clone' {

--- a/bucket/admin/RegisterBucketModule.json
+++ b/bucket/admin/RegisterBucketModule.json
@@ -2,7 +2,7 @@
   "$schema": "https://raw.githubusercontent.com/lukesampson/scoop/master/schema.json",
   "homepage": "https://github.com/MarkMichaelis/ScoopBucket",
   "description": "Opt-in: register MarkMichaelis.ScoopBucket on this machine so the bare Install-Package wrapper resolves to this bucket's module. Creates a junction under scoop\\modules and adds one Import-Module line to the CurrentUserAllHosts profile. Idempotent; supports -WhatIf.",
-  "notes": "This edits your CurrentUserAllHosts PowerShell profile (adds a single 'Import-Module MarkMichaelis.ScoopBucket' line) and creates a junction at <scoopRoot>\\modules\\MarkMichaelis.ScoopBucket pointing at the bucket clone's module. Re-running is idempotent. Reverse it with 'scoop uninstall RegisterBucketModule'. Preview first from the bucket clone with 'Register-BucketModule.ps1 -WhatIf'.",
+  "notes": "This edits your CurrentUserAllHosts PowerShell profile (adds a single 'Import-Module MarkMichaelis.ScoopBucket' line) and creates a junction at <scoopRoot>\\modules\\MarkMichaelis.ScoopBucket pointing at the bucket clone's module. Re-running is idempotent. Reverse it with 'scoop uninstall RegisterBucketModule'. To preview changes without applying them, run the installed script with -WhatIf: & (Join-Path (scoop prefix RegisterBucketModule) 'Register-BucketModule.ps1') -WhatIf (or run '.\\Register-BucketModule.ps1 -WhatIf' from a repo or bucket clone).",
   "version": "1.00.000",
   "url": "https://raw.githubusercontent.com/MarkMichaelis/ScoopBucket/main/Register-BucketModule.ps1",
   "installer": {

--- a/bucket/admin/RegisterBucketModule.json
+++ b/bucket/admin/RegisterBucketModule.json
@@ -1,0 +1,18 @@
+{
+  "$schema": "https://raw.githubusercontent.com/lukesampson/scoop/master/schema.json",
+  "homepage": "https://github.com/MarkMichaelis/ScoopBucket",
+  "description": "Opt-in: register MarkMichaelis.ScoopBucket on this machine so the bare Install-Package wrapper resolves to this bucket's module. Creates a junction under scoop\\modules and adds one Import-Module line to the CurrentUserAllHosts profile. Idempotent; supports -WhatIf.",
+  "notes": "This edits your CurrentUserAllHosts PowerShell profile (adds a single 'Import-Module MarkMichaelis.ScoopBucket' line) and creates a junction at <scoopRoot>\\modules\\MarkMichaelis.ScoopBucket pointing at the bucket clone's module. Re-running is idempotent. Reverse it with 'scoop uninstall RegisterBucketModule'. Preview first from the bucket clone with 'Register-BucketModule.ps1 -WhatIf'.",
+  "version": "1.00.000",
+  "url": "https://raw.githubusercontent.com/MarkMichaelis/ScoopBucket/main/Register-BucketModule.ps1",
+  "installer": {
+    "script": [
+      "& \"$dir\\Register-BucketModule.ps1\" -ScoopRoot (Resolve-Path \"$dir\\..\\..\\..\").Path"
+    ]
+  },
+  "uninstaller": {
+    "script": [
+      "& \"$dir\\Register-BucketModule.ps1\" -Remove -ScoopRoot (Resolve-Path \"$dir\\..\\..\\..\").Path"
+    ]
+  }
+}

--- a/bucket/ai/ChatGPT.json
+++ b/bucket/ai/ChatGPT.json
@@ -1,6 +1,6 @@
 {
     "$schema": "https://raw.githubusercontent.com/lukesampson/scoop/master/schema.json",
-    "version": "1.12.000",
+    "version": "1.13.000",
     "url": [
         "https://raw.githubusercontent.com/MarkMichaelis/ScoopBucket/main/bucket/ai/ChatGPT.ps1"
     ],

--- a/bucket/ai/ChatGPT.ps1
+++ b/bucket/ai/ChatGPT.ps1
@@ -1,5 +1,13 @@
-$scoopBucketPsd1 = Join-Path $PSScriptRoot '..\..\module\MarkMichaelis.ScoopBucket\MarkMichaelis.ScoopBucket.psd1'
-if (Test-Path $scoopBucketPsd1) { Import-Module $scoopBucketPsd1 -Force } else { Import-Module MarkMichaelis.ScoopBucket -Force }
+#region MarkMichaelis.ScoopBucket bundle module import (scoop-portable; see README)
+$scoopBucketModule = 'MarkMichaelis.ScoopBucket'
+$scoopBucketPsd1 = Join-Path $PSScriptRoot "..\..\module\$scoopBucketModule\$scoopBucketModule.psd1"
+if (-not (Test-Path $scoopBucketPsd1)) {
+    $scoopBucketRoot = if ($env:SCOOP) { $env:SCOOP } else { Join-Path $PSScriptRoot '..\..\..' }
+    $scoopBucketFound = Get-ChildItem -Path (Join-Path $scoopBucketRoot "buckets\*\module\$scoopBucketModule\$scoopBucketModule.psd1") -ErrorAction SilentlyContinue | Select-Object -First 1
+    if ($scoopBucketFound) { $scoopBucketPsd1 = $scoopBucketFound.FullName }
+}
+if (Test-Path $scoopBucketPsd1) { Import-Module $scoopBucketPsd1 -Force } else { Import-Module $scoopBucketModule -Force }
+#endregion MarkMichaelis.ScoopBucket bundle module import
 
 # OpenAI ships the official ChatGPT desktop app via the Microsoft Store
 # (Publisher: OpenAI, ProductId: 9NT1R1C2HH7J). winget's `msstore` source

--- a/bucket/ai/ClaudeExcel.json
+++ b/bucket/ai/ClaudeExcel.json
@@ -1,6 +1,6 @@
 {
     "$schema": "https://raw.githubusercontent.com/lukesampson/scoop/master/schema.json",
-    "version": "1.08.000",
+    "version": "1.09.000",
     "url": [
         "https://raw.githubusercontent.com/MarkMichaelis/ScoopBucket/main/bucket/ai/ClaudeExcel.ps1"
     ],

--- a/bucket/ai/ClaudeExcel.ps1
+++ b/bucket/ai/ClaudeExcel.ps1
@@ -1,6 +1,14 @@
 
-$scoopBucketPsd1 = Join-Path $PSScriptRoot '..\..\module\MarkMichaelis.ScoopBucket\MarkMichaelis.ScoopBucket.psd1'
-if (Test-Path $scoopBucketPsd1) { Import-Module $scoopBucketPsd1 -Force } else { Import-Module MarkMichaelis.ScoopBucket -Force }
+#region MarkMichaelis.ScoopBucket bundle module import (scoop-portable; see README)
+$scoopBucketModule = 'MarkMichaelis.ScoopBucket'
+$scoopBucketPsd1 = Join-Path $PSScriptRoot "..\..\module\$scoopBucketModule\$scoopBucketModule.psd1"
+if (-not (Test-Path $scoopBucketPsd1)) {
+    $scoopBucketRoot = if ($env:SCOOP) { $env:SCOOP } else { Join-Path $PSScriptRoot '..\..\..' }
+    $scoopBucketFound = Get-ChildItem -Path (Join-Path $scoopBucketRoot "buckets\*\module\$scoopBucketModule\$scoopBucketModule.psd1") -ErrorAction SilentlyContinue | Select-Object -First 1
+    if ($scoopBucketFound) { $scoopBucketPsd1 = $scoopBucketFound.FullName }
+}
+if (Test-Path $scoopBucketPsd1) { Import-Module $scoopBucketPsd1 -Force } else { Import-Module $scoopBucketModule -Force }
+#endregion MarkMichaelis.ScoopBucket bundle module import
 
 # Claude for Excel is an Office Web Add-in (Microsoft 365 only), distributed
 # exclusively through Microsoft AppSource as asset id WA200010001 - it has no

--- a/bucket/ai/Gemini.json
+++ b/bucket/ai/Gemini.json
@@ -1,6 +1,6 @@
 {
     "$schema": "https://raw.githubusercontent.com/lukesampson/scoop/master/schema.json",
-    "version": "1.12.000",
+    "version": "1.13.000",
     "url": [
         "https://raw.githubusercontent.com/MarkMichaelis/ScoopBucket/main/bucket/ai/Gemini.ps1"
     ],

--- a/bucket/ai/Gemini.ps1
+++ b/bucket/ai/Gemini.ps1
@@ -1,6 +1,14 @@
 
-$scoopBucketPsd1 = Join-Path $PSScriptRoot '..\..\module\MarkMichaelis.ScoopBucket\MarkMichaelis.ScoopBucket.psd1'
-if (Test-Path $scoopBucketPsd1) { Import-Module $scoopBucketPsd1 -Force } else { Import-Module MarkMichaelis.ScoopBucket -Force }
+#region MarkMichaelis.ScoopBucket bundle module import (scoop-portable; see README)
+$scoopBucketModule = 'MarkMichaelis.ScoopBucket'
+$scoopBucketPsd1 = Join-Path $PSScriptRoot "..\..\module\$scoopBucketModule\$scoopBucketModule.psd1"
+if (-not (Test-Path $scoopBucketPsd1)) {
+    $scoopBucketRoot = if ($env:SCOOP) { $env:SCOOP } else { Join-Path $PSScriptRoot '..\..\..' }
+    $scoopBucketFound = Get-ChildItem -Path (Join-Path $scoopBucketRoot "buckets\*\module\$scoopBucketModule\$scoopBucketModule.psd1") -ErrorAction SilentlyContinue | Select-Object -First 1
+    if ($scoopBucketFound) { $scoopBucketPsd1 = $scoopBucketFound.FullName }
+}
+if (Test-Path $scoopBucketPsd1) { Import-Module $scoopBucketPsd1 -Force } else { Import-Module $scoopBucketModule -Force }
+#endregion MarkMichaelis.ScoopBucket bundle module import
 
 # Google's "Google app for desktop" (which embeds Gemini and binds Alt+Space)
 # is the only official Windows-native Gemini surface. Google does not publish

--- a/bucket/client/MicrosoftOffice365.json
+++ b/bucket/client/MicrosoftOffice365.json
@@ -1,6 +1,6 @@
 {
     "$schema": "https://raw.githubusercontent.com/lukesampson/scoop/master/schema.json",
-    "version": "1.14.000",
+    "version": "1.15.000",
     "url": [
         "https://raw.githubusercontent.com/MarkMichaelis/ScoopBucket/main/bucket/client/MicrosoftOffice365.ps1"
     ],

--- a/bucket/client/MicrosoftOffice365.ps1
+++ b/bucket/client/MicrosoftOffice365.ps1
@@ -1,5 +1,13 @@
-$scoopBucketPsd1 = Join-Path $PSScriptRoot '..\..\module\MarkMichaelis.ScoopBucket\MarkMichaelis.ScoopBucket.psd1'
-if (Test-Path $scoopBucketPsd1) { Import-Module $scoopBucketPsd1 -Force } else { Import-Module MarkMichaelis.ScoopBucket -Force }
+#region MarkMichaelis.ScoopBucket bundle module import (scoop-portable; see README)
+$scoopBucketModule = 'MarkMichaelis.ScoopBucket'
+$scoopBucketPsd1 = Join-Path $PSScriptRoot "..\..\module\$scoopBucketModule\$scoopBucketModule.psd1"
+if (-not (Test-Path $scoopBucketPsd1)) {
+    $scoopBucketRoot = if ($env:SCOOP) { $env:SCOOP } else { Join-Path $PSScriptRoot '..\..\..' }
+    $scoopBucketFound = Get-ChildItem -Path (Join-Path $scoopBucketRoot "buckets\*\module\$scoopBucketModule\$scoopBucketModule.psd1") -ErrorAction SilentlyContinue | Select-Object -First 1
+    if ($scoopBucketFound) { $scoopBucketPsd1 = $scoopBucketFound.FullName }
+}
+if (Test-Path $scoopBucketPsd1) { Import-Module $scoopBucketPsd1 -Force } else { Import-Module $scoopBucketModule -Force }
+#endregion MarkMichaelis.ScoopBucket bundle module import
 
 # Microsoft 365 baseline: Office ProPlus + Teams + any Office Web Add-ins.
 # Claude for Excel lives here (not AIAgents) because it is delivered through

--- a/bucket/developer/Aspire.json
+++ b/bucket/developer/Aspire.json
@@ -1,6 +1,6 @@
 {
     "$schema": "https://raw.githubusercontent.com/lukesampson/scoop/master/schema.json",
-    "version": "1.10.000",
+    "version": "1.11.000",
     "url": [
         "https://raw.githubusercontent.com/MarkMichaelis/ScoopBucket/main/bucket/developer/Aspire.ps1"
     ],

--- a/bucket/developer/Aspire.ps1
+++ b/bucket/developer/Aspire.ps1
@@ -1,5 +1,13 @@
-$scoopBucketPsd1 = Join-Path $PSScriptRoot '..\..\module\MarkMichaelis.ScoopBucket\MarkMichaelis.ScoopBucket.psd1'
-if (Test-Path $scoopBucketPsd1) { Import-Module $scoopBucketPsd1 -Force } else { Import-Module MarkMichaelis.ScoopBucket -Force }
+#region MarkMichaelis.ScoopBucket bundle module import (scoop-portable; see README)
+$scoopBucketModule = 'MarkMichaelis.ScoopBucket'
+$scoopBucketPsd1 = Join-Path $PSScriptRoot "..\..\module\$scoopBucketModule\$scoopBucketModule.psd1"
+if (-not (Test-Path $scoopBucketPsd1)) {
+    $scoopBucketRoot = if ($env:SCOOP) { $env:SCOOP } else { Join-Path $PSScriptRoot '..\..\..' }
+    $scoopBucketFound = Get-ChildItem -Path (Join-Path $scoopBucketRoot "buckets\*\module\$scoopBucketModule\$scoopBucketModule.psd1") -ErrorAction SilentlyContinue | Select-Object -First 1
+    if ($scoopBucketFound) { $scoopBucketPsd1 = $scoopBucketFound.FullName }
+}
+if (Test-Path $scoopBucketPsd1) { Import-Module $scoopBucketPsd1 -Force } else { Import-Module $scoopBucketModule -Force }
+#endregion MarkMichaelis.ScoopBucket bundle module import
 
 # Microsoft .NET Aspire delivers two artefacts:
 #   1. Aspire.Cli           — global dotnet tool providing the `aspire` command.

--- a/bucket/developer/Chocolatey.json
+++ b/bucket/developer/Chocolatey.json
@@ -1,6 +1,6 @@
 {
     "$schema": "https://raw.githubusercontent.com/lukesampson/scoop/master/schema.json",
-    "version": "1.10.000",
+    "version": "1.11.000",
     "url": [
         "https://raw.githubusercontent.com/MarkMichaelis/ScoopBucket/main/bucket/developer/Chocolatey.ps1"
     ],

--- a/bucket/developer/Chocolatey.ps1
+++ b/bucket/developer/Chocolatey.ps1
@@ -1,7 +1,15 @@
 Write-Verbose 'Installing and configuring Chocolatey...'
 
-$scoopBucketPsd1 = Join-Path $PSScriptRoot '..\..\module\MarkMichaelis.ScoopBucket\MarkMichaelis.ScoopBucket.psd1'
-if (Test-Path $scoopBucketPsd1) { Import-Module $scoopBucketPsd1 -Force } else { Import-Module MarkMichaelis.ScoopBucket -Force }
+#region MarkMichaelis.ScoopBucket bundle module import (scoop-portable; see README)
+$scoopBucketModule = 'MarkMichaelis.ScoopBucket'
+$scoopBucketPsd1 = Join-Path $PSScriptRoot "..\..\module\$scoopBucketModule\$scoopBucketModule.psd1"
+if (-not (Test-Path $scoopBucketPsd1)) {
+    $scoopBucketRoot = if ($env:SCOOP) { $env:SCOOP } else { Join-Path $PSScriptRoot '..\..\..' }
+    $scoopBucketFound = Get-ChildItem -Path (Join-Path $scoopBucketRoot "buckets\*\module\$scoopBucketModule\$scoopBucketModule.psd1") -ErrorAction SilentlyContinue | Select-Object -First 1
+    if ($scoopBucketFound) { $scoopBucketPsd1 = $scoopBucketFound.FullName }
+}
+if (Test-Path $scoopBucketPsd1) { Import-Module $scoopBucketPsd1 -Force } else { Import-Module $scoopBucketModule -Force }
+#endregion MarkMichaelis.ScoopBucket bundle module import
 
 Function Install-Chocolatey {
     

--- a/bucket/developer/GitConfigBeyondCompare.json
+++ b/bucket/developer/GitConfigBeyondCompare.json
@@ -1,6 +1,6 @@
 {
     "$schema": "https://raw.githubusercontent.com/lukesampson/scoop/master/schema.json",
-    "version": "1.13.000",
+    "version": "1.14.000",
     "url": [
         "https://raw.githubusercontent.com/MarkMichaelis/ScoopBucket/main/bucket/developer/GitConfigBeyondCompare.ps1"
     ],

--- a/bucket/developer/GitConfigBeyondCompare.ps1
+++ b/bucket/developer/GitConfigBeyondCompare.ps1
@@ -1,6 +1,14 @@
 
-$scoopBucketPsd1 = Join-Path $PSScriptRoot '..\..\module\MarkMichaelis.ScoopBucket\MarkMichaelis.ScoopBucket.psd1'
-if (Test-Path $scoopBucketPsd1) { Import-Module $scoopBucketPsd1 -Force } else { Import-Module MarkMichaelis.ScoopBucket -Force }
+#region MarkMichaelis.ScoopBucket bundle module import (scoop-portable; see README)
+$scoopBucketModule = 'MarkMichaelis.ScoopBucket'
+$scoopBucketPsd1 = Join-Path $PSScriptRoot "..\..\module\$scoopBucketModule\$scoopBucketModule.psd1"
+if (-not (Test-Path $scoopBucketPsd1)) {
+    $scoopBucketRoot = if ($env:SCOOP) { $env:SCOOP } else { Join-Path $PSScriptRoot '..\..\..' }
+    $scoopBucketFound = Get-ChildItem -Path (Join-Path $scoopBucketRoot "buckets\*\module\$scoopBucketModule\$scoopBucketModule.psd1") -ErrorAction SilentlyContinue | Select-Object -First 1
+    if ($scoopBucketFound) { $scoopBucketPsd1 = $scoopBucketFound.FullName }
+}
+if (Test-Path $scoopBucketPsd1) { Import-Module $scoopBucketPsd1 -Force } else { Import-Module $scoopBucketModule -Force }
+#endregion MarkMichaelis.ScoopBucket bundle module import
 
 
 Function Get-BeyondCompareDirFromRegistry {

--- a/bucket/developer/GitConfigVSCode.json
+++ b/bucket/developer/GitConfigVSCode.json
@@ -1,6 +1,6 @@
 {
     "$schema": "https://raw.githubusercontent.com/lukesampson/scoop/master/schema.json",
-    "version": "1.03.000",
+    "version": "1.04.000",
     "url": [
         "https://raw.githubusercontent.com/MarkMichaelis/ScoopBucket/main/bucket/developer/GitConfigVSCode.ps1",
         "https://raw.githubusercontent.com/MarkMichaelis/ScoopBucket/main/bucket/developer/Invoke-GitDiffCode.ps1"

--- a/bucket/developer/GitConfigVSCode.ps1
+++ b/bucket/developer/GitConfigVSCode.ps1
@@ -1,6 +1,14 @@
 
-$scoopBucketPsd1 = Join-Path $PSScriptRoot '..\..\module\MarkMichaelis.ScoopBucket\MarkMichaelis.ScoopBucket.psd1'
-if (Test-Path $scoopBucketPsd1) { Import-Module $scoopBucketPsd1 -Force } else { Import-Module MarkMichaelis.ScoopBucket -Force }
+#region MarkMichaelis.ScoopBucket bundle module import (scoop-portable; see README)
+$scoopBucketModule = 'MarkMichaelis.ScoopBucket'
+$scoopBucketPsd1 = Join-Path $PSScriptRoot "..\..\module\$scoopBucketModule\$scoopBucketModule.psd1"
+if (-not (Test-Path $scoopBucketPsd1)) {
+    $scoopBucketRoot = if ($env:SCOOP) { $env:SCOOP } else { Join-Path $PSScriptRoot '..\..\..' }
+    $scoopBucketFound = Get-ChildItem -Path (Join-Path $scoopBucketRoot "buckets\*\module\$scoopBucketModule\$scoopBucketModule.psd1") -ErrorAction SilentlyContinue | Select-Object -First 1
+    if ($scoopBucketFound) { $scoopBucketPsd1 = $scoopBucketFound.FullName }
+}
+if (Test-Path $scoopBucketPsd1) { Import-Module $scoopBucketPsd1 -Force } else { Import-Module $scoopBucketModule -Force }
+#endregion MarkMichaelis.ScoopBucket bundle module import
 
 
 Function Resolve-VSCodeCommand {

--- a/bucket/developer/GitConfigVisualStudio.json
+++ b/bucket/developer/GitConfigVisualStudio.json
@@ -1,6 +1,6 @@
 {
     "$schema": "https://raw.githubusercontent.com/lukesampson/scoop/master/schema.json",
-    "version": "1.10.000",
+    "version": "1.11.000",
     "url": [
         "https://raw.githubusercontent.com/MarkMichaelis/ScoopBucket/main/bucket/developer/GitConfigVisualStudio.ps1"
     ],

--- a/bucket/developer/GitConfigVisualStudio.ps1
+++ b/bucket/developer/GitConfigVisualStudio.ps1
@@ -1,6 +1,14 @@
 
-$scoopBucketPsd1 = Join-Path $PSScriptRoot '..\..\module\MarkMichaelis.ScoopBucket\MarkMichaelis.ScoopBucket.psd1'
-if (Test-Path $scoopBucketPsd1) { Import-Module $scoopBucketPsd1 -Force } else { Import-Module MarkMichaelis.ScoopBucket -Force }
+#region MarkMichaelis.ScoopBucket bundle module import (scoop-portable; see README)
+$scoopBucketModule = 'MarkMichaelis.ScoopBucket'
+$scoopBucketPsd1 = Join-Path $PSScriptRoot "..\..\module\$scoopBucketModule\$scoopBucketModule.psd1"
+if (-not (Test-Path $scoopBucketPsd1)) {
+    $scoopBucketRoot = if ($env:SCOOP) { $env:SCOOP } else { Join-Path $PSScriptRoot '..\..\..' }
+    $scoopBucketFound = Get-ChildItem -Path (Join-Path $scoopBucketRoot "buckets\*\module\$scoopBucketModule\$scoopBucketModule.psd1") -ErrorAction SilentlyContinue | Select-Object -First 1
+    if ($scoopBucketFound) { $scoopBucketPsd1 = $scoopBucketFound.FullName }
+}
+if (Test-Path $scoopBucketPsd1) { Import-Module $scoopBucketPsd1 -Force } else { Import-Module $scoopBucketModule -Force }
+#endregion MarkMichaelis.ScoopBucket bundle module import
 
 
 Function Invoke-GitConfigVisualStudio {

--- a/bucket/developer/GitConfigure.json
+++ b/bucket/developer/GitConfigure.json
@@ -1,6 +1,6 @@
 {
     "$schema": "https://raw.githubusercontent.com/lukesampson/scoop/master/schema.json",
-    "version": "1.23.000",
+    "version": "1.24.000",
     "url": [
         "https://raw.githubusercontent.com/MarkMichaelis/ScoopBucket/main/bucket/developer/GitConfigBeyondCompare.ps1",
         "https://raw.githubusercontent.com/MarkMichaelis/ScoopBucket/main/bucket/developer/GitConfigVSCode.ps1",

--- a/bucket/developer/GitConfigure.ps1
+++ b/bucket/developer/GitConfigure.ps1
@@ -1,6 +1,14 @@
 
-$scoopBucketPsd1 = Join-Path $PSScriptRoot '..\..\module\MarkMichaelis.ScoopBucket\MarkMichaelis.ScoopBucket.psd1'
-if (Test-Path $scoopBucketPsd1) { Import-Module $scoopBucketPsd1 -Force } else { Import-Module MarkMichaelis.ScoopBucket -Force }
+#region MarkMichaelis.ScoopBucket bundle module import (scoop-portable; see README)
+$scoopBucketModule = 'MarkMichaelis.ScoopBucket'
+$scoopBucketPsd1 = Join-Path $PSScriptRoot "..\..\module\$scoopBucketModule\$scoopBucketModule.psd1"
+if (-not (Test-Path $scoopBucketPsd1)) {
+    $scoopBucketRoot = if ($env:SCOOP) { $env:SCOOP } else { Join-Path $PSScriptRoot '..\..\..' }
+    $scoopBucketFound = Get-ChildItem -Path (Join-Path $scoopBucketRoot "buckets\*\module\$scoopBucketModule\$scoopBucketModule.psd1") -ErrorAction SilentlyContinue | Select-Object -First 1
+    if ($scoopBucketFound) { $scoopBucketPsd1 = $scoopBucketFound.FullName }
+}
+if (Test-Path $scoopBucketPsd1) { Import-Module $scoopBucketPsd1 -Force } else { Import-Module $scoopBucketModule -Force }
+#endregion MarkMichaelis.ScoopBucket bundle module import
 . "$PSScriptRoot\GitConfigBeyondCompare.ps1" # Runs Invoke-GitConfigBeyondCompare
 . "$PSScriptRoot\GitConfigVSCode.ps1"        # Runs Invoke-GitConfigVSCode
 . "$PSScriptRoot\GitConfigVisualStudio.ps1"  # Runs Invoke-GitConfigVisualStudio

--- a/bucket/developer/PowerShell.ps1
+++ b/bucket/developer/PowerShell.ps1
@@ -1,7 +1,15 @@
 
 Write-Verbose 'Installing and configuring PowerShell...'
-$scoopBucketPsd1 = Join-Path $PSScriptRoot '..\..\module\MarkMichaelis.ScoopBucket\MarkMichaelis.ScoopBucket.psd1'
-if (Test-Path $scoopBucketPsd1) { Import-Module $scoopBucketPsd1 -Force } else { Import-Module MarkMichaelis.ScoopBucket -Force }
+#region MarkMichaelis.ScoopBucket bundle module import (scoop-portable; see README)
+$scoopBucketModule = 'MarkMichaelis.ScoopBucket'
+$scoopBucketPsd1 = Join-Path $PSScriptRoot "..\..\module\$scoopBucketModule\$scoopBucketModule.psd1"
+if (-not (Test-Path $scoopBucketPsd1)) {
+    $scoopBucketRoot = if ($env:SCOOP) { $env:SCOOP } else { Join-Path $PSScriptRoot '..\..\..' }
+    $scoopBucketFound = Get-ChildItem -Path (Join-Path $scoopBucketRoot "buckets\*\module\$scoopBucketModule\$scoopBucketModule.psd1") -ErrorAction SilentlyContinue | Select-Object -First 1
+    if ($scoopBucketFound) { $scoopBucketPsd1 = $scoopBucketFound.FullName }
+}
+if (Test-Path $scoopBucketPsd1) { Import-Module $scoopBucketPsd1 -Force } else { Import-Module $scoopBucketModule -Force }
+#endregion MarkMichaelis.ScoopBucket bundle module import
 
 # Remove the Microsoft Store / MSIX build of PowerShell 7 so the first-party
 # MSI build (C:\Program Files\PowerShell\7) is the resolved `pwsh` and its

--- a/bucket/developer/PowerShellCore.json
+++ b/bucket/developer/PowerShellCore.json
@@ -1,6 +1,6 @@
 {
     "$schema": "https://raw.githubusercontent.com/lukesampson/scoop/master/schema.json",
-    "version": "1.15.000",
+    "version": "1.16.000",
     "url": [
         "https://raw.githubusercontent.com/MarkMichaelis/ScoopBucket/main/bucket/developer/PowerShell.ps1"
     ],

--- a/bucket/developer/PowerShellWindows.json
+++ b/bucket/developer/PowerShellWindows.json
@@ -1,6 +1,6 @@
 {
     "$schema": "https://raw.githubusercontent.com/lukesampson/scoop/master/schema.json",
-    "version": "1.16.000",
+    "version": "1.17.000",
     "url": [
         "https://raw.githubusercontent.com/MarkMichaelis/ScoopBucket/main/bucket/developer/PowerShell.ps1"
     ],

--- a/bucket/os/McAfeeUninstall.json
+++ b/bucket/os/McAfeeUninstall.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/lukesampson/scoop/master/schema.json",
-  "version": "1.01.001",
+  "version": "1.02.000",
   "url": [
     "https://raw.githubusercontent.com/MarkMichaelis/ScoopBucket/main/bucket/os/McAfeeUninstall.ps1",
     "https://download.mcafee.com/molbin/iss-loc/SupportTools/MCPR/MCPR.exe"

--- a/bucket/os/McAfeeUninstall.ps1
+++ b/bucket/os/McAfeeUninstall.ps1
@@ -1,8 +1,16 @@
 
 Write-Host "Uninstalling McAfee Applications..."
 
-$scoopBucketPsd1 = Join-Path $PSScriptRoot '..\..\module\MarkMichaelis.ScoopBucket\MarkMichaelis.ScoopBucket.psd1'
-if (Test-Path $scoopBucketPsd1) { Import-Module $scoopBucketPsd1 -Force } else { Import-Module MarkMichaelis.ScoopBucket -Force }
+#region MarkMichaelis.ScoopBucket bundle module import (scoop-portable; see README)
+$scoopBucketModule = 'MarkMichaelis.ScoopBucket'
+$scoopBucketPsd1 = Join-Path $PSScriptRoot "..\..\module\$scoopBucketModule\$scoopBucketModule.psd1"
+if (-not (Test-Path $scoopBucketPsd1)) {
+    $scoopBucketRoot = if ($env:SCOOP) { $env:SCOOP } else { Join-Path $PSScriptRoot '..\..\..' }
+    $scoopBucketFound = Get-ChildItem -Path (Join-Path $scoopBucketRoot "buckets\*\module\$scoopBucketModule\$scoopBucketModule.psd1") -ErrorAction SilentlyContinue | Select-Object -First 1
+    if ($scoopBucketFound) { $scoopBucketPsd1 = $scoopBucketFound.FullName }
+}
+if (Test-Path $scoopBucketPsd1) { Import-Module $scoopBucketPsd1 -Force } else { Import-Module $scoopBucketModule -Force }
+#endregion MarkMichaelis.ScoopBucket bundle module import
 
 Function Uninstall-McAfeeApplications {
     Get-Program 'McAfee*' | ForEach-Object {

--- a/docs/designs/2026-06-30-scoop-bucket-module-load-plan.md
+++ b/docs/designs/2026-06-30-scoop-bucket-module-load-plan.md
@@ -50,7 +50,9 @@ New repo-root `Register-BucketModule.ps1` (`[CmdletBinding(SupportsShouldProcess
 - Appends exactly one idempotent, sentinel-bracketed `Import-Module MarkMichaelis.ScoopBucket`
   block to `-ProfilePath` (default `$PROFILE.CurrentUserAllHosts`). Distinct sentinel
   (`RegisterBucketModule`) so it never collides with Install-Module.ps1's lazy v3 block.
-- `-Remove` reverses both (junction only if it points at our module; profile block always).
+- `-Remove` reverses both: the junction (only when it is a reparse point at that path -- a
+  real directory there is left untouched with a warning, and only the link is deleted, never
+  the target contents) and the sentinel-bracketed profile block (always).
 
 New opt-in manifest `bucket\admin\RegisterBucketModule.json` (mirrors the admin precedent;
 NO new executable `.ps1` under bucket/ so bundle discovery never executes it):

--- a/docs/designs/2026-06-30-scoop-bucket-module-load-plan.md
+++ b/docs/designs/2026-06-30-scoop-bucket-module-load-plan.md
@@ -1,0 +1,92 @@
+# Plan: Fix scoop bundle module load + opt-in per-machine module registration (#390)
+
+Date: 2026-06-30
+Branch: feat/390-scoop-bucket-module-load
+
+## Part B -- portable core fix (the original bug)
+
+Replace the 2-line module-import header in all 16 production bundle `.ps1` files with a
+3-branch, self-contained, region-delimited block. Branch 1 (repo checkout) keeps each
+file's existing depth; branch 2 (scoop bucket clone) is new; branch 3 (by-name) last.
+
+Canonical block (top-level bundles use `..\module`; subdir bundles use `..\..\module`
+on the psd1 Join-Path line -- everything else identical):
+
+```powershell
+#region MarkMichaelis.ScoopBucket bundle module import (scoop-portable; see README)
+$scoopBucketModule = 'MarkMichaelis.ScoopBucket'
+$scoopBucketPsd1 = Join-Path $PSScriptRoot "..\module\$scoopBucketModule\$scoopBucketModule.psd1"
+if (-not (Test-Path $scoopBucketPsd1)) {
+    $scoopBucketRoot = if ($env:SCOOP) { $env:SCOOP } else { Join-Path $PSScriptRoot '..\..\..' }
+    $scoopBucketFound = Get-ChildItem -Path (Join-Path $scoopBucketRoot "buckets\*\module\$scoopBucketModule\$scoopBucketModule.psd1") -ErrorAction SilentlyContinue | Select-Object -First 1
+    if ($scoopBucketFound) { $scoopBucketPsd1 = $scoopBucketFound.FullName }
+}
+if (Test-Path $scoopBucketPsd1) { Import-Module $scoopBucketPsd1 -Force } else { Import-Module $scoopBucketModule -Force }
+#endregion MarkMichaelis.ScoopBucket bundle module import
+```
+
+Under scoop, the bundle runs from `<scoopRoot>\apps\<bundle>\<ver>\`, so branch 2's
+`$PSScriptRoot\..\..\..` == `<scoopRoot>` for ALL bundles regardless of repo subdir. Prefer
+`$env:SCOOP` when set. The `buckets\*` glob works whatever the bucket was named.
+
+### 16 files (branch-1 depth preserved) + manifest minor bumps
+
+Top-level (`..\module`): AIAgents, ClientBasePackages, DeveloperBasePackages, OSBasePackages
+Subdir (`..\..\module`): ai/ChatGPT, ai/ClaudeExcel, ai/Gemini, client/MicrosoftOffice365,
+developer/Aspire, developer/Chocolatey, developer/GitConfigBeyondCompare, developer/GitConfigure,
+developer/GitConfigVisualStudio, developer/GitConfigVSCode, developer/PowerShell, os/McAfeeUninstall
+
+Each corresponding `.json` gets a MINOR bump (patch -> 000), e.g. OSBasePackages 1.33.000 -> 1.34.000.
+
+## Part C -- opt-in per-machine module registration
+
+New repo-root `Register-BucketModule.ps1` (`[CmdletBinding(SupportsShouldProcess)]`):
+- Resolves the module source dir: `-ModulePath` (explicit, e.g. a local checkout) > sibling
+  `module\MarkMichaelis.ScoopBucket` when present (and not `-FromBucketClone`) > this machine's
+  bucket clone `<scoopRoot>\buckets\*\module\MarkMichaelis.ScoopBucket`.
+- `<scoopRoot>` = `-ScoopRoot` param > `$env:SCOOP` > `~\scoop`.
+- Creates/repairs junction `<scoopRoot>\modules\MarkMichaelis.ScoopBucket` -> module source
+  (idempotent; SupportsShouldProcess). `~\scoop\modules` is already on PSModulePath.
+- Appends exactly one idempotent, sentinel-bracketed `Import-Module MarkMichaelis.ScoopBucket`
+  block to `-ProfilePath` (default `$PROFILE.CurrentUserAllHosts`). Distinct sentinel
+  (`RegisterBucketModule`) so it never collides with Install-Module.ps1's lazy v3 block.
+- `-Remove` reverses both (junction only if it points at our module; profile block always).
+
+New opt-in manifest `bucket\admin\RegisterBucketModule.json` (mirrors the admin precedent;
+NO new executable `.ps1` under bucket/ so bundle discovery never executes it):
+- `url` -> repo-root `Register-BucketModule.ps1` (scoop downloads it to `$dir`).
+- `installer.script`: `& "$dir\Register-BucketModule.ps1"`
+- `uninstaller.script`: `& "$dir\Register-BucketModule.ps1" -Remove`
+NOT wired as a `depends` on any other bundle.
+
+## Tests (behavior-first, Light, temp/child-process isolation)
+
+- `bucket\ScoopAppDirModuleImport.Tests.ps1` (Part B): stage a fake scoop layout in TestDrive
+  (`apps\<bundle>\<ver>\<bundle>.ps1` copy with NO sibling module; sibling
+  `buckets\TestBucket\module\MarkMichaelis.ScoopBucket\` copy of the real module). Extract the
+  canonical header REGION from a real production bundle, compose a minimal bundle
+  (`[Package]@{ Name='BootstrapProbe'; CustomInstallScript={} }` + `Invoke-PackageInstall -DryRun`),
+  run under `pwsh -NoProfile -File`, assert `RESULT:BootstrapProbe=Installed`. Cover both the
+  `..\..\..` derivation (SCOOP unset) and `$env:SCOOP` set. Negative control: remove the bucket
+  clone -> the same run FAILS (proves branch 2 is what loads the module -> fail-on-revert).
+- `bucket\BundleModuleImportDrift.Tests.ps1` (Part B drift guard): assert all 16 production
+  bundles contain the identical canonical region (modulo branch-1 depth) so no bundle can
+  silently lose branch 2.
+- `bucket\admin\RegisterBucketModule.Tests.ps1` (Part C): invoke the repo-root script with
+  `-ScoopRoot`/`-ProfilePath`/`-ModulePath` seams against TestDrive. Assert: junction created to
+  the module source; exactly one Import-Module line added; `-WhatIf` makes no changes; second run
+  idempotent; bucket-clone discovery finds a staged clone; `-Remove` reverses both.
+
+## Docs
+
+- README.md: update the bundle header example (lines ~85-99) to the new canonical block; add a
+  short "Register the module on another machine" note referencing RegisterBucketModule.
+- bucket\Test-Template.Tests.ps1.txt: update its header to the canonical block (top-level depth).
+
+## Commit sequence (Conventional Commits + Co-authored-by: Copilot)
+
+1. test(bundle): add fake-scoop-layout module-load + drift tests (red)
+2. fix(bundle): load module from scoop bucket clone under -NoProfile (16 headers) + manifest bumps
+3. test(admin): add Register-BucketModule behavior-first tests (red)
+4. feat(admin): add opt-in Register-BucketModule.ps1 + RegisterBucketModule manifest
+5. docs(readme,template): document the scoop-portable header + module registration


### PR DESCRIPTION
## Summary

Fixes #390. `scoop install` / `scoop update MarkMichaelis/<bundle>` failed for every
migrated bundle. This PR fixes that (Part B) and adds an opt-in per-machine module
registration helper (Part C). One PR, two parts.

### Part B -- portable core (the bug fix)

Under scoop, only the single bundle `.ps1` is downloaded into
`~\scoop\apps\<bundle>\<version>\` and run with `-NoProfile`. The old 2-line header
tried `Import-Module $PSScriptRoot\..\module\...` (absent in the app dir), then fell
back to `Import-Module MarkMichaelis.ScoopBucket` by name (not on the -NoProfile
PSModulePath). Result: the `[Package]` type and `Invoke-PackageInstall` never
loaded -> the bundle errored and nothing installed.

Fix: all 16 production bundle headers now ALSO search the bucket clone that scoop
always keeps on disk at
`<scoopRoot>\buckets\*\module\MarkMichaelis.ScoopBucket\MarkMichaelis.ScoopBucket.psd1`
(preferring `$env:SCOOP`, else deriving the scoop root from the app dir via
`..\..\..`). Priority order: (1) repo checkout, (2) bucket clone, (3) by-name
fallback. Each bundle preserves its original branch-1 depth (`..\module` for the 4
top-level bundles, `..\..\module` for the 12 subdir bundles); branch 2 is identical
for all because scoop flattens every bundle to `apps\<bundle>\<version>\`.

Because each bundle `.ps1` is referenced by a manifest `url`, the 17 referencing
manifests received a minor version bump (patch reset to 000).

### Part C -- opt-in per-machine helper

New `Register-BucketModule.ps1` (repo root) + `bucket/admin/RegisterBucketModule.json`.
It performs the two deliberate, idempotent steps that make the bare
`Install-Package <x>` wrapper win the name clash with
`PackageManagement\Install-Package`:

1. Create a junction `<scoopRoot>\modules\MarkMichaelis.ScoopBucket` -> the module
   source (so it is discoverable on PSModulePath).
2. Append exactly one `Import-Module MarkMichaelis.ScoopBucket` line to the
   CurrentUserAllHosts profile, inside a distinctly-marked sentinel block.

- Opt-in only: `scoop install MarkMichaelis/RegisterBucketModule` or run the script
  directly. NOT wired as a `depends` on any bundle, so third-party consumers of
  individual bundles are never forced to alter their machine.
- Idempotent (safe to re-run); `SupportsShouldProcess` (-WhatIf / -Confirm).
- `-Remove` reverses both steps (never deletes the module source).
- `-FromLocalRepo` targets a local repo checkout for a dev machine; `-ModulePath` /
  `-ScoopRoot` / `-ProfilePath` are override/test seams.

## Evidence (faithful scoop -NoProfile simulation; before vs after)

BEFORE -- old 2-line header, bucket clone present on disk:
```
DIAG:MODULE_LOADED=False
DIAG:PACKAGE_TYPE_AVAILABLE=False
ERROR:Unable to find type [Package].
```

AFTER -- new block header, $env:SCOOP unset (uses the ..\..\.. derivation):
```
DIAG:MODULE_LOADED=True
DIAG:PACKAGE_TYPE_AVAILABLE=True
RESULT:BootstrapProbe=Installed
```

Register-BucketModule idempotency + reversal (temp scoop root + temp profile):
```
-WhatIf     -> junction: (none), Import-Module lines: 0   (no changes)
real run    -> junction created, Import-Module lines: 1
second run  -> junction current, Import-Module lines: 1   (idempotent)
-Remove     -> junction: (none), Import-Module lines: 0   (module source preserved)
```

## Testing

- `bucket/ScoopAppDirModuleImport.Tests.ps1` (Light): stages a fake scoop layout
  (app dir with NO sibling module + a bucket clone) and asserts the header loads the
  module + `[Package]` + a `-DryRun` plan under `-NoProfile`. The negative control
  (clone absent) fails, so reverting branch 2 fails the test behaviorally.
- `bucket/BundleModuleImportDrift.Tests.ps1` (Light): pins all 16 bundle headers to
  the canonical block (depth-agnostic), discovering exactly 16 bundles.
- `bucket/admin/RegisterBucketModule.Tests.ps1` (Light): junction creation,
  exactly-one import line, idempotency, -WhatIf no-op, -Remove reversal, bucket-clone
  discovery, -FromLocalRepo, and manifest wiring.
- Full Light suite: 1597 passed, 0 failed, 3 skipped.
- PSScriptAnalyzer: Register-BucketModule.ps1 is clean (Warning+Error); the 16 header
  changes add zero new findings (verified by comparing finding counts vs main -- only
  line numbers shift).

## Conservative choices (noted per the task)

- Distinct profile sentinel (`# MarkMichaelis.ScoopBucket:RegisterBucketModule:BEGIN/:END`)
  so Part C never collides with `module/Add-ScoopBucketProfileBlock.ps1`'s lazy v3
  block. This is the EAGER "the bare command resolves to ours" option; run only one
  of the two.
- Junction targets `<scoopRoot>\modules` (on PSModulePath), NOT the OneDrive user
  module path -- avoiding the KFM issue that moved the DEFAULT install away from
  junctions (#375 / #376). Part C is strictly opt-in.
- The profile edit appends a single idempotent, clearly-marked block and honors
  -WhatIf / -Confirm, so it is safe and fully reversible.

## How to verify

```
# Tests
pwsh -NoProfile -File ./bucket/Invoke-Tests.ps1 -Tag Light

# Part B -- the original bug is fixed
scoop update
scoop install MarkMichaelis/OSBasePackages

# Part C -- register the module on this machine (opt-in)
scoop install MarkMichaelis/RegisterBucketModule
#   or, on a dev machine, from the repo checkout:
./Register-BucketModule.ps1 -FromLocalRepo -WhatIf   # preview
./Register-BucketModule.ps1 -FromLocalRepo           # apply
```

Closes #390