### PR TITLE
feat(packages): label new installs in the Details column

### DIFF
--- a/bucket/PackageResultDetails.Tests.ps1
+++ b/bucket/PackageResultDetails.Tests.ps1
@@ -9,7 +9,7 @@ BeforeAll {
     Import-Module $script:moduleManifest -Force
 }
 
-Describe 'PackageResult.Details()' {
+Describe 'PackageResult.Details()' -Tag 'Light', 'Module' {
     It 'renders a from -> to transition for a real update' {
         $r = [PackageResult]@{ Status = 'Updated'; VersionFrom = '1.2.0'; VersionTo = '1.3.0' }
         $r.Details() | Should -Be '1.2.0 -> 1.3.0'
@@ -33,6 +33,21 @@ Describe 'PackageResult.Details()' {
     It 'renders -> to for a fresh install with no prior version' {
         $r = [PackageResult]@{ Status = 'Installed'; VersionTo = '2.0.0' }
         $r.Details() | Should -Be '-> 2.0.0'
+    }
+
+    It 'renders "new install" for a fresh install with no version info' {
+        $r = [PackageResult]@{ Status = 'Installed' }
+        $r.Details() | Should -Be 'new install'
+    }
+
+    It 'prefers an explicit reason over the new-install label for an install' {
+        $r = [PackageResult]@{ Status = 'Installed'; Reason = '(DryRun)' }
+        $r.Details() | Should -Be '(DryRun)'
+    }
+
+    It 'leaves Details blank for an Updated result with no version info' {
+        $r = [PackageResult]@{ Status = 'Updated' }
+        $r.Details() | Should -Be ''
     }
 
     It 'renders <version> (latest) for AlreadyLatest' {

--- a/module/MarkMichaelis.ScoopBucket/Classes/PackageResult.ps1
+++ b/module/MarkMichaelis.ScoopBucket/Classes/PackageResult.ps1
@@ -58,7 +58,9 @@ class PackageResult {
     # Single human-readable cell merging the version transition and the
     # reason for the summary table's `Details` column (#283). Rules:
     #   Updated/Installed : 'Reinstalled', or 'from -> to', or '-> to' (fresh
-    #                       install), suffixed ' (WhatIf)' on a dry run.
+    #                       install), suffixed ' (WhatIf)' on a dry run. A fresh
+    #                       install with no known version and no other note
+    #                       renders 'new install' rather than a blank cell.
     #   AlreadyLatest     : '<version> (latest)'.
     #   NotInstalled      : 'not installed'.
     #   SelfManaged       : 'self-managed'.
@@ -82,7 +84,13 @@ class PackageResult {
                     if ($d) { return "$d (WhatIf)" }
                     return [string]$this.Reason
                 }
-                if (-not $d) { return [string]$this.Reason }
+                if (-not $d) {
+                    # A fresh install with no version transition and no other
+                    # note would otherwise leave the Details cell blank; label
+                    # it explicitly so a new install reads as such (#283).
+                    if ($this.Status -eq 'Installed' -and -not $this.Reason) { return 'new install' }
+                    return [string]$this.Reason
+                }
                 return $d
             }
             '^(AlreadyLatest|AlreadyInstalled)$' {


### PR DESCRIPTION
## Summary

`PackageResult.Details()` now renders `new install` for a freshly installed
package that has no version transition to show, instead of leaving the Details
cell blank. The install drivers in `Invoke-PackageInstall` never populate
`VersionFrom`/`VersionTo`, so every `Installed` row previously fell through to a
blank cell -- ambiguous next to the `latest` shown for unchanged rows.

A real reason (e.g. `(DryRun)`) still takes precedence, and `Updated` rows are
unaffected.

### Before / After

```
=  Windows Terminal   winget   global   latest
+  WinDirStat          winget   global                 (before: blank)
+  WinDirStat          winget   global   new install   (after)
```

## Tests

- Added 3 behavior-first tests to `PackageResultDetails.Tests.ps1`:
  - a fresh install with no version info renders `new install`
  - an explicit reason (`(DryRun)`) still wins over the label
  - an `Updated` row with no version info stays blank (guards the distinction)
- Tagged the Describe `Light`,`Module` -- it was untagged, so the whole
  presentation contract was `NotRun` under the CI Light gate.
- Full Light gate: 1617 passed, 0 failed.

Closes #392